### PR TITLE
Fix robot arm moving up after reset in aic_engine

### DIFF
--- a/aic_controller/src/aic_controller.cpp
+++ b/aic_controller/src/aic_controller.cpp
@@ -704,6 +704,11 @@ controller_interface::CallbackReturn Controller::on_deactivate(
   target_state_ = std::nullopt;
   joint_target_state_ = std::nullopt;
 
+  // Reset feedforward wrenches
+  feedforward_wrench_at_tip_.setZero();
+  impedance_params_.feedforward_wrench.setZero();
+  joint_impedance_params_.feedforward_torques.setZero();
+
   return controller_interface::CallbackReturn::SUCCESS;
 }
 


### PR DESCRIPTION
# Overview

Fix the issue seen where the robot arm moves up after resetting and homing the robot via `aic_engine`.
In between deactivation and activation of `aic_controller`, the feedforward wrench term from the last sent message was not reset within the `aic_controller`
Hence, the issue results from the controller still using the previously set feedforward wrench values from the last received `MotionUpdate` or `JointMotionUpdate` message.

# Changes Made

Reset feedforward wrenches upon deactivating controller so that any previously sent values does not carry over into the controller's reactivation