### PR TITLE
Teleop script cleanup

### DIFF
--- a/aic_utils/aic_teleoperation/README.md
+++ b/aic_utils/aic_teleoperation/README.md
@@ -34,22 +34,22 @@ Control individual robot joints directly.
 Control end-effector pose (position and orientation).
 
 **Linear Movement:**
-- `a/d` - X axis: +/-
-- `w/s` - Y axis: +/-
-- `q/e` - Z axis: +/-
+- `a/d` - X axis: -/+
+- `w/s` - Y axis: -/+
+- `r/f` - Z axis: -/+
 
 **Angular Movement:**
-- `j/l` - Roll: +/-
-- `i/k` - Pitch: +/-
-- `u/o` - Yaw: +/-
+- `Shift + s/w` : -/+ Angular X
+- `Shift + a/d` : -/+ Angular Y
+- `q/e` : -/+ Angular Z
 
 **Speed Control:**
-- `n` - Slow mode (linear: 0.02 m/s, angular: 0.02 rad/s)
-- `m` - Fast mode (linear: 0.1 m/s, angular: 0.1 rad/s)
+- `k` - Slow mode (linear: 0.02 m/s, angular: 0.02 rad/s)
+- `l` - Fast mode (linear: 0.1 m/s, angular: 0.1 rad/s)
 
 **Frame Toggle:**
-- `b` - Tool frame (end-effector)
-- `m` - Global frame (base_link)
+- `n` - Tool frame (`gripper/tcp`)
+- `m` - Global frame (`base_link`)
 
 **Exit:**
 - `ESC` - Quit teleoperation
@@ -84,4 +84,4 @@ ros2 run aic_teleoperation cartesian_keyboard_teleop
 
 - The scripts automatically switch the controller to the appropriate control mode (joint or Cartesian) when started
 - Press ESC to cleanly exit teleoperation
-- Ensure you have focus on the terminal window for keyboard input to be captured
+- Keyboard input will be captured regardless of whether keyboard focus is on the terminal window

--- a/aic_utils/aic_teleoperation/aic_teleoperation/cartesian_keyboard_teleop.py
+++ b/aic_utils/aic_teleoperation/aic_teleoperation/cartesian_keyboard_teleop.py
@@ -46,18 +46,18 @@ FAST_LINEAR_VEL = 0.1
 FAST_ANGULAR_VEL = 0.1
 
 KEY_MAPPINGS = {
-    "d": (-1, 0, 0, 0, 0, 0),  # -linear.x
-    "a": (1, 0, 0, 0, 0, 0),  # +linear.x
+    "d": (1, 0, 0, 0, 0, 0),  # +linear.x
+    "a": (-1, 0, 0, 0, 0, 0),  # -linear.x
     "w": (0, -1, 0, 0, 0, 0),  # -linear.y
     "s": (0, 1, 0, 0, 0, 0),  # +linear.y
     "r": (0, 0, -1, 0, 0, 0),  # -linear.z
     "f": (0, 0, 1, 0, 0, 0),  # +linear.z
-    "W": (0, 0, 0, -1, 0, 0),  # -angular.x
-    "S": (0, 0, 0, 1, 0, 0),  # +angular.x
+    "W": (0, 0, 0, 1, 0, 0),  # angular.x
+    "S": (0, 0, 0, -1, 0, 0),  # -angular.x
     "A": (0, 0, 0, 0, -1, 0),  # -angular.y
     "D": (0, 0, 0, 0, 1, 0),  # +angular.y
-    "e": (0, 0, 0, 0, 0, -1),  # -angular.z
-    "q": (0, 0, 0, 0, 0, 1),  # +angular.z
+    "e": (0, 0, 0, 0, 0, 1),  # +angular.z
+    "q": (0, 0, 0, 0, 0, -1),  # -angular.z
 }
 
 
@@ -106,7 +106,7 @@ class AICCartesianTeleoperatorNode(Node):
         # Variable parameters for teleoperation
         self.linear_vel = FAST_LINEAR_VEL  # Linear velocity (m/s)
         self.angular_vel = FAST_ANGULAR_VEL  # Angular velocity (rad/s)
-        self.frame_id = "base_link"
+        self.frame_id = "gripper/tcp"
 
     def on_key_press(self, key):
         """Callback for keyboard listener when a key is pressed."""
@@ -242,14 +242,14 @@ def main(args=None):
         Keyboard teleoperation for Cartesian control
         ---------------------------
         Linear translation:
-            d/a : -/+ Linear X
+            a/d : -/+ Linear X
             w/s : -/+ Linear Y
             r/f : -/+ Linear Z
 
         Angular rotation:
-            Shift + w/s : -/+ Angular X
+            Shift + s/w : -/+ Angular X
             Shift + a/d : -/+ Angular Y
-            e/q : -/+ Angular Z
+            q/e : -/+ Angular Z
 
         Toggle between SLOW and FAST teleoperation:
             k : Activate SLOW mode ({SLOW_LINEAR_VEL} m/s and {SLOW_ANGULAR_VEL} rad/s)

--- a/aic_utils/lerobot_robot_aic/README.md
+++ b/aic_utils/lerobot_robot_aic/README.md
@@ -58,7 +58,7 @@ View and edit key mappings and speed settings in `AICKeyboardJointTeleop` and `A
 
 :warning: Note: In our experience, SpaceMouse teleoperation was laggier than keyboard teleoperation.
 
-We used a 3Dconnexion SpaceMouse. To enable USB permissions, you may need to add the following to your `/etc/udev/rules.d/99-spacemouse.rules`:
+We used a 3Dconnexion SpaceMouse with the [pyspacemouse](https://github.com/JakubAndrysek/PySpaceMouse?tab=readme-ov-file#dependencies) library. To enable USB permissions, you may need to add the following to your `/etc/udev/rules.d/99-spacemouse.rules`:
 ``` bash
 # Apply to all hidraw nodes for 3Dconnexion devices
 KERNEL=="hidraw*", ATTRS{idVendor}=="046d", MODE="0666", GROUP="plugdev"

--- a/docs/participant_utilities.md
+++ b/docs/participant_utilities.md
@@ -8,7 +8,7 @@
 
 ### lerobot_robot_aic
 
-- [lerobot_robot_aic](../aic_utils/lerobot_robot_aic/README.md#teleoperating-with-lerobot): LeRobot-based teleoperation using SpaceMouse devices
+- [lerobot_robot_aic](../aic_utils/lerobot_robot_aic/README.md#teleoperating-with-lerobot): LeRobot-based teleoperation for joint-space and Cartesian-space control (using keyboard or SpaceMouse device)
 - Enables dataset recording for training LeRobot policies
 
 ### Additional Examples


### PR DESCRIPTION
- Standardize cartesian gripper/tcp keyboard mappings between lerobot and non-lerobot teleop scripts.
- Make a few corrections and clarifications in the teleop readmes.