### PR TITLE
Reset target if controller does not make progress towards target.

### DIFF
--- a/aic_bringup/config/aic_ros2_controllers.yaml
+++ b/aic_bringup/config/aic_ros2_controllers.yaml
@@ -355,6 +355,10 @@ aic_controller:
         - 3.14159 # y
         - 3.14159 # z
       max_rotational_velocity: 2.0 # [rad/s]
+      tracking_error:
+        timeout: 2.0 # [s]
+        min_angular_change: 0.01 #[rad]
+        min_translation_change: 0.01 #[m]
 
     control_frequency: 500.0 # [Hz]
 

--- a/aic_controller/include/aic_controller/aic_controller.hpp
+++ b/aic_controller/include/aic_controller/aic_controller.hpp
@@ -322,6 +322,9 @@ class Controller : public controller_interface::ControllerInterface {
   double time_to_target_seconds_;
   double remaining_time_to_target_seconds_;
 
+  // Time since last non-negligible change in error
+  rclcpp::Time last_error_change_time_;
+
   std::shared_ptr<
       pluginlib::ClassLoader<kinematics_interface::KinematicsInterface>>
       kinematics_loader_;

--- a/aic_controller/src/aic_controller.cpp
+++ b/aic_controller/src/aic_controller.cpp
@@ -41,6 +41,7 @@ Controller::Controller()
       last_tool_pose_error_(Eigen::Matrix<double, 6, 1>::Zero()),
       time_to_target_seconds_(0.0),
       remaining_time_to_target_seconds_(0.0),
+      last_error_change_time_(0, 0, RCL_ROS_TIME),
       kinematics_loader_(nullptr),
       kinematics_(nullptr),
       force_torque_sensor_(nullptr) {
@@ -898,6 +899,40 @@ controller_interface::return_type Controller::update(
                      "target tool frame");
         return controller_interface::return_type::ERROR;
       }
+
+      // If there is no change in the error for a given timeout duration,
+      // the controller is not making progress towards the target so we reset
+      // the target to the current position and wait for the next MotionUpdate.
+      rclcpp::Time current_time = get_node()->get_clock()->now();
+      auto abs_change_in_error =
+          (tool_pose_error - last_tool_pose_error_).cwiseAbs();
+
+      if (motion_update_received_ &&
+          tool_pose_error.cwiseAbs().maxCoeff() > 1e-2 &&
+          abs_change_in_error.head<3>().maxCoeff() <
+              params_.clamp_to_limits.tracking_error.min_translation_change &&
+          abs_change_in_error.tail<3>().maxCoeff() <
+              params_.clamp_to_limits.tracking_error.min_angular_change) {
+        rclcpp::Duration time_since_last_error_change =
+            current_time - last_error_change_time_;
+        if (time_since_last_error_change.seconds() >
+            params_.clamp_to_limits.tracking_error.timeout) {
+          RCLCPP_ERROR(get_node()->get_logger(),
+                       "Tracking error is not converging! Resetting "
+                       "target to current position.");
+          // Reset target state to current tool position
+          new_tool_reference = current_tool_state_;
+
+          last_error_change_time_ = current_time;
+          // Reset motion update to prevent reading from it until the next
+          // received message
+          target_state_ = std::nullopt;
+          motion_update_received_ = false;
+        }
+      } else {
+        last_error_change_time_ = current_time;
+      }
+
       last_tool_pose_error_ = tool_pose_error;
 
       // Transform target velocity from TCP frame into base frame

--- a/aic_controller/src/aic_controller_parameters.yaml
+++ b/aic_controller/src/aic_controller_parameters.yaml
@@ -108,6 +108,22 @@ aic_controller:
       default_value: 0.0,
       description: "Maximum rotational velocity in rad/s"
     }
+    tracking_error:
+      timeout: {
+        type: double,
+        default_value: 0.0,
+        description: "If there is no change in the error after the timeout duration, the tracking error will be clamped to their max values."
+      }
+      min_angular_change: {
+        type: double,
+        default_value: 0.0,
+        description: "Mininimum change in angular error such that the robot is moving towards the target. Units in radians"
+      }
+      min_translation_change: {
+        type: double,
+        default_value: 0.0,
+        description: "Minimum change in translation error such that the robot is moving towards the target. Units in meters"
+      }
 
   # Cartesian impedance controller parameters
   impedance:
@@ -235,7 +251,6 @@ aic_controller:
           fixed_size<>: 6
         }
       }
-
     default_values:
       control_stiffness: {
         type: double_array,


### PR DESCRIPTION
This PR adds the logic within `aic_controller` to reset the controller target if there is a significant error that is not reduced over a `timeout` duration.

# Video demo

I sent a velocity target of `- 0.25 m/s` in the z-axis and there is a timeout duration of 1.0s where if the error does not change significantly then the target is reset to the robot current position. 
And then, the controller simply awaits the next target.

The top plot is the tracking error. The bottom plot is the reference z position.

[Reset target if timeout on error reduction.webm](https://github.com/user-attachments/assets/b32b9d4e-23ab-4a36-b265-dbbaf07aaf73)

