### PR TITLE
Export aic_scoring library

### DIFF
--- a/aic_scoring/CMakeLists.txt
+++ b/aic_scoring/CMakeLists.txt
@@ -11,26 +11,38 @@ find_package(rclcpp_components REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
-add_executable(scoring_tier1 src/ScoringTier1.cc)
-target_link_libraries(scoring_tier1
-  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS} yaml-cpp)
+# Create a library that can be linked against
+add_library(${PROJECT_NAME} SHARED src/ScoringTier1.cc)
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC rclcpp::rclcpp ${std_msgs_TARGETS} yaml-cpp)
 
-target_include_directories(scoring_tier1
+target_include_directories(${PROJECT_NAME}
   PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
+
+# Create executable that uses the library
+add_executable(scoring_tier1 src/ScoringTier1.cc)
+target_link_libraries(scoring_tier1
+  PRIVATE ${PROJECT_NAME})
 
 install(
   DIRECTORY config
   DESTINATION share/${PROJECT_NAME}
 )
 
+# Install library and executable with export
 install(TARGETS
+  ${PROJECT_NAME}
   scoring_tier1
-  DESTINATION lib/${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}_targets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 
+# Install headers
 install(
   DIRECTORY include/
   DESTINATION include/${PROJECT_NAME}
@@ -40,5 +52,9 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()
+
+# Export the targets and dependencies
+ament_export_targets(${PROJECT_NAME}_targets HAS_LIBRARY_TARGET)
+ament_export_dependencies(rclcpp rclcpp_components std_msgs yaml-cpp)
 
 ament_package()


### PR DESCRIPTION
This PR create an `aic_scoring` library that is exported by the `aic_scoring` package. A separate `scoring_tier1` executable is also created. I think we can further refactor the implementation here to export an `rclcpp_component` library that will automatically create an executable. This way we can remove the `main` function in `ScoringTier1.cc` altogether. 