### PR TITLE
Trigger observation cb only if goal_handle is active

### DIFF
--- a/aic_model/aic_model/aic_model.py
+++ b/aic_model/aic_model/aic_model.py
@@ -137,7 +137,7 @@ class AicModel(LifecycleNode):
     def observation_callback(self, msg):
         if not self.is_active:
             return
-        if self._policy and self.goal_handle and self.goal_handle.is_active:
+        if self._policy and self.goal_handle is not None and self.goal_handle.is_active:
             self._policy.observation_callback(msg)
 
     def insert_cable_goal_callback(self, goal_request):


### PR DESCRIPTION
It seems like as long as `aic_model` is in `active` lifecycle state, we trigger `PolicyRos.observation_callback()`. This leads to the robot waving when the node is simply activated as opposed to when the goal is sent. This PR fixes the behavior by only calling observation_callback() only when there is an active goal