### PR TITLE
Update SC Port, NIC Card Mount, and Task Board Base collisions

### DIFF
--- a/aic_assets/models/NIC Card Mount/nic_card_mount_macro.xacro
+++ b/aic_assets/models/NIC Card Mount/nic_card_mount_macro.xacro
@@ -109,6 +109,93 @@
           <box size="0.043 0.048 0.003149"/>
         </geometry>
       </collision>
+
+      <collision name="10099100-011lfc001_collider_box">
+        <origin xyz="-0.017799 -0.052954 0.00548" rpy="3.128092 0.0 0.0"/>
+        <geometry>
+          <box size="0.001099 0.04872 0.011083"/>
+        </geometry>
+      </collision>
+
+      <collision name="10099100-011lfc001_collider_box.001">
+        <origin xyz="-0.002687 -0.052954 0.005461" rpy="3.128092 0.0 0.0"/>
+        <geometry>
+          <box size="0.001125 0.04872 0.011121"/>
+        </geometry>
+      </collision>
+      <collision name="10099100-011lfc001_collider_box.002">
+        <origin xyz="-0.010237 -0.052889 0.010234" rpy="3.128092 0.0 0.0"/>
+        <geometry>
+          <box size="0.016224 0.04872 0.000923"/>
+        </geometry>
+      </collision>
+      <collision name="10099100-011lfc001_collider_box.003">
+        <origin xyz="-0.010237 -0.053024 0.000296" rpy="3.128092 0.0 0.0"/>
+        <geometry>
+          <box size="0.016224 0.04872 0.001054"/>
+        </geometry>
+      </collision>
+      <collision name="10099100-011lfc001_collider_box.004">
+        <origin xyz="-0.010237 -0.028738 0.003845" rpy="3.128092 0.0 0.0"/>
+        <geometry>
+          <box size="0.016224 0.00025 0.013698"/>
+        </geometry>
+      </collision>
+      <collision name="10099100-011lfc001_collider_box.005">
+        <origin xyz="0.005401 -0.052954 0.00548" rpy="3.128092 0.0 0.0"/>
+        <geometry>
+          <box size="0.001099 0.04872 0.011083"/>
+        </geometry>
+      </collision>
+      <collision name="10099100-011lfc001_collider_box.006">
+        <origin xyz="0.020513 -0.052954 0.005461" rpy="3.128092 0.0 0.0"/>
+        <geometry>
+          <box size="0.001125 0.04872 0.011121"/>
+        </geometry>
+      </collision>
+      <collision name="10099100-011lfc001_collider_box.007">
+        <origin xyz="0.012963 -0.052889 0.010234" rpy="3.128092 0.0 0.0"/>
+        <geometry>
+          <box size="0.016224 0.04872 0.00092"/>
+        </geometry>
+      </collision>
+      <collision name="10099100-011lfc001_collider_box.008">
+        <origin xyz="0.012963 -0.053024 0.000296" rpy="3.128092 0.0 0.0"/>
+        <geometry>
+          <box size="0.016224 0.04872 0.001054"/>
+        </geometry>
+      </collision>
+      <collision name="10099100-011lfc001_collider_box.009">
+        <origin xyz="0.012963 -0.028738 0.003845" rpy="3.128092 0.0 0.0"/>
+        <geometry>
+          <box size="0.016224 0.00025 0.01369"/>
+        </geometry>
+      </collision>
+
+      <collision name="plane001_collider_box">
+        <origin xyz="-0.007649 -0.074646 -0.0007515" rpy="0.0 0.0 0.0"/>
+        <geometry>
+          <box size="0.113402 0.000875 0.003449"/>
+        </geometry>
+      </collision>
+      <collision name="plane001_collider_box.001">
+        <origin xyz="-0.007649 -0.074646 0.01352" rpy="0.0 0.0 0.0"/>
+        <geometry>
+          <box size="0.113402 0.000875 0.00501"/>
+        </geometry>
+      </collision>
+      <collision name="plane001_collider_box.002">
+        <origin xyz="0.038559 -0.074646 0.006455" rpy="0.0 0.0 0.0"/>
+        <geometry>
+          <box size="0.036181 0.000875 0.01112"/>
+        </geometry>
+      </collision>
+      <collision name="plane001_collider_box.003">
+        <origin xyz="-0.041261 -0.074646 0.006455" rpy="0.0 0.0 0.0"/>
+        <geometry>
+          <box size="0.046178 0.000875 0.011123"/>
+        </geometry>
+      </collision>
     </link>
 
     <!-- Joint connecting card to mount -->

