### PR TITLE
Fix velocity target in different frames

### DIFF
--- a/aic_controller/src/aic_controller.cpp
+++ b/aic_controller/src/aic_controller.cpp
@@ -768,13 +768,14 @@ controller_interface::return_type Controller::update(
             if (!target_state_.has_value() ||
                 target_state_.value().header.stamp !=
                     latest_target_state.header.stamp) {
-              // transform target pose from "gripper/tcp" frame to "base_link"
-              // frame
+              // Pose targets are processed in the "base_link" frame.
+              // Therefore, if the frame_id is "gripper/tcp", then we transform
+              // the pose target to the "base_link" frame
               latest_target_state.pose.linear() =
-                  current_tool_state_.pose.linear().inverse() *
+                  current_tool_state_.pose.linear() *
                   latest_target_state.pose.linear();
               latest_target_state.pose.translation() =
-                  current_tool_state_.pose.linear().inverse() *
+                  current_tool_state_.pose.linear() *
                       latest_target_state.pose.translation() +
                   current_tool_state_.pose.translation();
 


### PR DESCRIPTION
This PR fixes issue #281.

The fix is to ensure that the pose and velocity targets are converted to the right frames **during target interpolation** and **computing the tracking error**.

**During target interpolation,** the pose targets are expected to be in global `"base_link"` frame and the velocity targets are expected to be in `"gripper/tcp"` frame. 
  - For velocity targets, they are used to integrate the TCP pose so they transformed relative to the `"gripper/tcp"` frame.

**When computing the tracking error,** both the pose and velocity targets are expected to be in the global `"base_link"` frame. 
  - This is because the current TCP pose and velocity are obtained in the `"base_link"` frame.
 
 I think it's unclear what frames the targets are in so it is best to have a follow-up PR where I add `frame_id` data to the `CartesianTarget` data struct.  
 