### PR TITLE
Add parameter for minimum error to trigger reset

### DIFF
--- a/aic_bringup/config/aic_ros2_controllers.yaml
+++ b/aic_bringup/config/aic_ros2_controllers.yaml
@@ -359,6 +359,7 @@ aic_controller:
         timeout: 2.0 # [s]
         min_angular_change: 0.01 #[rad]
         min_translation_change: 0.01 #[m]
+        min_translation_error: 0.2 #[m] make sure it's larger than min_translation_change to avoid instability
 
     control_frequency: 500.0 # [Hz]
 

--- a/aic_controller/src/aic_controller.cpp
+++ b/aic_controller/src/aic_controller.cpp
@@ -908,7 +908,8 @@ controller_interface::return_type Controller::update(
           (tool_pose_error - last_tool_pose_error_).cwiseAbs();
 
       if (motion_update_received_ &&
-          tool_pose_error.cwiseAbs().maxCoeff() > 1e-2 &&
+          tool_pose_error.cwiseAbs().maxCoeff() >
+              params_.clamp_to_limits.tracking_error.min_translation_error &&
           abs_change_in_error.head<3>().maxCoeff() <
               params_.clamp_to_limits.tracking_error.min_translation_change &&
           abs_change_in_error.tail<3>().maxCoeff() <

--- a/aic_controller/src/aic_controller_parameters.yaml
+++ b/aic_controller/src/aic_controller_parameters.yaml
@@ -124,6 +124,11 @@ aic_controller:
         default_value: 0.0,
         description: "Minimum change in translation error such that the robot is moving towards the target. Units in meters"
       }
+      min_translation_error: {
+        type: double,
+        default_value: 0.2,
+        description: "Minimum translation error to trigger clamping. Make sure it is larger than min_translation_change to avoid instability. Units in meters"
+      }
 
   # Cartesian impedance controller parameters
   impedance:


### PR DESCRIPTION
Previously, we would trigger position target reset when:

* The error is above 0.01 m (hardcoded).
* At least `timeout = 2s` has past.
* The error has not gone down by more than `min_translation_change = 0.01m`.

This created an odd corner case, where if the set point set by the user was just a tiny bit past 0.01m we would basically always reset the controller because the condition would require the error to decrease by at least 0.01m and essentially be 0.
This created oscillations in the CheatCode example as shown below:

https://github.com/user-attachments/assets/4a380ae0-d665-4303-b333-2128ed3d235b

I just added a parameter for the minimum error to trigger this behavior and made it at least one order of magnitude larger than the error change we want to see to trigger resetting.

CC @grkw since the original PR was to address some issues you had with teleop