### PR TITLE
tune example values in aic_model.py

### DIFF
--- a/aic_model/aic_model/aic_model.py
+++ b/aic_model/aic_model/aic_model.py
@@ -201,10 +201,10 @@ class AicModel(LifecycleNode):
         motion_update_msg.header.stamp = self.get_clock().now().to_msg()
 
         motion_update_msg.target_stiffness = np.diag(
-            [100.0, 100.0, 100.0, 50.0, 50.0, 50.0]
+            [85.0, 85.0, 85.0, 85.0, 85.0, 85.0]
         ).flatten()
         motion_update_msg.target_damping = np.diag(
-            [40.0, 40.0, 40.0, 15.0, 15.0, 15.0]
+            [75.0, 75.0, 75.0, 75.0, 75.0, 75.0]
         ).flatten()
 
         motion_update_msg.feedforward_wrench_at_tip = Wrench(
@@ -212,7 +212,7 @@ class AicModel(LifecycleNode):
         )
 
         motion_update_msg.wrench_feedback_gains_at_tip = Wrench(
-            force=Vector3(x=0.5, y=0.5, z=0.5), torque=Vector3(x=0.0, y=0.0, z=0.0)
+            force=Vector3(x=0.0, y=0.0, z=0.0), torque=Vector3(x=0.0, y=0.0, z=0.0)
         )
 
         motion_update_msg.trajectory_generation_mode.mode = (


### PR DESCRIPTION
This PR simply sets a more optimal value for the stiffness and damping parameters in the `aic_model.py` example. It also sets the  `wrench_feedback_gains_at_tip` to 0.0 as it is currently not necessary to incorporate force torque sensor measurements into the feed-foward wrench.