### PR TITLE
Update models to auto compute inertial values based on mass

### DIFF
--- a/aic_assets/models/LC Plug/model.sdf
+++ b/aic_assets/models/LC Plug/model.sdf
@@ -2,6 +2,9 @@
 <sdf version="1.9">
   <model name="LC Plug">
     <link name="lc_plug_link">
+      <inertial auto="true">
+        <mass>0.010</mass>
+      </inertial>
       <visual name="lc_plug_visual">
         <geometry>
           <mesh>

--- a/aic_assets/models/PCIe NIC Card/model.sdf
+++ b/aic_assets/models/PCIe NIC Card/model.sdf
@@ -2,6 +2,9 @@
 <sdf version="1.9">
   <model name="PCIe_NIC_Card">
     <link name="nic_card_link">
+      <inertial auto="true">
+        <mass>0.15</mass>
+      </inertial>
       <visual name="nic_card_visual">
         <geometry>
           <mesh>

--- a/aic_assets/models/SC Plug/model.sdf
+++ b/aic_assets/models/SC Plug/model.sdf
@@ -2,6 +2,9 @@
 <sdf version="1.9">
   <model name="SC Plug">
     <link name="sc_plug_link">
+      <inertial auto="true">
+        <mass>0.04</mass>
+      </inertial>
       <visual name="sc_plug_visual">
         <geometry>
           <mesh>

--- a/aic_assets/models/SC Port/model.sdf
+++ b/aic_assets/models/SC Port/model.sdf
@@ -2,6 +2,9 @@
 <sdf version="1.9">
   <model name="SC_Port">
     <link name="sc_port_link">
+      <inertial auto="true">
+        <mass>0.04</mass>
+      </inertial>
       <visual name="sc_port_visual">
         <geometry>
           <mesh>

--- a/aic_assets/models/SFP Module/model.sdf
+++ b/aic_assets/models/SFP Module/model.sdf
@@ -2,6 +2,9 @@
 <sdf version="1.9">
   <model name="SFP Module">
     <link name="sfp_module_link">
+      <inertial auto="true">
+        <mass>0.03</mass>
+      </inertial>
       <visual name="sfp_module_visual">
         <geometry>
           <mesh>

--- a/aic_assets/models/SFP Plug/model.sdf
+++ b/aic_assets/models/SFP Plug/model.sdf
@@ -2,6 +2,9 @@
 <sdf version="1.9">
   <model name="SFP Plug">
     <link name="sfp_plug_link">
+      <inertial auto="true">
+        <mass>0.01</mass>
+      </inertial>
       <visual name="sfp_plug_visual">
         <geometry>
           <mesh>

--- a/aic_description/world/aic.sdf
+++ b/aic_description/world/aic.sdf
@@ -426,42 +426,41 @@
       </link>
     </model>
 
-
-    <include>
-      <uri>model://SFP Module</uri>
-      <name>sfp_module</name>
-      <pose>0.7 0 1.06 0 0 0</pose>
-      <static>false</static>
-    </include>
-
     <include>
       <uri>model://LC Plug</uri>
       <name>lc_plug</name>
-      <pose>0.5 0.1 1.06 0 0 0</pose>
+      <pose>0.3 0.1 1.06 0 0 0</pose>
       <static>false</static>
     </include>
 
     <include>
       <uri>model://SC Plug</uri>
       <name>sc_plug</name>
-      <pose>0.6 0.1 1.06 0 0 0</pose>
+      <pose>0.4 0.1 1.06 0 0 0</pose>
       <static>false</static>
     </include>
 
     <include>
       <uri>model://SC Port</uri>
       <name>sc_port</name>
-      <pose>0.4 0.1 1.06 0 0 0</pose>
+      <pose>0.5 0.1 1.06 0 0 0</pose>
+      <static>false</static>
+    </include>
+
+    <include>
+      <uri>model://SFP Module</uri>
+      <name>sfp_module</name>
+      <pose>0.2 0 1.06 0 0 0</pose>
       <static>false</static>
     </include>
 
     <include>
       <uri>model://PCIe NIC Card</uri>
       <name>nic_card</name>
-      <pose>0.7 0.1 1.06 0 0 0</pose>
+      <pose>0.2 0.2 1.06 0 0 0</pose>
       <static>false</static>
     </include>
-    
+
     <include>
       <uri>model://Enclosure</uri>
       <name>enclosure</name>


### PR DESCRIPTION
Updated the models to automatically compute inertial based on mass. This makes the models more stable in simulation. They should no longer rock back and forth when resting on the floor of the enclosure. The mass values are an estimate based on google search. We can tweak these later if we have more accurate numbers.

I also updated the model poses so that some of them do not fall off the edge of the enclosure.

See screenshot of models with their inertial visualization enabled. The pink boxes are the inertial visualizations. A general rule of thumb is that the inertial visualizations should roughly match the size of the model. In the cases below with auto-computed inertia values, they do match fine.

<img width="515" height="543" alt="aic_assets_inertia" src="https://github.com/user-attachments/assets/99e755b2-3e02-4948-9604-7b14ff24763e" />
