### PR TITLE
Tune SFP module and port properties for Trial 1

### DIFF
--- a/aic_assets/models/NIC Card Mount/model.sdf
+++ b/aic_assets/models/NIC Card Mount/model.sdf
@@ -71,6 +71,20 @@
             <size>0.056 0.145 0.0016</size>
           </box>
         </geometry>
+        <!-- bullet-featherstone sets friction for the whole link using
+             values from the first collision in the link -->
+        <surface>
+          <friction>
+            <torsional>
+              <coefficient>0.1</coefficient>
+            </torsional>
+            <bullet>
+              <friction>0.1</friction>
+              <friction2>0.1</friction2>
+              <rolling_friction>0.1</rolling_friction>
+            </bullet>
+          </friction>
+        </surface>
       </collision>
       <collision name="pcb_collider_box.001">
         <pose>0.0065 -0.0025 -0.0008 0.0 0.0 0.0</pose>
@@ -153,17 +167,6 @@
             <size>0.001099 0.04872 0.011083</size>
           </box>
         </geometry>
-        <surface>
-          <friction>
-            <torsional>
-              <coefficient>0.5</coefficient>
-            </torsional>
-            <bullet>
-              <friction>0.5</friction>
-              <friction2>0.5</friction2>
-            </bullet>
-          </friction>
-        </surface>
       </collision>
       <collision name="10099100-011lfc001_collider_box.001">
         <pose>-0.002437 -0.052954 0.005461 3.128092 0.0 0.0</pose>
@@ -172,17 +175,6 @@
             <size>0.001125 0.04872 0.011121</size>
           </box>
         </geometry>
-        <surface>
-          <friction>
-            <torsional>
-              <coefficient>0.5</coefficient>
-            </torsional>
-            <bullet>
-              <friction>0.5</friction>
-              <friction2>0.5</friction2>
-            </bullet>
-          </friction>
-        </surface>
       </collision>
       <collision name="10099100-011lfc001_collider_box.002">
         <pose>-0.010237 -0.052889 0.010484 3.128092 0.0 0.0</pose>
@@ -191,17 +183,6 @@
             <size>0.016224 0.04872 0.000923</size>
           </box>
         </geometry>
-        <surface>
-          <friction>
-            <torsional>
-              <coefficient>0.5</coefficient>
-            </torsional>
-            <bullet>
-              <friction>0.5</friction>
-              <friction2>0.5</friction2>
-            </bullet>
-          </friction>
-        </surface>
       </collision>
       <collision name="10099100-011lfc001_collider_box.003">
         <pose>-0.010237 -0.053024 0.000046 3.128092 0.0 0.0</pose>
@@ -210,17 +191,6 @@
             <size>0.016224 0.04872 0.001054</size>
           </box>
         </geometry>
-        <surface>
-          <friction>
-            <torsional>
-              <coefficient>0.5</coefficient>
-            </torsional>
-            <bullet>
-              <friction>0.5</friction>
-              <friction2>0.5</friction2>
-            </bullet>
-          </friction>
-        </surface>
       </collision>
       <collision name="10099100-011lfc001_collider_box.004">
         <pose>-0.010237 -0.028738 0.003845 3.128092 0.0 0.0</pose>
@@ -237,17 +207,6 @@
             <size>0.001099 0.04872 0.011083</size>
           </box>
         </geometry>
-        <surface>
-          <friction>
-            <torsional>
-              <coefficient>0.5</coefficient>
-            </torsional>
-            <bullet>
-              <friction>0.5</friction>
-              <friction2>0.5</friction2>
-            </bullet>
-          </friction>
-        </surface>
       </collision>
       <collision name="10099100-011lfc001_collider_box.006">
         <pose>0.020763 -0.052954 0.005461 3.128092 0.0 0.0</pose>
@@ -256,17 +215,6 @@
             <size>0.001125 0.04872 0.011121</size>
           </box>
         </geometry>
-        <surface>
-          <friction>
-            <torsional>
-              <coefficient>0.5</coefficient>
-            </torsional>
-            <bullet>
-              <friction>0.5</friction>
-              <friction2>0.5</friction2>
-            </bullet>
-          </friction>
-        </surface>
       </collision>
       <collision name="10099100-011lfc001_collider_box.007">
         <pose>0.012963 -0.052889 0.010484 3.128092 0.0 0.0</pose>