--- a/aic_assets/models/SC Port/model.sdf
+++ b/aic_assets/models/SC Port/model.sdf
@@ -24,7 +24,31 @@
         <pose>0.0 0.0 0.004225 0.0 0.0 0.0</pose>
         <geometry>
           <box>
-            <size>0.025781 0.027432 0.00085</size>
+            <size>0.025781 0.0108 0.00085</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="cube_collider_box_mid">
+        <pose>0.0 0.0 0.004225 0.0 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.0103 0.027432 0.00085</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="cube_collider_box_mid02">
+        <pose>0.01 0.0 0.004225 0.0 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.005 0.027432 0.00085</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="cube_collider_box_mid03">
+        <pose>-0.01 0.0 0.004225 0.0 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.005 0.027432 0.00085</size>
           </box>
         </geometry>
       </collision>
@@ -65,14 +89,6 @@
         <geometry>
           <box>
             <size>0.003492 0.027432 0.0093</size>
-          </box>
-        </geometry>
-      </collision>
-      <collision name="foa-005a_3d_collider_box">
-        <pose>0.0 0.0 -0.0 3.141593 -0.0 0.0</pose>
-        <geometry>
-          <box>
-            <size>0.025 0.002946 0.009</size>
           </box>
         </geometry>
       </collision>

--- a/aic_assets/models/SC Port/sc_port_macro.xacro
+++ b/aic_assets/models/SC Port/sc_port_macro.xacro
@@ -26,7 +26,28 @@
       <collision name="cube_collider_box_001">
         <origin xyz="0.0 0.0 0.004225" rpy="0.0 0.0 0.0"/>
         <geometry>
-          <box size="0.025781 0.027432 0.00085"/>
+          <box size="0.025781 0.0108 0.00085"/>
+        </geometry>
+      </collision>
+
+      <collision name="cube_collider_box_mid">
+        <origin xyz="0.0 0.0 0.004225" rpy="0.0 0.0 0.0"/>
+        <geometry>
+          <box size="0.0103 0.027432 0.00085"/>
+        </geometry>
+      </collision>
+
+      <collision name="cube_collider_box_mid02">
+        <origin xyz="0.01 0.0 0.004225" rpy="0.0 0.0 0.0"/>
+        <geometry>
+          <box size="0.005 0.027432 0.00085"/>
+        </geometry>
+      </collision>
+
+      <collision name="cube_collider_box_mid03">
+        <origin xyz="-0.01 0.0 0.004225" rpy="0.0 0.0 0.0"/>
+        <geometry>
+          <box size="0.005 0.027432 0.00085"/>
         </geometry>
       </collision>
 
@@ -65,12 +86,6 @@
         </geometry>
       </collision>
 
-      <collision name="foa_005a_3d_collider_box">
-        <origin xyz="0.0 0.0 0.0" rpy="3.141593 0.0 0.0"/>
-        <geometry>
-          <box size="0.025 0.002946 0.009"/>
-        </geometry>
-      </collision>
     </link>
   </xacro:macro>
 

--- a/aic_assets/models/Task Board Base/model.sdf
+++ b/aic_assets/models/Task Board Base/model.sdf
@@ -9,19 +9,43 @@
           </mesh>
         </geometry>
       </visual>
-      <collision name="v1015074_collider_box">
-        <pose>-0.075 0.05 0.0105 0.0 -0.0 -0.0</pose>
+      <collision name="v1015083001_collider_box_left">
+        <pose>0.0 -0.10 0.0075 0.0 0.0 -0.0</pose>
         <geometry>
           <box>
-            <size>0.14 0.087 0.005</size>
+            <size>0.3 0.228 0.005</size>
           </box>
         </geometry>
       </collision>
-      <collision name="v1015083001_collider_box">
-        <pose>-0.0 0.0 0.0075 0.0 0.0 -0.0</pose>
+      <collision name="v1015083001_collider_right">
+        <pose>0.0 0.149 0.0075 0.0 0.0 -0.0</pose>
         <geometry>
           <box>
