### PR TITLE
Remove NIC from trial 3

### DIFF
--- a/aic_engine/config/sample_config.yaml
+++ b/aic_engine/config/sample_config.yaml
@@ -241,13 +241,7 @@ trials:
           nic_rail_0:
             entity_present: False
           nic_rail_1:
-            entity_present: True
-            entity_name: "nic_card_1"
-            entity_pose:
-              translation: -0.02
-              roll: -0.0157
-              pitch: 0.0192
-              yaw: -0.0297
+            entity_present: False
           nic_rail_2:
             entity_present: False
           nic_rail_3:


### PR DESCRIPTION
Remove NIC from trial 3 because when the robot moves to the SC mount, the cable snags on the NIC and can't reach the SC mount.
[cable_stuck_on_nic.webm](https://github.com/user-attachments/assets/aaadf667-b57d-45cc-b669-74cab7090627)