@@ -275,17 +223,6 @@
             <size>0.016224 0.04872 0.000923</size>
           </box>
         </geometry>
-        <surface>
-          <friction>
-            <torsional>
-              <coefficient>0.5</coefficient>
-            </torsional>
-            <bullet>
-              <friction>0.5</friction>
-              <friction2>0.5</friction2>
-            </bullet>
-          </friction>
-        </surface>
       </collision>
       <collision name="10099100-011lfc001_collider_box.008">
         <pose>0.012963 -0.053024 0.000046 3.128092 0.0 0.0</pose>
@@ -294,17 +231,6 @@
             <size>0.016224 0.04872 0.001054</size>
           </box>
         </geometry>
-        <surface>
-          <friction>
-            <torsional>
-              <coefficient>0.5</coefficient>
-            </torsional>
-            <bullet>
-              <friction>0.5</friction>
-              <friction2>0.5</friction2>
-            </bullet>
-          </friction>
-        </surface>
       </collision>
       <collision name="10099100-011lfc001_collider_box.009">
         <pose>0.012963 -0.028738 0.003845 3.128092 0.0 0.0</pose>

--- a/aic_assets/models/sfp_sc_cable/model.sdf
+++ b/aic_assets/models/sfp_sc_cable/model.sdf
@@ -2,6 +2,13 @@
 <sdf version="1.9">
   <model name="sfp_sc_cable">
     <include merge="true">
+      <!--
+        The first link in cable intersects with gripper palm
+         Workaround this by removing this collision.
+      -->
+      <experimental:params>
+        <collision element_id="link_1::link_1_collision" action="remove"/>
+      </experimental:params>
       <uri>model://cable_base_c_rotated</uri>
     </include>
     <include merge="true">
@@ -48,7 +55,7 @@
         <collision element_id="sfp_module_link::head_collider_box.003" action="remove"/>
       </experimental:params>
       <uri>model://SFP Module</uri>
-      <pose relative_to="lc_plug_link">0 0.0341 0 0 3.14159 3.14159</pose>
+      <pose relative_to="lc_plug_link">0 0.0384 0 0 3.14159 3.14159</pose>
     </include>
     <joint name="plug_0_joint" type="fixed">
       <parent>cable_connection_0</parent>

--- a/aic_assets/models/sfp_sc_cable_reversed/model.sdf
+++ b/aic_assets/models/sfp_sc_cable_reversed/model.sdf
@@ -14,7 +14,7 @@
     </include>
     <include merge="true">
       <uri>model://SFP Module</uri>
-      <pose relative_to="lc_plug_link">-0 0.0341 0 0 -3.14159 -3.14159</pose>
+      <pose relative_to="lc_plug_link">-0 0.0384 0 0 -3.14159 -3.14159</pose>
     </include>
     <joint name="plug_0_joint" type="fixed">
       <parent>cable_connection_0</parent>

--- a/aic_description/world/aic.sdf
+++ b/aic_description/world/aic.sdf
@@ -87,6 +87,15 @@
       <max_step_size>0.002</max_step_size>
       <real_time_factor>1.0</real_time_factor>
     </physics>
+    <!--
+        Explicitly add UserCommands to ensure it is run before other systems.
+        This is necessary for contact sensors to work properly for
+        spawned entities
+    -->
+    <plugin
+      filename="gz-sim-user-commands-system"
+      name="gz::sim::systems::UserCommands">
+    </plugin>
     <plugin
       filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">


### PR DESCRIPTION
Several changes:
* Reduced friction values for SFP port on NIC card. 
    * This makes it much easier for the SFP module to slide into the port 
* Fixed contact sensor for insertion detection
    * Worked around an upstream bug related to contact sensor not working for spawned entities
 * Tweaked the SFP module position w.r.t the LC plug to better match the real cable
     * moved SFP module further outwards

    * Before:
    <img width="387" height="473" alt="Screenshot 2026-01-21 at 2 15 28 PM" src="https://github.com/user-attachments/assets/58a33291-6ce4-4c2d-b68a-254b176f5bfc" />

    * After:
    <img width="368" height="433" alt="Screenshot 2026-01-29 at 7 52 57 PM" src="https://github.com/user-attachments/assets/9f00fd03-d086-4d86-984f-71a1ac1c48ba" />
