### PR TITLE
Align TCP transform in observation message with aic_controller frame

### DIFF
--- a/aic_adapter/src/aic_adapter.cpp
+++ b/aic_adapter/src/aic_adapter.cpp
@@ -162,8 +162,8 @@ class AicAdapterNode : public rclcpp::Node {
     // Try to compute the transform between the TCP and base_link
     try {
       geometry_msgs::msg::TransformStamped t =
-          tf_buffer_->lookupTransform("gripper/tcp", "world", t_image_0);
-      observation_msg->tcp_to_world = t;
+          tf_buffer_->lookupTransform("base_link", "gripper/tcp", t_image_0);
+      observation_msg->tcp_transform = t;
     } catch (const tf2::TransformException& ex) {
       RCLCPP_WARN(get_logger(), "Gripper transform not available: %s",
                   ex.what());

--- a/aic_interfaces/aic_model_interfaces/msg/Observation.msg
+++ b/aic_interfaces/aic_model_interfaces/msg/Observation.msg
@@ -2,4 +2,4 @@ sensor_msgs/Image[3] images
 sensor_msgs/CameraInfo[3] camera_infos
 sensor_msgs/JointState joint_states
 geometry_msgs/WrenchStamped wrist_wrench
-geometry_msgs/TransformStamped tcp_to_world
+geometry_msgs/TransformStamped tcp_transform

--- a/aic_model/aic_model/model_node.py
+++ b/aic_model/aic_model/model_node.py
@@ -106,9 +106,9 @@ class AicModel(LifecycleNode):
         t_cam_2 = self.get_seconds(msg.images[2].header)
         t_joints = self.get_seconds(msg.joint_states.header)
         t_wrench = self.get_seconds(msg.wrist_wrench.header)
-        tcp_x = msg.tcp_to_world.transform.translation.x
-        tcp_y = msg.tcp_to_world.transform.translation.y
-        tcp_z = msg.tcp_to_world.transform.translation.z
+        tcp_x = msg.tcp_transform.transform.translation.x
+        tcp_y = msg.tcp_transform.transform.translation.y
+        tcp_z = msg.tcp_transform.transform.translation.z
         self.get_logger().info(
             f"times: images [{t_cam_0:.2f}, {t_cam_1:.2f}, {t_cam_2:.2f}] joints {t_joints:.2f} wrench {t_wrench:.2f} tcp: ({tcp_x:+0.4f} {tcp_y:+0.4f}, {tcp_z:+0.4f})"
         )


### PR DESCRIPTION
Align the transform in the Observation message with the `base_link -> gripper/tcp` transform used by `aic_controller` inputs, so that there is no offset or direction difference between them.

Rename `tcp_to_world` in the `Observation` message to become `tcp_transform`, to avoid confusion since this transform no longer starts from the world origin, but instead the `base_link` of the kinematic chain, as used by `aic_controller` for command inputs and state measurement. Having the extra "top-level" `world` frame was probably just going to add confusion, and since nothing will ever be lower than the tabletop, z=0 meaning "tabletop" is probably more intuitive than z=0 meaning "floor".