### PR TITLE
Set GZ_IP to 127.0.0.1

### DIFF
--- a/aic_bringup/launch/aic_gz_bringup.launch.py
+++ b/aic_bringup/launch/aic_gz_bringup.launch.py
@@ -294,10 +294,7 @@ def launch_setup(context, *args, **kwargs):
         condition=IfCondition(spawn_cable),
     )
 
-    gz_ip_env = SetEnvironmentVariable(
-        name='GZ_IP',
-        value='127.0.0.1'
-    )
+    gz_ip_env = SetEnvironmentVariable(name="GZ_IP", value="127.0.0.1")
 
     # GZ nodes
     gz_spawn_entity = Node(


### PR DESCRIPTION
When sim launches, gz-transport multicast discovery spams `239.255.0.7`. Explicitly setting `GZ_IP` to 127.0.0.1 seems to suppress this, likely because most network configurations do not have multicast enabled on the loopback device.