### PR TITLE
Add force torque sensor to cable plug

### DIFF
--- a/aic_assets/models/sfp_sc_cable/model.sdf
+++ b/aic_assets/models/sfp_sc_cable/model.sdf
@@ -60,6 +60,13 @@
     <joint name="plug_0_joint" type="fixed">
       <parent>cable_connection_0</parent>
       <child>lc_plug_link</child>
+      <sensor name="force_torque_sensor" type="force_torque">
+        <update_rate>50</update_rate>
+        <force_torque>
+          <frame>sensor</frame>
+        </force_torque>
+      </sensor>
+
     </joint>
     <joint name="plug_1_joint" type="fixed">
       <parent>cable_connection_1</parent>

--- a/aic_bringup/config/ros_gz_bridge_config.yaml
+++ b/aic_bringup/config/ros_gz_bridge_config.yaml
@@ -109,3 +109,10 @@
   gz_type_name: "gz.msgs.Boolean"
   direction: GZ_TO_ROS
   lazy: true
+
+- ros_topic_name: "/cable_0/wrench"
+  gz_topic_name: "/world/aic_world/model/cable_0/joint/plug_0_joint/sensor/force_torque_sensor/forcetorque"
+  ros_type_name: "geometry_msgs/msg/WrenchStamped"
+  gz_type_name: "gz.msgs.Wrench"
+  direction: GZ_TO_ROS
+  lazy: true


### PR DESCRIPTION
Add force torque sensor to the fixed joint connecting the cable plug to the cable body. This is an alternative approach for measuring and detecting excessive force values for scoring purposes.

Test by echo'ing the topic:

```
ros2 topic echo /cable_0/wrench
```