### PR TITLE
Declare that robot_description is a string, not maybe-yaml

### DIFF
--- a/aic_bringup/launch/aic_gz_bringup.launch.py
+++ b/aic_bringup/launch/aic_gz_bringup.launch.py
@@ -35,6 +35,7 @@ from launch.substitutions import (
     PythonExpression,
 )
 from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
 from launch_ros.substitutions import FindPackageShare
 from ros_gz_bridge.actions import RosGzBridge
 from ros_gz_sim.actions import GzServer
@@ -109,7 +110,9 @@ def launch_setup(context, *args, **kwargs):
             yaw,
         ]
     )
-    robot_description = {"robot_description": robot_description_content}
+    robot_description = {
+        "robot_description": ParameterValue(robot_description_content, value_type=str)
+    }
 
     robot_state_publisher_node = Node(
         package="robot_state_publisher",


### PR DESCRIPTION
Apparently `ros2 launch` will first attempt to parse strings as YAML. If an unfortunate combination of characters, such as a colon `:` is almost-but-not-quite YAML, it will fail.  This PR just declares that the `robot_description` parameters is definitively just a random string (it's XML), not a YAML document.