### PR TITLE
Reduce masses of links not in the kinematic chain and remove repeated <inertial> blocks

### DIFF
--- a/aic_assets/models/Basler Camera/basler_camera_macro.xacro
+++ b/aic_assets/models/Basler Camera/basler_camera_macro.xacro
@@ -6,7 +6,7 @@
     <link name="${tf_prefix}camera_link">
       <inertial>
         <origin xyz="0 0 0" rpy="0 0 0"/>
-        <mass value="0.1"/>
+        <mass value="0.001"/>
         <inertia ixx="0.00002083" ixy="0" ixz="0"
                  iyy="0.00002083" iyz="0"
                  izz="0.000015"/>

--- a/aic_assets/models/Robotiq Hand-E/robotiq_hande_macro.xacro
+++ b/aic_assets/models/Robotiq Hand-E/robotiq_hande_macro.xacro
@@ -52,7 +52,7 @@
     <link name="${tf_prefix}hande_finger_link_l">
       <inertial>
         <origin xyz="0 0 0" rpy="0 0 0"/>
-        <mass value="0.2"/>
+        <mass value="0.001"/>
         <inertia ixx="0.0001" ixy="0" ixz="0"
                  iyy="0.00009" iyz="0"
                  izz="0.00003"/>
@@ -92,18 +92,12 @@
           <box size="0.017387 0.018419 0.009271"/>
         </geometry>
       </collision>
-
-      <inertial>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <mass value="0.2"/>
-        <inertia ixx="0.0001" ixy="0.0" ixz="0.0" iyy="0.00009" iyz="0.0" izz="0.00003"/>
-      </inertial>
     </link>
 
     <link name="${tf_prefix}hande_finger_link_r">
       <inertial>
         <origin xyz="0 0 0" rpy="0 0 0"/>
-        <mass value="0.2"/>
+        <mass value="0.001"/>
         <inertia ixx="0.0001" ixy="0" ixz="0"
                  iyy="0.00009" iyz="0"
                  izz="0.00003"/>
@@ -143,12 +137,6 @@
           <box size="0.017387 0.018419 0.009271"/>
         </geometry>
       </collision>
-
-      <inertial>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <mass value="0.2"/>
-        <inertia ixx="0.0001" ixy="0.0" ixz="0.0" iyy="0.00009" iyz="0.0" izz="0.00003"/>
-      </inertial>
     </link>
 
     <joint name="${tf_prefix}left_finger_joint" type="prismatic">


### PR DESCRIPTION
This PR has the following changes:
1. For links that are not in kinematics chain of the robot arm (from the `base_link` to `gripper/tcp`), we set their masses to small values so as their gravitational forces are minimal. This is because for PR #67 , the gravity compensation is only able to compensate for masses in the kinematic chain. 
2. Remove repeated <inertial> blocks in the asset xacro files.