### PR TITLE
bump lerobot-robot-ros to avoid duplicated ros node names

### DIFF
--- a/aic_utils/lerobot_robot_aic/lerobot_robot_aic/aic_robot.py
+++ b/aic_utils/lerobot_robot_aic/lerobot_robot_aic/aic_robot.py
@@ -30,18 +30,21 @@ gripper_joint_name = "gripper/left_finger_joint"
 
 aic_cameras: dict[str, CameraConfig] = {
     "left_camera": ROS2CameraConfig(
+        name="left_camera",
         fps=20,
         width=1152,
         height=1024,
         topic="/left_camera/image",
     ),
     "center_camera": ROS2CameraConfig(
+        name="center_camera",
         fps=20,
         width=1152,
         height=1024,
         topic="/center_camera/image",
     ),
     "right_camera": ROS2CameraConfig(
+        name="right_camera",
         fps=20,
         width=1152,
         height=1024,

--- a/pixi.lock
+++ b/pixi.lock
@@ -504,8 +504,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/62/d9ba6323b9202dd2fe166beab8a86d29465c41a0288cbe229fac60c1ab8d/jsonlines-4.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/c9/c38f0bfe33527d1b139f67850d6a4c113d42d630cbf4846d02e3d6372d97/lerobot-0.4.3-py3-none-any.whl
-      - pypi: git+https://github.com/koonpeng/lerobot-ros?subdirectory=lerobot_robot_ros&rev=535ce545a8887c5f58596833827312ddebcbde75#535ce545a8887c5f58596833827312ddebcbde75
-      - pypi: git+https://github.com/koonpeng/lerobot-ros?subdirectory=lerobot_teleoperator_devices&rev=535ce545a8887c5f58596833827312ddebcbde75#535ce545a8887c5f58596833827312ddebcbde75
+      - pypi: git+https://github.com/koonpeng/lerobot-ros?subdirectory=lerobot_robot_ros&rev=b4a635fc5264266bd1575f07d54be3d4bbd620e0#b4a635fc5264266bd1575f07d54be3d4bbd620e0
+      - pypi: git+https://github.com/koonpeng/lerobot-ros?subdirectory=lerobot_teleoperator_devices&rev=b4a635fc5264266bd1575f07d54be3d4bbd620e0#b4a635fc5264266bd1575f07d54be3d4bbd620e0
       - pypi: https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
@@ -2619,7 +2619,7 @@ packages:
   - lerobot[sarm] ; extra == 'all'
   - lerobot[peft] ; extra == 'all'
   requires_python: '>=3.10'
-- pypi: git+https://github.com/koonpeng/lerobot-ros?subdirectory=lerobot_robot_ros&rev=535ce545a8887c5f58596833827312ddebcbde75#535ce545a8887c5f58596833827312ddebcbde75
+- pypi: git+https://github.com/koonpeng/lerobot-ros?subdirectory=lerobot_robot_ros&rev=b4a635fc5264266bd1575f07d54be3d4bbd620e0#b4a635fc5264266bd1575f07d54be3d4bbd620e0
   name: lerobot-robot-ros
   version: 0.1.0
   requires_dist:
@@ -2631,7 +2631,7 @@ packages:
   - geometry-msgs
   - moveit-msgs
   requires_python: '>=3.10'
-- pypi: git+https://github.com/koonpeng/lerobot-ros?subdirectory=lerobot_teleoperator_devices&rev=535ce545a8887c5f58596833827312ddebcbde75#535ce545a8887c5f58596833827312ddebcbde75
+- pypi: git+https://github.com/koonpeng/lerobot-ros?subdirectory=lerobot_teleoperator_devices&rev=b4a635fc5264266bd1575f07d54be3d4bbd620e0#b4a635fc5264266bd1575f07d54be3d4bbd620e0
   name: lerobot-teleoperator-devices
   version: 0.1.0
   requires_dist:

--- a/pixi.toml
+++ b/pixi.toml
@@ -36,8 +36,8 @@ ros-kilted-lerobot-robot-aic = { path = "aic_utils/lerobot_robot_aic" }
 
 [pypi-dependencies]
 lerobot = "==0.4.3"
-lerobot_robot_ros = { git = "https://github.com/koonpeng/lerobot-ros", rev = "535ce545a8887c5f58596833827312ddebcbde75", subdirectory = "lerobot_robot_ros" }
-lerobot_teleoperator_devices = { git = "https://github.com/koonpeng/lerobot-ros", rev = "535ce545a8887c5f58596833827312ddebcbde75", subdirectory = "lerobot_teleoperator_devices" }
+lerobot_robot_ros = { git = "https://github.com/koonpeng/lerobot-ros", rev = "b4a635fc5264266bd1575f07d54be3d4bbd620e0", subdirectory = "lerobot_robot_ros" }
+lerobot_teleoperator_devices = { git = "https://github.com/koonpeng/lerobot-ros", rev = "b4a635fc5264266bd1575f07d54be3d4bbd620e0", subdirectory = "lerobot_teleoperator_devices" }
 
 [activation.env]
 RMW_IMPLEMENTATION = "rmw_zenoh_cpp"


### PR DESCRIPTION
Updated https://github.com/koonpeng/lerobot-ros to avoid duplicated ros node names when there are multiple cameras.