### PR TITLE
Add cleanup and shutdown transition, refactor code

### DIFF
--- a/aic_engine/src/aic_engine.cpp
+++ b/aic_engine/src/aic_engine.cpp
@@ -270,6 +270,8 @@ Engine::Engine(const rclcpp::NodeOptions& options)
   node_->declare_parameter("model_configure_timeout_seconds", 60);
   node_->declare_parameter("model_activate_timeout_seconds", 60);
   node_->declare_parameter("model_deactivate_timeout_seconds", 60);
+  node_->declare_parameter("model_cleanup_timeout_seconds", 60);
+  node_->declare_parameter("model_shutdown_timeout_seconds", 60);
 
   spin_thread_ = std::thread([node = node_]() {
     rclcpp::executors::SingleThreadedExecutor executor;
@@ -435,10 +437,15 @@ EngineState Engine::run() {
                    "Trial '%s' failed or was not completed.", trial_id.c_str());
       engine_state_ = EngineState::Error;
       // TODO(Yadunund): Clean up and write scoring data.
+      // TODO(luca) refactor cleanup into single function
+      this->cleanup_model_node();
+      this->shutdown_model_node();
       return engine_state_;
     }
   }
 
+  this->cleanup_model_node();
+  this->shutdown_model_node();
   return engine_state_;
 }
 
