### PR TITLE
Lower contact collisions at the bottom of the SFP port 

### DIFF
--- a/aic_assets/models/NIC Card Mount/model.sdf
+++ b/aic_assets/models/NIC Card Mount/model.sdf
@@ -306,7 +306,7 @@
       </collision>
 
       <collision name="contact_collision_01">
-        <pose>0.012963 -0.032 0.003845 3.128092 0.0 0.0</pose>
+        <pose>0.012963 -0.0295 0.003845 3.128092 0.0 0.0</pose>
         <geometry>
           <box>
             <size>0.008112 0.00025 0.006849</size>
@@ -314,7 +314,7 @@
         </geometry>
       </collision>
       <collision name="contact_collision_02">
-        <pose>-0.010237 -0.032 0.003845 3.128092 0.0 0.0</pose>
+        <pose>-0.010237 -0.0295 0.003845 3.128092 0.0 0.0</pose>
         <geometry>
           <box>
             <size>0.008112 0.00025 0.006849</size>


### PR DESCRIPTION
Lower the contact collisions located at the bottom of the SFP port in the NIC Card mount so that the SFP module is able to go deeper into the port before latching.

<img width="306" height="314" alt="Screenshot 2026-01-30 at 2 04 20 PM" src="https://github.com/user-attachments/assets/a2981212-d2f3-4bd0-8bee-273139137e25" />
