### PR TITLE
Remove unused WaveArm line that crashes after Observation msg update

### DIFF
--- a/aic_example_policies/aic_example_policies/ros/WaveArm.py
+++ b/aic_example_policies/aic_example_policies/ros/WaveArm.py
@@ -55,7 +55,6 @@ class WaveArm(PolicyRos):
             self.get_logger().info(f"observation time: {t}")
 
             # Move the arm along a line, while looking down at the task board.
-            tcp = observation.tcp_transform.transform.translation
             loop_duration = 5.0  # seconds
             loop_fraction = (t % loop_duration) / loop_duration
             y_scale = 2 * loop_fraction


### PR DESCRIPTION
This line was not being used anyway, since `WaveArm` runs "open-loop". It is crashing after the update to `Observation.msg` in #202 that now uses a `ControllerState` submessage to convey the end-effector position, rather than a top-level field.