### PR TITLE
Use caches in docker builds

### DIFF
--- a/docker/aic_eval/Dockerfile
+++ b/docker/aic_eval/Dockerfile
@@ -1,12 +1,13 @@
-FROM ros:kilted-ros-base AS build
+FROM ros:kilted-ros-base
 
 # Add `packages.osrfoundation.org` to the apt sources list:
 RUN curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg && \
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
 
-# Build the workspace
-COPY --chmod=u=rwX,go=rX --exclude=docker . /ws_aic/src/aic
-SHELL ["/bin/bash", "-c"]
+# Install dependencies
+RUN mkdir -p /ws_aic/src/aic
+COPY --chmod=644 aic.repos /ws_aic/src/aic/
+COPY --chmod=u=rwX,go=rX --parents **/package.xml /ws_aic/src/aic
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
   apt update && apt upgrade -y && \
   # undeclared deps
@@ -17,10 +18,16 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,t
   apt -y install $(sort -u $(find . -iname 'packages-'`lsb_release -cs`'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | sed '/gz\|sdf/d' | tr '\n' ' ') && \
   cd /ws_aic && \
   # Install ROS dependencies using rosdep.
-  rosdep install --from-paths src --ignore-src --rosdistro kilted -yr --skip-keys "gz-cmake3 DART libogre-dev libogre-next-2.3-dev" && \
-  source /opt/ros/kilted/setup.bash && \
-  GZ_BUILD_FROM_SOURCE=1 colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --merge-install --executor sequential && \
-  rm -rf /ws_aic/build /ws_aic/log /ws_aic/src
+  rosdep install --from-paths src --ignore-src --rosdistro kilted -yr --skip-keys "gz-cmake3 DART libogre-dev libogre-next-2.3-dev"
+
+# Build the workspace
+COPY --chmod=u=rwX,go=rX --exclude=docker . /ws_aic/src/aic
+SHELL ["/bin/bash", "-c"]
+RUN --mount=type=cache,target=/ws_aic/build,sharing=locked \
+  cd /ws_aic \
+  && . /opt/ros/kilted/setup.bash \
+  && GZ_BUILD_FROM_SOURCE=1 colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --merge-install --executor sequential \
+  && rm -rf /ws_aic/log /ws_aic/src
 
 COPY --chmod=644 docker/aic_eval/zenoh_router_config.json5 /zenoh_router_config.json5
 COPY --chmod=755 <<EOF /entrypoint.sh

--- a/docker/aic_model/Dockerfile
+++ b/docker/aic_model/Dockerfile
@@ -11,9 +11,8 @@ COPY aic_interfaces /ws_aic/src/aic/aic_interfaces
 COPY aic_utils /ws_aic/src/aic/aic_utils
 COPY pixi.toml pixi.lock /ws_aic/src/aic
 SHELL ["/bin/bash", "-c"]
-RUN cd /ws_aic/src/aic && pixi install --frozen \
-    && pixi clean --build \
-    && pixi clean cache -y
+RUN --mount=type=cache,target=/root/.cache/rattler/cache --mount=type=cache,target=/ws_aic/src/aic/.pixi/build \
+    cd /ws_aic/src/aic && pixi install --frozen
 
 WORKDIR /ws_aic/src/aic
 ENTRYPOINT [ \


### PR DESCRIPTION
Use more caching to optimize docker build times. Note that the ROS toolchain is not reproducible and it is easy to make cmake become incoherent. So sometimes you might have to build with `--no-cache`.

This is mostly to improve build times when switching branches, I don't recommend using caches in production due to the mentioned issues (current workflow already disable caches).