### PR TITLE
Add static tf publisher for world->aic_world

### DIFF
--- a/aic_bringup/launch/aic_gz_bringup.launch.py
+++ b/aic_bringup/launch/aic_gz_bringup.launch.py
@@ -328,6 +328,20 @@ def launch_setup(context, *args, **kwargs):
         condition=IfCondition(ground_truth),
     )
 
+    ground_truth_static_tf_publisher = Node(
+        package="tf2_ros",
+        executable="static_transform_publisher",
+        name="ground_truth_static_tf_publisher",
+        output="screen",
+        arguments=[
+            "--frame-id",
+            "world",
+            "--child-frame-id",
+            "aic_world",
+        ],
+        condition=IfCondition(ground_truth),
+    )
+
     nodes_to_start = [
         robot_state_publisher_node,
         joint_state_broadcaster_spawner,
@@ -344,6 +358,7 @@ def launch_setup(context, *args, **kwargs):
         spawn_cable_launch,
         ground_truth_tf_relay,
         ground_truth_tf_static_relay,
+        ground_truth_static_tf_publisher,
     ]
 
     return nodes_to_start


### PR DESCRIPTION
I tried doing this a few other ways, but they all seemed to have problems: it seems GZ doesn't let you name the world `world`, and it also seemed to create various controller problems if the "ROS side" is named `aic_world` (the arm just topples over).

It seems the simplest solution is just to add a dummy static tf publisher that publishes an identity transform `world->aic_world` . With this change, everything appears in rviz as expected with `ground_truth:=true`