@@ -581,45 +588,10 @@ bool Engine::configure_model_node() {
   RCLCPP_INFO(node_->get_logger(), "Configuring lifecycle node '%s'...",
               model_node_name_.c_str());
 
-  if (!model_change_state_client_->wait_for_service(std::chrono::seconds(5))) {
-    RCLCPP_ERROR(
-        node_->get_logger(),
-        "ChangeState service not available for node '%s' after waiting",
-        model_node_name_.c_str());
+  if (!this->transition_model_lifecycle_node(
+          lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE)) {
     return false;
   }
-
-  // Create and send the request to transition to 'configured' state
-  auto request = std::make_shared<lifecycle_msgs::srv::ChangeState::Request>();
-  request->transition.id =
-      lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE;
-
-  auto future = model_change_state_client_->async_send_request(request);
-
-  const int model_configure_timeout_seconds =
-      node_->get_parameter("model_configure_timeout_seconds").as_int();
-  if (future.wait_for(std::chrono::seconds(model_configure_timeout_seconds)) !=
-      std::future_status::ready) {
-    RCLCPP_ERROR(node_->get_logger(),
-                 "ChangeState service call timed out for node '%s'",
-                 model_node_name_.c_str());
-    return false;
-  }
-
-  auto response = future.get();
-
-  if (!response->success) {
-    RCLCPP_ERROR(
-        node_->get_logger(),
-        "Failed to transition lifecycle node '%s' to 'configured' state",
-        model_node_name_.c_str());
-    return false;
-  }
-
-  RCLCPP_INFO(node_->get_logger(),
-              "Lifecycle node '%s' successfully transitioned to 'configured' "
-              "state. Checking expectations...",
-              model_node_name_.c_str());
 
   if (model_node_moved_robot()) {
     RCLCPP_ERROR(node_->get_logger(),
@@ -918,6 +890,74 @@ bool Engine::task_completed_successfully() {
 }
 
 //==============================================================================
+bool Engine::transition_model_lifecycle_node(const uint8_t transition) {
+  std::string transition_name;
+  switch (transition) {
+    case lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE:
+      transition_name = "configure";
+      break;
+    case lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE:
+      transition_name = "activate";
+      break;
+    case lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE:
+      transition_name = "deactivate";
+      break;
+    case lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP:
+      transition_name = "cleanup";
+      break;
+    case lifecycle_msgs::msg::Transition::TRANSITION_ACTIVE_SHUTDOWN:
+      [[fallthrough]];
+    case lifecycle_msgs::msg::Transition::TRANSITION_INACTIVE_SHUTDOWN:
+      [[fallthrough]];
+    case lifecycle_msgs::msg::Transition::TRANSITION_UNCONFIGURED_SHUTDOWN:
+      transition_name = "shutdown";
+      break;
+    default:
+      RCLCPP_ERROR(
+          node_->get_logger(),
+          "Failed to transition model node, transition %u not recognized",
+          (int)transition);
+      return false;
+  }
+  const std::string timeout_param_name =
+      "model_" + transition_name + "_timeout_seconds";
+  const int timeout = this->node_->get_parameter(timeout_param_name).as_int();
+
+  RCLCPP_INFO(node_->get_logger(),
+              "Transitioning model node '%s' to transition '%s'...",
+              model_node_name_.c_str(), transition_name.c_str());
+
+  auto change_state_request =
+      std::make_shared<lifecycle_msgs::srv::ChangeState::Request>();
+  change_state_request->transition.id = transition;
+
+  auto future =
+      model_change_state_client_->async_send_request(change_state_request);
+  if (future.wait_for(std::chrono::seconds(timeout)) !=
+      std::future_status::ready) {
+    RCLCPP_ERROR(
+        node_->get_logger(),
+        "ChangeState service call timed out for transition '%s' for node '%s'",
+        transition_name.c_str(), model_node_name_.c_str());
+    return false;
+  }
+
+  auto response = future.get();
+  if (!response->success) {
+    RCLCPP_ERROR(node_->get_logger(),
+                 "Failed to transition model node '%s' to state '%s'",
+                 model_node_name_.c_str(), transition_name.c_str());
+    return false;
+  }
+
+  RCLCPP_INFO(node_->get_logger(),
+              "Successfully transition model node '%s' to state '%s'",
+              model_node_name_.c_str(), transition_name.c_str());
+
+  return true;
+}
+
+//==============================================================================
 bool Engine::activate_model_node() {
   if (skip_model_ready_) {
     RCLCPP_INFO(node_->get_logger(),
@@ -925,40 +965,9 @@ bool Engine::activate_model_node() {
     return true;
   }
 
-  RCLCPP_INFO(node_->get_logger(),
-              "Activating model node '%s' to transition to 'active' state...",
-              model_node_name_.c_str());
-
-  auto change_state_request =
-      std::make_shared<lifecycle_msgs::srv::ChangeState::Request>();
-  change_state_request->transition.id =
-      lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE;
-
-  const int model_activate_timeout_seconds =
-      this->node_->get_parameter("model_activate_timeout_seconds").as_int();
-
-  auto future =
-      model_change_state_client_->async_send_request(change_state_request);
-  if (future.wait_for(std::chrono::seconds(model_activate_timeout_seconds)) !=
-      std::future_status::ready) {
-    RCLCPP_ERROR(node_->get_logger(),
-                 "ChangeState service call timed out for activating node '%s'",
-                 model_node_name_.c_str());
-    return false;
-  }
-
-  auto response = future.get();
-  if (!response->success) {
-    RCLCPP_ERROR(node_->get_logger(), "Failed to activate model node '%s'",
-                 model_node_name_.c_str());
-    return false;
-  }
-
-  RCLCPP_INFO(node_->get_logger(), "Successfully activated model node '%s'",
-              model_node_name_.c_str());
-
   // TODO(Yadunund): Verify active requirements.
-  return true;
+  return this->transition_model_lifecycle_node(
+      lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
 }
 
 //==============================================================================
@@ -968,41 +977,32 @@ bool Engine::deactivate_model_node() {
                 "Skipping model deactivation as per parameter.");
     return true;
   }
+  return this->transition_model_lifecycle_node(
+      lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+}
 
-  RCLCPP_INFO(
-      node_->get_logger(),
-      "Deactivating model node '%s' to transition to 'configured' state...",
-      model_node_name_.c_str());
-
-  auto change_state_request =
-      std::make_shared<lifecycle_msgs::srv::ChangeState::Request>();
-  change_state_request->transition.id =
-      lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE;
-
-  const int model_deactivate_timeout_seconds =
-      this->node_->get_parameter("model_deactivate_timeout_seconds").as_int();
-
-  auto future =
-      model_change_state_client_->async_send_request(change_state_request);
-  if (future.wait_for(std::chrono::seconds(model_deactivate_timeout_seconds)) !=
-      std::future_status::ready) {
-    RCLCPP_ERROR(
-        node_->get_logger(),
-        "ChangeState service call timed out for deactivating node '%s'",
-        model_node_name_.c_str());
-    return false;
+//==============================================================================
+bool Engine::cleanup_model_node() {
+  if (skip_model_ready_) {
+    RCLCPP_INFO(node_->get_logger(),
+                "Skipping model cleanup as per parameter.");
+    return true;
   }
 
-  auto response = future.get();
-  if (!response->success) {
-    RCLCPP_ERROR(node_->get_logger(), "Failed to deactivate model node '%s'",
-                 model_node_name_.c_str());
-    return false;
+  return this->transition_model_lifecycle_node(
+      lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP);
+}
+
+//==============================================================================
+bool Engine::shutdown_model_node() {
+  if (skip_model_ready_) {
+    RCLCPP_INFO(node_->get_logger(),
+                "Skipping model shutdown as per parameter.");
+    return true;
   }
 
-  RCLCPP_INFO(node_->get_logger(), "Successfully deactivated model node '%s'",
-              model_node_name_.c_str());
-  return true;
+  return this->transition_model_lifecycle_node(
+      lifecycle_msgs::msg::Transition::TRANSITION_UNCONFIGURED_SHUTDOWN);
 }
 
 //==============================================================================

--- a/aic_engine/src/aic_engine.hpp
+++ b/aic_engine/src/aic_engine.hpp
@@ -175,6 +175,12 @@ class Engine {
   /// @return True if the model is unconfigured, false otherwise.
   bool model_node_is_unconfigured();
 
+  /// @brief Trigger a state transition for the lifecycle node.
+  /// \param[in] transition The transition to trigger as per
+  /// lifecycle_msgs::msg::Transition enum definition.
+  /// @return True if transition succeeded, false otherwise.
+  bool transition_model_lifecycle_node(const uint8_t transition);
+
   /// @brief Configure the model node and check expectations in the configured
   /// state as per challenge requirements.
   /// @return True if configuration succeeded, false otherwise.
@@ -189,6 +195,16 @@ class Engine {
   /// state.
   /// @return True if deactivation succeeded, false otherwise.
   bool deactivate_model_node();
+
+  /// @brief Cleanup the model node to transition from inactive to
+  /// unconfigured state.
+  /// @return True if cleanup succeeded, false otherwise.
+  bool cleanup_model_node();
+
+  /// @brief Shutdown the model node to transition from unconfigured to
+  /// shutdown state.
+  /// @return True if shutdown succeeded, false otherwise.
+  bool shutdown_model_node();
 
   // Strings.
   // Name of the aic_adapter node for lifecycle transitions.

--- a/docs/challenge_rules.md
+++ b/docs/challenge_rules.md
@@ -11,6 +11,7 @@
 	- A transition to `active` state must succeed within a timeout of 60s.
 		- In `active` state, the node should accept any goal request sent to `/insert_cable` and the goals should be cancellable.
 	- A `deactivate` transition request should transition the node back to `configured` state successfully within a timeout of 60s.
+	- A `cleanup` transition request should transition the node back to `unconfigured` state successfully within a timeout of 60s.
 	- A `shutdown` transition request must succeed within a timeout of 60s.
 		- In `shutdown` state, no topics should be published by node, especially to command the robot.
 		- In the `shutdown` state, no robot command publishers should be present in the graph.


### PR DESCRIPTION
This PR adds transitions to cleanup + shutdown. Since the duplicated code for transitions was becoming a bit hard to maintain I refactored all transitions into a single function.

To test, run with the `aic_model` and make sure the model correctly transitions to shutdown after all the trials end