### PR TITLE
Publish robot transforms every joint state message

### DIFF
--- a/aic_bringup/launch/aic_gz_bringup.launch.py
+++ b/aic_bringup/launch/aic_gz_bringup.launch.py
@@ -132,7 +132,10 @@ def launch_setup(context, *args, **kwargs):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="both",
-        parameters=[{"use_sim_time": True}, robot_description],
+        parameters=[
+            {"use_sim_time": True, "ignore_timestamp": True},
+            robot_description,
+        ],
     )
 
     rviz_node = Node(


### PR DESCRIPTION
Currently, `robot_state_publisher` is running at its default rate, which decimates the 500 Hz `/joint_states` from GZ down to 20 Hz transforms. `aic_adapter` then queries the TF buffer for the gripper transform to create the `Observation` message to send to `aic_model`. However, this is fragile due to potential misalignment of the 20 Hz GZ image stream and the 20 Hz decimated `/tf` stream, if `robot_state_publisher` was not up and running before GZ started publishing, and its 20 Hz stream is therefore misaligned with the "top-of-second"-aligned GZ camera stream.

The `ignore_timestamp` parameter of `robot_state_publisher` causes it to generate and publish TF frames for every `joint_state` message. This ensures that, regardless of startup order, there will be a gripper TF frame aligned with the simulated image timestamps. Otherwise, it is possible that the gripper-frame TF query for the image timestamp will be attempting to extrapolate beyond the end of the TF buffer, which is not allowed.