-            <size>0.3 0.425 0.005</size>
+            <size>0.3 0.127 0.005</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="v1015083001_collider_mid">
+        <pose>-0.075 0.05 0.0075 0.0 0.0 -0.0</pose>
+        <geometry>
+          <box>
+            <size>0.14 0.012 0.005</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="v1015083001_collider_bottom">
+        <pose>0.068 0.0 0.0075 0.0 0.0 -0.0</pose>
+        <geometry>
+          <box>
+            <size>0.165 0.425 0.005</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="v1015083001_collider_top">
+        <pose>-0.143 0.0 0.0075 0.0 0.0 -0.0</pose>
+        <geometry>
+          <box>
+            <size>0.015 0.425 0.005</size>
           </box>
         </geometry>
       </collision>

--- a/aic_assets/models/Task Board Base/task_board_base_macro.xacro
+++ b/aic_assets/models/Task Board Base/task_board_base_macro.xacro
@@ -16,19 +16,42 @@
         </geometry>
       </visual>
 
-      <collision name="v1015074_collider_box">
-        <origin xyz="-0.075 0.05 0.0105" rpy="0.0 0.0 0.0"/>
+      <collision name="v1015083001_collider_box_left">
+        <origin xyz="0.0 -0.10 0.0075" rpy="0.0 0.0 0.0"/>
         <geometry>
-          <box size="0.14 0.087 0.005"/>
+          <box size="0.3 0.228 0.005"/>
         </geometry>
       </collision>
 
-      <collision name="v1015083001_collider_box">
-        <origin xyz="0.0 0.0 0.0075" rpy="0.0 0.0 0.0"/>
+      <collision name="v1015083001_collider_right">
+        <origin xyz="0.0 0.149 0.0075" rpy="0.0 0.0 0.0"/>
         <geometry>
-          <box size="0.3 0.425 0.005"/>
+          <box size="0.3 0.127 0.005"/>
         </geometry>
       </collision>
+
+      <collision name="v1015083001_collider_mid">
+        <pose>0.0 0.0 -0.0</pose>
+        <origin xyz="-0.075 0.05 0.0075" rpy="0.0 0.0 0.0"/>
+        <geometry>
+          <box size="0.14 0.012 0.005"/>
+        </geometry>
+      </collision>
+
+      <collision name="v1015083001_collider_bottom">
+        <origin xyz="0.068 0.0 0.0075" rpy="0.0 0.0 0.0"/>
+        <geometry>
+          <box size="0.165 0.425 0.005"/>
+        </geometry>
+      </collision>
+
+      <collision name="v1015083001_collider_top">
+        <origin xyz="-0.143 0.0 0.0075" rpy="0.0 0.0 0.0"/>
+        <geometry>
+          <box size="0.015 0.425 0.005"/>
+        </geometry>
+      </collision>
+
     </link>
   </xacro:macro>
 


### PR DESCRIPTION
Update asset collisions so that the SFP module and SC Plug can be inserted into the ports on the task board:

**SFP module insertion**

![sfp_insertion](https://github.com/user-attachments/assets/0bcaf0ed-276b-4d03-afee-7435b13c9ae2)

**SC Plug insertion**
![sc_insertion](https://github.com/user-attachments/assets/255d23af-d8a4-4c02-ac68-753fdced3e1d)


### Collisions updates

**NIC Card Mount** - some collisions that exist in the model.sdf file were missing in the urdf.xacro file.

Before:
<img width="297" height="361" alt="Screenshot 2025-12-29 at 3 53 53 PM" src="https://github.com/user-attachments/assets/6a74ecad-7755-4100-81a5-1efb16b88004" />

After:

<img width="313" height="358" alt="Screenshot 2025-12-29 at 3 50 11 PM" src="https://github.com/user-attachments/assets/e2a7bfac-5f80-4670-9ae1-2341753a6282" />

**SC Port**

Before:

<img width="469" height="492" alt="Screenshot 2025-12-29 at 2 14 34 PM" src="https://github.com/user-attachments/assets/aba8510e-7a94-43ce-95e4-c460cdc129e3" />

After:

<img width="556" height="502" alt="Screenshot 2025-12-29 at 2 13 26 PM" src="https://github.com/user-attachments/assets/a4d25e71-e3e3-4836-9d0e-3d16f073b036" />

**Task Board Base**

Before:

<img width="651" height="444" alt="Screenshot 2025-12-29 at 3 38 18 PM" src="https://github.com/user-attachments/assets/4111d7ff-0664-42a6-b0b2-3d50e668a679" />

After:

<img width="685" height="486" alt="Screenshot 2025-12-29 at 3 35 42 PM" src="https://github.com/user-attachments/assets/bb010fa8-0bf5-4e37-b6ec-5b0572494088" />


