### PR TITLE
Fix typo in Quick Start section of Getting Started doc

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -97,7 +97,7 @@ Also see [Alternative Installation Methods](https://pixi.prefix.dev/latest/insta
    git clone https://github.com/intrinsic-dev/aic
 
    # Install and build dependencies
-   cd ~/ws_aic/src/arc
+   cd ~/ws_aic/src/aic
    pixi install
    ```
 


### PR DESCRIPTION
https://github.com/intrinsic-dev/aic/issues/255