### PR TITLE
Fix "bouncing" issue in aic_controller

### DIFF
--- a/aic_controller/src/aic_controller.cpp
+++ b/aic_controller/src/aic_controller.cpp
@@ -903,10 +903,10 @@ controller_interface::return_type Controller::update(
       // Transform target velocity from TCP frame into base frame
       Eigen::Matrix<double, 6, 1> new_tool_reference_base_frame;
       new_tool_reference_base_frame.head<3>() =
-          current_tool_state_.pose.rotation().inverse() *
+          current_tool_state_.pose.rotation() *
           new_tool_reference.velocity.head<3>();
       new_tool_reference_base_frame.tail<3>() =
-          current_tool_state_.pose.rotation().inverse() *
+          current_tool_state_.pose.rotation() *
           new_tool_reference.velocity.tail<3>();
 
       Eigen::Matrix<double, 6, 1> tool_vel_error =


### PR DESCRIPTION
Fixes issue #240 (For real!)

Turns out the damping term was the one that was causing the issue. Further inspection revealed that the reference velocity within the `aic_controller` was not transformed to the right frame. 
This PR fixes that by making sure that the reference velocity is transformed to be relative to the `base_link` (global) frame of the robot.

# Video demo

[fix_bouncing_issue.webm](https://github.com/user-attachments/assets/3919c02d-a8ae-4b07-a71c-95381c4424c6)
