### PR TITLE
Pin ros2_control deps

### DIFF
--- a/aic.repos
+++ b/aic.repos
@@ -7,14 +7,6 @@ repositories:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
     version: 4.3.0
-  UniversalRobots/Universal_Robots_ROS2_Driver:
-    type: git
-    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
-    version: c1d3656bcaeb998636dad0b5577c2ea563499290
-  UniversalRobots/Universal_Robots_ROS2_GZ_Simulation:
-    type: git
-    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation.git
-    version: 2.5.0
   UniversalRobots/ur_msgs:
     type: git
     url: https://github.com/ros-industrial/ur_msgs.git
@@ -148,19 +140,31 @@ repositories:
     type: git
     url: https://github.com/gazebosim/sdformat
     version: 940be3dcf9e9a0a43ded60703985fa7ebed40980
-  ros-control/control_toolbox:
+  ros-controls/control_msgs:
+    type: git
+    url: https://github.com/ros-controls/control_msgs.git
+    version: 6.7.0
+  ros/joint_state_publisher:
+    type: git
+    url: https://github.com/ros/joint_state_publisher.git
+    version: 2.4.1
+  ros-controls/control_toolbox:
     type: git
     url: https://github.com/ros-controls/control_toolbox.git
     version: 5.8.3
-  ros-control/kinematics_interface:
+  ros-controls/kinematics_interface:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git
     version: 2.4.0
-  ros-control/ros2_controllers:
+  ros-controls/realtime_tools:
     type: git
-    url: https://github.com/ros-controls/ros2_controllers.git
-  ros-control/ros2_control:
+    url: https://github.com/ros-controls/realtime_tools.git
+    version: 4.7.1
+  ros-controls/ros2_control:
     type: git
     url: https://github.com/ros-controls/ros2_control.git
     version: 5.11.3
+  ros-controls/ros2_controllers:
+    type: git
+    url: https://github.com/ros-controls/ros2_controllers.git
     version: 5.12.0

--- a/aic_description/package.xml
+++ b/aic_description/package.xml
@@ -12,7 +12,6 @@
   <exec_depend>aic_assets</exec_depend>
   <exec_depend>aic_gazebo</exec_depend>
   <exec_depend>ur_description</exec_depend>
-  <exec_depend>ur_simulation_gz</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/aic_description/urdf/ur_gz.urdf.xacro
+++ b/aic_description/urdf/ur_gz.urdf.xacro
@@ -10,7 +10,6 @@
   <xacro:include filename="$(find aic_assets)/models/Basler Camera/basler_camera_macro.xacro"/>
   <xacro:include filename="$(find aic_assets)/models/Robotiq Hand-E/robotiq_hande_macro.xacro"/>
 
-  <!-- <xacro:include filename="$(find ur_simulation_gz)/urdf/ur_gz.ros2_control.xacro" /> -->
   <xacro:include filename="$(find ur_description)/urdf/inc/ur_joint_control.xacro" />
 
   <xacro:property name="D2R" value="${pi / 180.0}"/>


### PR DESCRIPTION
This PR adds all our `ros2_control` deps to aic.repos to build from source. I've also removed some unused UR sim packages that were pulling in moveit and and other ros2_control binaries. 

before rebuild purge binaries 

```
sudo apt purge ros-kilted-ros2-control*
sudo apt purge ros-kilted-control*
sudo apt purge ros-kilted-kinematics*
sudo apt purge ros-kilted-joint-state-publisher
sudo apt purge ros-kilted-realtime-tools
```