### PR TITLE
change frame from non-existent sfp_plug to sfp_tip

### DIFF
--- a/aic_model/test/create_and_cancel_task.py
+++ b/aic_model/test/create_and_cancel_task.py
@@ -78,7 +78,7 @@ class CreateAndCancelTaskNode(Node):
         goal_msg.task.cable_type = "sfp_sc"
         goal_msg.task.cable_name = "cable_0"
         goal_msg.task.plug_type = "sfp"
-        goal_msg.task.plug_name = "sfp_plug"
+        goal_msg.task.plug_name = "sfp_tip"
         goal_msg.task.port_type = "sfp"
         goal_msg.task.port_name = "sfp_port_0"
         goal_msg.task.target_module_name = "nic_card_mount_0"


### PR DESCRIPTION
This PR is a fix to the missing `sfp_plug_link` frame.

# Original Bug

Following [Example 2 in policy.md](https://github.com/intrinsic-dev/aic/blob/main/docs/policy.md#example-2-a-cheating-policy), I got the following error that the frame cable_0/sfp_plug_link does not exist:
```
[INFO] [1770885205.860919199] [aic_model]: Waiting for transform 'cable_0/sfp_plug_link' -> 'base_link'...
[INFO] [1770885206.856815509] [aic_model]: insert_cable execute loop
[INFO] [1770885207.857487018] [aic_model]: insert_cable execute loop
[ERROR] [1770885207.863241818] [aic_model]: Transform 'cable_0/sfp_plug_link' not available after 10.0s
[INFO] [1770885208.858939221] [aic_model]: insert_cable() returned False
```