### PR TITLE
Update NIC card mount collision

### DIFF
--- a/aic_assets/models/NIC Card Mount/model.sdf
+++ b/aic_assets/models/NIC Card Mount/model.sdf
@@ -19,10 +19,10 @@
         </geometry>
       </collision>
       <collision name="v1015085006_collider_box.001">
-        <pose>-0.048402 -0.0155 0.172 0.0 0.0 1.570796</pose>
+        <pose>-0.0555 -0.0155 0.172 0.0 0.0 1.570796</pose>
         <geometry>
           <box>
-            <size>0.025 0.036192 0.014</size>
+            <size>0.025 0.0215 0.014</size>
           </box>
         </geometry>
       </collision>
@@ -43,10 +43,18 @@
         </geometry>
       </collision>
       <collision name="v1015085006_collider_box004_collider_box">
-        <pose>-0.045132 -0.025499 0.147803 0.0 0.0 1.570796</pose>
+        <pose>-0.042132 -0.025499 0.151803 0.785 0.0 1.570796</pose>
         <geometry>
           <box>
-            <size>0.005001 0.036343 0.034395</size>
+            <size>0.005001 0.0515 0.015</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="v1015085006_collider_box.005">
+        <pose>-0.043 -0.0198 0.1665 0.78 0.0 1.570796</pose>
+        <geometry>
+          <box>
+            <size>0.016 0.02 0.015</size>
           </box>
         </geometry>
       </collision>


### PR DESCRIPTION
Resolves #278 

Tweaked collisions on the NIC Card Mount to better match the visual. Still not perfect but an improvement.

See original collision geometry in #278 

Here's a screenshot of the updated collision geom:

<img width="403" height="342" alt="Screenshot 2026-02-13 at 2 07 16 PM" src="https://github.com/user-attachments/assets/8bdcae0c-1f4f-4454-8411-ae255ef22b21" />
