### PR TITLE
Update sfp_sc_cable collisions to prevent the cable body from passing through gripper

### DIFF
--- a/aic_assets/models/sfp_sc_cable/model.sdf
+++ b/aic_assets/models/sfp_sc_cable/model.sdf
@@ -3,12 +3,22 @@
   <model name="sfp_sc_cable">
     <include merge="true">
       <!--
-        The first link in cable intersects with gripper palm
-         Workaround this by removing this collision.
+         A few links in cable intersect with gripper palm.
+         Workaround this by removing their collisions.
       -->
       <experimental:params>
-        <collision element_id="link_1::link_1_collision" action="remove"/>
+        <collision element_id="link_1::link_1_collision" action="modify">
+          <pose>0 0 0.006 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.036</length>
+              <radius>0.002</radius>
+            </cylinder>
+          </geometry>
+        </collision>
         <collision element_id="cable_end_0::base_collision" action="remove"/>
+        <collision element_id="cable_connection_0::collision_0" action="remove"/>
+        <collision element_id="cable_connection_0::collision_1" action="remove"/>
       </experimental:params>
       <uri>model://cable_base_c_rotated</uri>
     </include>


### PR DESCRIPTION
Part of https://github.com/intrinsic-dev/aic/issues/240

An invisible collision was added in #144 to prevent the cable from swinging through the gripper fingers. However, the collision in the first link of the cable body (namely `link_1::link_1_collision`) was also disabled to workaround a different issue (penetration with the gripper palm). As the result, the cable body does not collide with the invisible collision between the gripper. 

The PR makes more tweaks to the cable collisions so that we shorten the collision in the cable link instead of completely removing it. While working on this, I noticed more collisions were colliding with the gripper palm, so I disabled them (`cable_connection_0::collision_0,` `cable_connection_0::collision_1`). 

Screenshot of updated collisions. The long cylinder link on the right of the screenshot has orange collision overlaid over it. You can see it's now shorter than the actual link (no collision at the top). Previously this was the collision that was completely disabled

<img width="352" height="547" alt="Screenshot 2026-02-10 at 2 21 36 PM" src="https://github.com/user-attachments/assets/d78bc581-cac2-43bd-bbc1-ed5365be6829" />


Here's testing with the gripper holding the cable / plug in a horizontal position. The cable no longer falls through the gap between the gripper. Note that there's still no self-collision between the links in the cable so you can see that the cable still intersects with the SFP module.

<img width="334" height="306" alt="Screenshot 2026-02-10 at 2 27 03 PM" src="https://github.com/user-attachments/assets/33733b5b-1e88-4d84-91ec-19576b668dff" />
