### PR TITLE
Store tasks in a vector rather than a hash map

### DIFF
--- a/aic_engine/src/aic_engine.cpp
+++ b/aic_engine/src/aic_engine.cpp
@@ -200,19 +200,18 @@ Trial::Trial(const std::string& _id, YAML::Node _config)
     }
 
     // Parse and store task
-    auto task = aic_task_interfaces::build<aic_task_interfaces::msg::Task>()
-                    .id(task_id)
-                    .cable_type(task_config["cable_type"].as<std::string>())
-                    .cable_name(task_config["cable_name"].as<std::string>())
-                    .plug_type(task_config["plug_type"].as<std::string>())
-                    .plug_name(task_config["plug_name"].as<std::string>())
-                    .port_type(task_config["port_type"].as<std::string>())
-                    .port_name(task_config["port_name"].as<std::string>())
-                    .target_module_name(
-                        task_config["target_module_name"].as<std::string>())
-                    .time_limit(task_config["time_limit"].as<std::size_t>());
-
-    this->tasks[task_id] = task;
+    this->tasks.emplace_back(
+        aic_task_interfaces::build<aic_task_interfaces::msg::Task>()
+            .id(task_id)
+            .cable_type(task_config["cable_type"].as<std::string>())
+            .cable_name(task_config["cable_name"].as<std::string>())
+            .plug_type(task_config["plug_type"].as<std::string>())
+            .plug_name(task_config["plug_name"].as<std::string>())
+            .port_type(task_config["port_type"].as<std::string>())
+            .port_name(task_config["port_name"].as<std::string>())
+            .target_module_name(
+                task_config["target_module_name"].as<std::string>())
+            .time_limit(task_config["time_limit"].as<std::size_t>()));
   }
 
   // Validate scoring array

--- a/aic_engine/src/aic_engine.hpp
+++ b/aic_engine/src/aic_engine.hpp
@@ -82,7 +82,7 @@ struct Trial {
   std::string id;
   std::optional<std::string> spawned_task_board_name;
   YAML::Node config;
-  std::unordered_map<std::string, Task> tasks;  // Map of task_id -> Task
+  std::vector<Task> tasks;
   TrialState state;
 };
 


### PR DESCRIPTION
I'm not 100% sure what the intention behind the storage was but it sounds like we should store the tasks in a vector if we want to iterate over them in a deterministic fashion. If we were to store them in a `unordered_map` we will have non deterministic order of execution once we start executing a trial and running its tasks, this could make reproducing runs tricky.