### PR TITLE
Update numpy rosdep to python3-numpy

### DIFF
--- a/aic_bringup/package.xml
+++ b/aic_bringup/package.xml
@@ -17,7 +17,7 @@
   <exec_depend>kinematics_interface_kdl</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
-  <exec_depend>numpy</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
   <exec_depend>parallel_gripper_controller</exec_depend>
   <exec_depend>rmw_zenoh_cpp</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>


### PR DESCRIPTION
Trivial adjustment to the `numpy` dependency name so that `rosdep` runs without errors.