### PR TITLE
Jt/fix wrench offset transform

### DIFF
--- a/aic_controller/src/aic_controller.cpp
+++ b/aic_controller/src/aic_controller.cpp
@@ -1699,7 +1699,8 @@ void Controller::interpolate_impedance_parameters() {
     impedance_params_.feedforward_wrench.tail<3>() =
         current_tool_state_.pose.rotation() * total_wrench_at_tip.tail<3>();
 
-    // Update offset wrench by transforming it to the gripper frame
+    // Update offset wrench by transforming it from the global frame to the
+    // TCP frame
     impedance_params_.offset_wrench =
         Eigen::Map<const Eigen::Matrix<double, 6, 1>>(
             params_.impedance.default_values.offset_wrench.data());


### PR DESCRIPTION
This PR fixes issue #240 by transforming the constant `wrench_offset`, originally applied in the `gripper/tcp` frame, to the global `base_link` frame.