### PR TITLE
Disable light visualization

### DIFF
--- a/aic_description/world/aic.sdf
+++ b/aic_description/world/aic.sdf
@@ -130,12 +130,13 @@
         <constant>1.0</constant>
         <linear>0.01</linear>
         <quadratic>0.001</quadratic>
-        </attenuation>
+      </attenuation>
       <spot>
         <inner_angle>0.1</inner_angle>
         <outer_angle>2</outer_angle>
         <falloff>1.0</falloff>
       </spot>
+      <visualize>false</visualize>
     </light>
 
     <light type="point" name="ceiling_01">
@@ -150,6 +151,7 @@
         <linear>0.01</linear>
         <quadratic>0.001</quadratic>
       </attenuation>
+      <visualize>false</visualize>
     </light>
 
     <light type="point" name="ceiling_02">
@@ -164,6 +166,7 @@
         <linear>0.01</linear>
         <quadratic>0.001</quadratic>
       </attenuation>
+      <visualize>false</visualize>
     </light>
 
     <include>


### PR DESCRIPTION
Remove those green lines that represent the lights. 

The most obvious one is the spot light inside the enclosure. 

Before:
<img width="260" height="251" alt="Screenshot 2026-01-15 at 4 00 26 PM" src="https://github.com/user-attachments/assets/ba16f470-6f2f-4c0e-87a5-a2eced75fb6c" />

After:
<img width="324" height="320" alt="Screenshot 2026-01-15 at 3 56 50 PM" src="https://github.com/user-attachments/assets/fbcd2ccb-33ca-44dd-ac61-7218eb359339" />

Note that the sensors shouldn't see these visualizations anyway. It's only visible to the GUI camera. 
