### PR TITLE
Enforce plug-port insertion orientation

### DIFF
--- a/aic_assets/models/NIC Card Mount/model.sdf
+++ b/aic_assets/models/NIC Card Mount/model.sdf
@@ -314,22 +314,37 @@
       </collision>
 
       <collision name="contact_collision_01">
-        <pose>0.012963 -0.0295 0.003845 3.128092 0.0 0.0</pose>
+        <pose>0.012963 -0.0305 0.002845 3.128092 0.0 0.0</pose>
         <geometry>
           <box>
-            <size>0.008112 0.00025 0.006849</size>
+            <size>0.008112 0.00025 0.0025</size>
           </box>
         </geometry>
       </collision>
       <collision name="contact_collision_02">
-        <pose>-0.010237 -0.0295 0.003845 3.128092 0.0 0.0</pose>
+        <pose>-0.010237 -0.0305 0.002845 3.128092 0.0 0.0</pose>
         <geometry>
           <box>
-            <size>0.008112 0.00025 0.006849</size>
+            <size>0.008112 0.00025 0.0025</size>
           </box>
         </geometry>
       </collision>
-
+      <collision name="contact_collision_01_holder">
+        <pose>0.012963 -0.030 0.008 3.128092 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.008112 0.00025 0.002</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="contact_collision_02_holder">
+        <pose>-0.010237 -0.030 0.008 3.128092 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.008112 0.00025 0.002</size>
+          </box>
+        </geometry>
+      </collision>
       <sensor name="sfp_port_sensor" type="contact">
         <contact>
           <collision>contact_collision_01</collision>

--- a/aic_assets/models/NIC Card Mount/nic_card_mount_macro.xacro
+++ b/aic_assets/models/NIC Card Mount/nic_card_mount_macro.xacro
@@ -10,7 +10,7 @@
         <plugin
           filename="gz-sim-touchplugin-system"
           name="gz::sim::systems::TouchPlugin">
-          <target>sfp_module</target>
+          <target>sfp_tip_link/collision/contact_collision</target>
           <time>1</time>
           <namespace>${prefix}</namespace>
           <enabled>true</enabled>

--- a/aic_assets/models/SC Plug/model.sdf
+++ b/aic_assets/models/SC Plug/model.sdf
@@ -72,6 +72,22 @@
           </cylinder>
         </geometry>
       </collision>
+      <collision name="side_box_collision">
+        <pose>0.00146 -0.00632 0.0042 0.0 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.00425 0.00162 0.001</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="side_box_collision_2">
+        <pose>0.00146 0.00632 0.0042 0.0 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.00425 0.00162 0.001</size>
+          </box>
+        </geometry>
+      </collision>
     </link>
   </model>
 </sdf>

--- a/aic_assets/models/SFP Module/model.sdf
+++ b/aic_assets/models/SFP Module/model.sdf
@@ -157,7 +157,7 @@
         </geometry>
       </collision>
       <collision name="body_collider_box">
-        <pose>0.0 0.0 0.00383 0.0 0.0 0.0</pose>
+        <pose>0.0 0.001 0.00383 0.0 0.0 0.0</pose>
         <geometry>
           <box>
             <size>0.01375 0.0473 0.000789</size>
@@ -165,7 +165,7 @@
         </geometry>
       </collision>
       <collision name="body_collider_box.001">
-        <pose>0.0 0.0 -0.004138 0.0 0.0 0.0</pose>
+        <pose>0.0 0.001 -0.004138 0.0 0.0 0.0</pose>
         <geometry>
           <box>
             <size>0.01375 0.0473 0.000178</size>
@@ -173,7 +173,7 @@
         </geometry>
       </collision>
       <collision name="body_collider_box.002">
-        <pose>-0.006588 0.0 0.0 0.0 0.0 0.0</pose>
+        <pose>-0.006588 0.001 0.0 0.0 0.0 0.0</pose>
         <geometry>
           <box>
             <size>0.000574 0.0473 0.00845</size>
@@ -181,18 +181,10 @@
         </geometry>
       </collision>
       <collision name="body_collider_box.003">
-        <pose>0.00647 0.0 0.0 0.0 0.0 0.0</pose>
+        <pose>0.00647 0.001 0.0 0.0 0.0 0.0</pose>
         <geometry>
           <box>
             <size>0.000811 0.0473 0.00845</size>
-          </box>
-        </geometry>
-      </collision>
-      <collision name="body_collider_box.004">
-        <pose>0.0 -0.018731 0.0 0.0 0.0 0.0</pose>
-        <geometry>
-          <box>
-            <size>0.01375 0.009838 0.00845</size>
           </box>
         </geometry>
       </collision>
@@ -230,6 +222,22 @@
           <izz>1e-6</izz>
         </inertia>
       </inertial>
+      <collision name="contact_collision">
+        <pose>0.0 0.0021125 -0.0005 0 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.01375 0.004225 0.001</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="non_contact_collision">
+        <pose>0.0 -0.0021125 -0.0005 0 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.01375 0.004225 0.001</size>
+          </box>
+        </geometry>
+      </collision>
       <pose>0 -0.02365 0 1.5708 0 0</pose>
     </link>
     <joint name="sfp_tip_joint" type="fixed">


### PR DESCRIPTION
Made a couple of changes to ensure that the plugs can only be inserted / latched into the ports in the correct orientation.

**Trial 1 & 2**
Added a contact collision on one side of the the SFP module's tip. Similarly, I moved the contact sensor at the bottom of the SFP port in the NIC Card mount to the matching side (instead of being in the middle). So that the insertion event will only be triggered if these two matching collisions come into contact.

Contact collision at the SFP module tip (bounding box highlighted in white lines)
<img width="225" height="355" alt="Screenshot 2026-02-05 at 5 02 42 PM" src="https://github.com/user-attachments/assets/c0fdc9b6-9957-4dc6-a64c-18b027e6b80c" />

Contact collision at the bottom of SFP port. 
<img width="572" height="431" alt="Screenshot 2026-02-05 at 5 03 57 PM" src="https://github.com/user-attachments/assets/23bdf79a-a48d-46f7-a751-e2395a002e9a" />

**Trial 3**

Added collisions for the 2 little protruding parts on the side of the the SC Plug model. This ensures the plug can only be inserted into the SC port in one orientation. 

Before:
<img width="329" height="450" alt="Screenshot 2026-02-05 at 4 47 29 PM" src="https://github.com/user-attachments/assets/5eefe5f9-f33f-40fd-88ab-bccf29bd7129" />

After:
<img width="337" height="368" alt="Screenshot 2026-02-05 at 4 46 33 PM" src="https://github.com/user-attachments/assets/d610f007-7edf-4a23-8377-5e1dfa86c60e" />



