### PR TITLE
update aic.repos and documentation for Kilted

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,9 @@
 
 ### Requirements
 - [Ubuntu 24.04](https://releases.ubuntu.com/noble/)
-- [ROS 2 Jazzy Jalisco](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html)
+- [ROS 2 Kilted Kaiju](https://docs.ros.org/en/kilted/Installation/Ubuntu-Install-Debs.html)
 
 ### Install
-
-Purge existing Gazebo binaries
-```bash
-sudo apt purge gz-harmonic
-sudo apt purge ros-jazzy-gz-*-vendor ros-jazzy-gz-ros2-control
-```
 
 Add `packages.osrfoundation.org` to the apt sources list:
 ```bash
@@ -23,7 +17,7 @@ sudo apt-get update
 
 Build the workspace
 ```bash
-sudo apt update && sudo apt upgrade -y && sudo apt install ros-jazzy-rmw-zenoh-cpp -y
+sudo apt update && sudo apt upgrade -y && sudo apt install ros-kilted-rmw-zenoh-cpp -y
 mkdir ~/ws_aic/src -p
 cd ~/ws_aic/src
 git clone https://github.com/intrinsic-dev/aic
@@ -32,8 +26,8 @@ vcs import . < aic/aic.repos --recursive
 sudo apt -y install $(sort -u $(find . -iname 'packages-'`lsb_release -cs`'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | sed '/gz\|sdf/d' | tr '\n' ' ')
 cd ~/ws_aic
 # Install ROS dependencies using rosdep.
-rosdep install --from-paths src --ignore-src --rosdistro jazzy -yr --skip-keys "gz-cmake3 DART libogre-dev libogre-next-2.3-dev"
-source /opt/ros/jazzy/setup.bash
+rosdep install --from-paths src --ignore-src --rosdistro kilted -yr --skip-keys "gz-cmake3 DART libogre-dev libogre-next-2.3-dev"
+source /opt/ros/kilted/setup.bash
 GZ_BUILD_FROM_SOURCE=1 colcon build --merge-install --cmake-args -DCMAKE_BUILD_TYPE=Release --symlink-install
 ```
 

--- a/aic.repos
+++ b/aic.repos
@@ -10,7 +10,7 @@ repositories:
   UniversalRobots/Universal_Robots_ROS2_Driver:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
-    version: jazzy
+    version: main
   UniversalRobots/Universal_Robots_ROS2_GZ_Simulation:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation.git


### PR DESCRIPTION
Now that we are able to run the simulation setup successfully in `Kilted` via PR #32 ,this PR takes some changes from #26:
1. Updates the documentation from `Jazzy` to `Kilted`  
2. Update the `UniversalRobots/Universal_Robots_ROS2_Driver` in `aic.repos` from `jazzy` to `main` (There is no `kilted` branch) 

This means that we will build Gazebo Ionic from source with `Kilted` so that we can take advantage of the latest changes.