### PR TITLE
Fix score truncation issues

### DIFF
--- a/aic_engine/src/aic_engine.cpp
+++ b/aic_engine/src/aic_engine.cpp
@@ -261,7 +261,7 @@ TaskAttempt::TaskAttempt(const std::string& _id)
 
 //==============================================================================
 YAML::Node Score::serialize() const {
-  const int total_score = this->calculate_total_score();
+  const double total_score = this->calculate_total_score();
   YAML::Node score;
   score["total"] = total_score;
   for (const auto& [trial_name, trial_score] : this->breakdown) {
@@ -273,9 +273,9 @@ YAML::Node Score::serialize() const {
 }
 
 //==============================================================================
-int Score::calculate_total_score() const {
+double Score::calculate_total_score() const {
   // TODO(luca) check calculation
-  int score = 0;
+  double score = 0;
   for (const auto& [trial_name, trial_score] : this->breakdown) {
     score += trial_score.tier_1.total_score();
     score += trial_score.tier_2.total_score();
@@ -594,7 +594,7 @@ EngineState Engine::run() {
     if (trial.state == TrialState::AllTasksCompleted) {
       RCLCPP_INFO(
           node_->get_logger(),
-          "\033[1;32m✓ Trial '%s' completed successfully! Score: %d\033[0m",
+          "\033[1;32m✓ Trial '%s' completed successfully! Score: %f\033[0m",
           trial_id.c_str(), trial_score.total_score());
     } else {
       RCLCPP_ERROR(node_->get_logger(),
@@ -618,7 +618,7 @@ EngineState Engine::run() {
     RCLCPP_INFO(node_->get_logger(),
                 "\033[1;32m║   ✓ All Trials Completed!              ║\033[0m");
     RCLCPP_INFO(node_->get_logger(),
-                "\033[1;32m║   Total Score: %.3d                     ║\033[0m",
+                "\033[1;32m║   Total Score: %.3f                     ║\033[0m",
                 score.calculate_total_score());
     RCLCPP_INFO(node_->get_logger(),
                 "\033[1;32m╚════════════════════════════════════════╝\033[0m");
@@ -1762,7 +1762,7 @@ void Engine::score_trial(TrialScore& score) {
   score.tier_2 = tier2_score;
   score.tier_3 = tier3_score;
 
-  RCLCPP_INFO(node_->get_logger(), "Finished scoring trial, total score is: %u",
+  RCLCPP_INFO(node_->get_logger(), "Finished scoring trial, total score is: %f",
               score.total_score());
 }
 

--- a/aic_engine/src/aic_engine.hpp
+++ b/aic_engine/src/aic_engine.hpp
@@ -157,7 +157,7 @@ struct TrialScore {
 
   void tier_1_success() { tier_1 = aic_scoring::Tier1Score(1); }
 
-  int total_score() const {
+  double total_score() const {
     return tier_1.total_score() + tier_2.total_score() + tier_3.total_score();
   }
 };
@@ -171,7 +171,7 @@ struct Score {
   YAML::Node serialize() const;
 
   /// \brief Computes the total score from the score breakdown.
-  int calculate_total_score() const;
+  double calculate_total_score() const;
 };
 
 //==============================================================================

--- a/aic_scoring/include/aic_scoring/TierScore.hh
+++ b/aic_scoring/include/aic_scoring/TierScore.hh
@@ -36,7 +36,7 @@ public:
 
   std::string message;
 
-  virtual int total_score() const = 0;
+  virtual double total_score() const = 0;
 
   virtual YAML::Node to_yaml() const {
     YAML::Node score;
@@ -64,7 +64,7 @@ public:
     }
   }
 
-  int total_score() const override {
+  double total_score() const override {
     return score;
   }
 };
@@ -73,18 +73,18 @@ public:
 class Tier2Score : public TierScore {
 public:
   struct CategoryScore {
-    int score;
+    double score;
     std::optional<std::string> message;
 
-    CategoryScore(int s, const std::optional<std::string>& msg) : score(s), message(msg) {}
+    CategoryScore(double s, const std::optional<std::string>& msg) : score(s), message(msg) {}
   };
 
   using CategoryScores = std::map<std::string, CategoryScore>;
 
   Tier2Score(const std::string& msg) : TierScore(msg) {}
 
-  int total_score() const override {
-    int score = 0;
+  double total_score() const override {
+    double score = 0;
     for (const auto& category : category_scores) {
       score += category.second.score;
     }
@@ -104,7 +104,7 @@ public:
     return score;
   }
 
-  void add_category_score(const std::string& category, int score,
+  void add_category_score(const std::string& category, double score,
                           const std::optional<std::string>& msg = std::nullopt) {
     this->category_scores.insert({category, CategoryScore(score, msg)});
   }
@@ -122,12 +122,12 @@ private:
 
 class Tier3Score : public TierScore {
 private:
-  int score;
+  double score;
 
 public:
-  Tier3Score(int s, const std::string& msg) : TierScore(msg), score(s) { }
+  Tier3Score(double s, const std::string& msg) : TierScore(msg), score(s) { }
 
-  int total_score() const override {
+  double total_score() const override {
     return score;
   }
 };


### PR DESCRIPTION
The previous score storate types were using `int`. However, our multiple scoring functions are using `double`. Therefore, we were having some truncated scores when storing them. This patch updates our scoring storage types from `int` to `double`.

The generated `score.yaml` is also updated:

```
total: 81.728866799706154
trial_1:
  tier_1:
    score: 1
    message: Model validation succeeded.
  tier_2:
    score: 18.452288636313668
    message: Scoring succeeded.
    categories:
      contacts:
        score: 0
        message: No contact detected.
...
```