### PR TITLE
Exit bringup when aic_engine returns

### DIFF
--- a/aic_bringup/README.md
+++ b/aic_bringup/README.md
@@ -129,6 +129,7 @@ ros2 launch aic_bringup aic_gz_bringup.launch.py [parameters]
 
 **AIC Engine:**
 - `start_aic_engine` (default: `"false"`) - Start the `aic_engine` orchestrator node for evaluation.
+- `shutdown_on_aic_engine_exit` (default: `"false"`) - Shutdown the entire launch file when `aic_engine` exits, propagating its exit code. Only takes effect when `start_aic_engine` is `true`. Useful for automated evaluation where the container should exit after trial completion.
 - `aic_engine_config_file` (default: `"aic_engine/config/sample_config.yaml"`) - Absolute path to YAML file with the AIC engine configuration.
 
 ---

--- a/aic_bringup/launch/aic_gz_bringup.launch.py
+++ b/aic_bringup/launch/aic_gz_bringup.launch.py
@@ -23,6 +23,7 @@ from launch.actions import (
     OpaqueFunction,
     RegisterEventHandler,
     SetEnvironmentVariable,
+    Shutdown,
 )
 from launch.conditions import IfCondition, UnlessCondition
 from launch.event_handlers import OnProcessExit
@@ -82,6 +83,7 @@ def launch_setup(context, *args, **kwargs):
     cable_type = LaunchConfiguration("cable_type")
     ground_truth = LaunchConfiguration("ground_truth")
     start_aic_engine = LaunchConfiguration("start_aic_engine")
+    shutdown_on_aic_engine_exit = LaunchConfiguration("shutdown_on_aic_engine_exit")
     aic_engine_config_file = LaunchConfiguration("aic_engine_config_file")
 
     gripper_initial_pos = "0.00655"
@@ -246,6 +248,29 @@ def launch_setup(context, *args, **kwargs):
         condition=IfCondition(start_aic_engine),
     )
 
+    # Event handler to shutdown launch file when aic_engine exits
+    shutdown_on_aic_engine_exit_handler = RegisterEventHandler(
+        OnProcessExit(
+            target_action=aic_engine,
+            on_exit=[
+                Shutdown(
+                    reason="aic_engine exited",
+                )
+            ],
+        ),
+        condition=IfCondition(
+            PythonExpression(
+                [
+                    "'",
+                    start_aic_engine,
+                    "' == 'true' and '",
+                    shutdown_on_aic_engine_exit,
+                    "' == 'true'",
+                ]
+            )
+        ),
+    )
+
     # Task board spawning (conditional)
     spawn_task_board = LaunchConfiguration("spawn_task_board")
     task_board_description_file = LaunchConfiguration("task_board_description_file")
@@ -398,6 +423,7 @@ def launch_setup(context, *args, **kwargs):
         ground_truth_tf_static_relay,
         ground_truth_static_tf_publisher,
         aic_engine,
+        shutdown_on_aic_engine_exit_handler,
     ]
 
     return nodes_to_start
@@ -715,6 +741,14 @@ def generate_launch_description():
             "start_aic_engine",
             default_value="false",
             description="Whether to start the AIC engine.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "shutdown_on_aic_engine_exit",
+            default_value="false",
+            description="Whether to shutdown the launch file when aic_engine exits. "
+            "Only takes effect when start_aic_engine is true.",
         )
     )
     declared_arguments.append(

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -5,7 +5,8 @@ services:
     build:
       dockerfile: docker/aic_eval/Dockerfile
       context: ..
-    command: gazebo_gui:=false launch_rviz:=false ground_truth:=false start_aic_engine:=true
+    entrypoint: ["/entrypoint_eval.sh"]
+    command: gazebo_gui:=false launch_rviz:=false ground_truth:=false start_aic_engine:=true shutdown_on_aic_engine_exit:=true
     gpus: all
     networks:
       - default


### PR DESCRIPTION
This PR adds a new `shutdown_on_aic_engine_exit` launch arg to `aic_gz_bringup`. When set to `true`, the launch will exit whenever the `aic_engine` exits. 

This is needed for cloud evaluation.

## Test it

Launch bringup

```
ros2 launch aic_bringup aic_gz_bringup.launch.py start_aic_engine:=true shutdown_on_aic_engine_exit:=true
```

Then either let the `aic_engine` node timeout after not discovering the `aic_model` OR

Start the model and wait for completion of scoring

```
ros2 run aic_model aic_model --ros-args -p policy:=aic_example_policies.ros.WaveArm
```

The bringup launch should exit after either of these 