### PR TITLE
Update cable pose in launch file

### DIFF
--- a/aic_assets/models/sfp_sc_cable/model.sdf
+++ b/aic_assets/models/sfp_sc_cable/model.sdf
@@ -8,6 +8,7 @@
       -->
       <experimental:params>
         <collision element_id="link_1::link_1_collision" action="remove"/>
+        <collision element_id="cable_end_0::base_collision" action="remove"/>
       </experimental:params>
       <uri>model://cable_base_c_rotated</uri>
     </include>

--- a/aic_bringup/launch/aic_gz_bringup.launch.py
+++ b/aic_bringup/launch/aic_gz_bringup.launch.py
@@ -671,14 +671,14 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "cable_y",
-            default_value="0.025",
+            default_value="0.024",
             description="Cable spawn Y position",
         )
     )
     declared_arguments.append(
         DeclareLaunchArgument(
             "cable_z",
-            default_value="1.51",
+            default_value="1.518",
             description="Cable spawn Z position",
         )
     )
@@ -692,7 +692,7 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "cable_pitch",
-            default_value="-0.45",
+            default_value="-0.48",
             description="Cable spawn pitch orientation (radians)",
         )
     )


### PR DESCRIPTION
The cable spawn pose in the launch file was changed in https://github.com/intrinsic-dev/aic/pull/217. This PR makes minor tweaks to keep the pose between gripper and SFP module consistent with real world configuration.
<img width="322" height="389" alt="Screenshot 2026-02-09 at 2 28 14 PM" src="https://github.com/user-attachments/assets/938c1b72-09ac-4b8c-9908-fe2deb5556eb" />
