### PR TITLE
Use gz-rendering9 global illumination branch

### DIFF
--- a/aic.repos
+++ b/aic.repos
@@ -130,7 +130,7 @@ repositories:
   gazebo/gz-rendering:
     type: git
     url: https://github.com/gazebosim/gz-rendering
-    version: gz-rendering9
+    version: 4c1988d13667404184efb91de36c9c2b1c12935d
   gazebo/gz-sensors:
     type: git
     url: https://github.com/gazebosim/gz-sensors


### PR DESCRIPTION
Use a branch of gz-rendering9 [with the fix](https://github.com/gazebosim/gz-rendering/commit/4c1988d13667404184efb91de36c9c2b1c12935d) that allows consistent startup when running with a GPU, whether a cable is spawned or not.