### PR TITLE
Add and fix contact sensor

### DIFF
--- a/aic_assets/models/ATI_Axia80_M20/axia80_m20_macro.xacro
+++ b/aic_assets/models/ATI_Axia80_M20/axia80_m20_macro.xacro
@@ -4,7 +4,7 @@
   <!-- robot name parameter -->
   <xacro:property name="name" value="axia80_m20"/>
   <!-- TF prefix parameter -->
-  <xacro:property name="tf_prefix" value="ati"/>
+  <xacro:property name="tf_prefix" value="ati/"/>
   <!-- adapter_offset is the effective length that the adapter adds to the endeffector -->
   <xacro:property name="adapter_offset" value="0.0245"/>
 
@@ -110,7 +110,11 @@
     <gazebo reference="${tf_prefix}tool_link">
       <sensor name="contact_sensor" type="contact">
         <contact>
-          <collision>collision1</collision>
+          <!-- The reason for the convoluted collision name reference is due to URDF to SDF
+          conversion prepending and appending names to the collision name. The current workaround
+          is provide an exact name -->
+          <collision>${tf_prefix}tool_link_fixed_joint_lump__collision1_collision</collision>
+          <topic>collision/tool_link</topic>
         </contact>
       </sensor>
       <!-- Reduce contact stiffness and damping for better stability -->

--- a/aic_description/world/aic.sdf
+++ b/aic_description/world/aic.sdf
@@ -279,9 +279,9 @@
 
       <!-- Visualize Contacts -->
       <plugin filename="VisualizeContacts" name="Visualize Contacts">
-        <ignition-gui>
+        <gz-gui>
           <property key="state" type="string">docked</property>
-        </ignition-gui>
+        </gz-gui>
       </plugin>
 
     </gui>
@@ -312,8 +312,8 @@
       name="aic_gazebo::ScoringPlugin">
     </plugin>
     <plugin
-      filename="libignition-gazebo-contact-system.so"
-      name="ignition::gazebo::systems::Contact">
+      filename="gz-sim-contact-system"
+      name="gz::sim::systems::Contact">
     </plugin>
 
     <gravity>0 0 -9.8</gravity>
@@ -440,21 +440,21 @@
       <pose>0.5 0.1 1.06 0 0 0</pose>
       <static>false</static>
     </include>
-    
+
     <include>
       <uri>model://SC Plug</uri>
       <name>sc_plug</name>
       <pose>0.6 0.1 1.06 0 0 0</pose>
       <static>false</static>
     </include>
-    
+
     <include>
       <uri>model://SC Port</uri>
       <name>sc_port</name>
       <pose>0.4 0.1 1.06 0 0 0</pose>
       <static>false</static>
     </include>
-    
+
     <include>
       <uri>model://Enclosure</uri>
       <name>enclosure</name>


### PR DESCRIPTION
1. Fix contact sensor reference to collision 
2. Contact can now be visualized in gazebo using the `VisualizeContact` plugin or queried on `gz topic -e --topic collision/tool_link`