### PR TITLE
Set offset wrench to 0.0 to eliminate bouncing behaviour

### DIFF
--- a/aic_bringup/config/aic_ros2_controllers.yaml
+++ b/aic_bringup/config/aic_ros2_controllers.yaml
@@ -308,7 +308,7 @@ aic_controller:
       default_values:
         control_stiffness: [75.0, 75.0, 75.0, 75.0, 75.0, 75.0]
         control_damping: [35.0, 35.0, 35.0, 35.0, 35.0, 35.0]
-        offset_wrench: [0.0, 0.0, 0.7848, 0.0, 0.0, 0.0]
+        offset_wrench: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
 
     joint_impedance:
       interpolator:


### PR DESCRIPTION
This PR is a hotfix for issue #240. 

The `wrench_offset` was added to compensate for the gravity of the SFP module. 

However, after changing the orientation of the gripper, the `wrench_offset` now has a force in both the z-axis and y-axis. This leads to the unintended effect of the robot "bouncing" whenever it tries to close in on the error. 
 
 A more sophisticated fix is required if we are to both compensate for the gravity of the SFP module and eliminate the "bouncing"