### PR TITLE
Bump Universal_Robots_ROS2_Description version to 4.3.0

### DIFF
--- a/aic.repos
+++ b/aic.repos
@@ -6,7 +6,7 @@ repositories:
   UniversalRobots/Universal_Robots_ROS2_Description:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
-    version: 3.4.0
+    version: 4.3.0
   UniversalRobots/Universal_Robots_ROS2_Driver:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Bump Universal_Robots_ROS2_Description version to[ 4.3.0 which targets Kilted and Rolling](https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/releases/tag/4.3.0). 
This release also adds effort command interface to all joints which is required for sending torque control commands computed by the Impedance controller.
