### PR TITLE
Update insertion frame link name, inertial values, and orientation

### DIFF
--- a/aic_assets/models/SC Plug/model.sdf
+++ b/aic_assets/models/SC Plug/model.sdf
@@ -90,13 +90,21 @@
       </collision>
     </link>
 
-    <link name="sc_plug_tip_link">
-      <pose>0.01165 0 0 0 1.5708 0</pose>
+    <link name="sc_tip_link">
+      <pose>0.01165 0 0 -1.5708 0 -1.5708</pose>
+      <inertial>
+        <mass>1e-3</mass>
+        <inertia>
+          <ixx>1e-6</ixx>
+          <iyy>1e-6</iyy>
+          <izz>1e-6</izz>
+        </inertia>
+      </inertial>
     </link>
 
-    <joint name="sc_plug_tip_joint" type="fixed">
+    <joint name="sc_tip_joint" type="fixed">
       <parent>sc_plug_link</parent>
-      <child>sc_plug_tip_link</child>
+      <child>sc_tip_link</child>
     </joint>
 
   </model>

--- a/aic_assets/models/SC Port/model.sdf
+++ b/aic_assets/models/SC Port/model.sdf
@@ -144,15 +144,15 @@
       </sensor>
 
     </link>
-    
+
     <link name="sc_port_base_link">
-      <pose>0 -0.002 0 1.5708 0 0</pose>
+      <pose>0 -0.002 0 1.5708 3.14159 0</pose>
     </link>
 
     <joint name="sc_port_base_joint" type="fixed">
       <parent>sc_port_link</parent>
       <child>sc_port_base_link</child>
     </joint>
-    
+
   </model>
 </sdf>

--- a/aic_assets/models/SC Port/sc_port_macro.xacro
+++ b/aic_assets/models/SC Port/sc_port_macro.xacro
@@ -12,7 +12,7 @@
           name="gz::sim::systems::TouchPlugin">
           <target>sc_plug</target>
           <time>1</time>
-          <namespace>${prefix}/sc_port</namespace>
+          <namespace>${prefix}/sc_port_base</namespace>
           <enabled>true</enabled>
         </plugin>
       </include>

--- a/aic_description/urdf/cable.sdf.xacro
+++ b/aic_description/urdf/cable.sdf.xacro
@@ -15,7 +15,7 @@
   </xacro:if>
   <xacro:if value="${cable_type == 'sfp_sc_cable_reversed'}">
     <xacro:property name="cable_connection_0_link" value="sc_plug_link" />
-    <xacro:property name="cable_connection_0_port" value="sc_port" />
+    <xacro:property name="cable_connection_0_port" value="sc_port_base" />
     <xacro:property name="cable_connection_1_link" value="lc_plug_link" />
   </xacro:if>
 

--- a/aic_engine/config/sample_config.yaml
+++ b/aic_engine/config/sample_config.yaml
@@ -319,9 +319,9 @@ trials:
         cable_type: "sfp_sc"
         cable_name: "cable_1"
         plug_type: "sc"
-        plug_name:  "sc_plug"
+        plug_name:  "sc_tip"
         port_type: "sc"
-        port_name: "sc_port"
+        port_name: "sc_port_base"
         target_module_name: "sc_port_1"
         time_limit: 300
 robot:


### PR DESCRIPTION
Targets #293 

Changes:
* Changed `sc_plug_tip_link` to `sc_tip_link` to be consistent with `sfp_tip_link`
* Set neglible mass and inertial values to the tip link on the plug so that it does not affect the arm controller
* Updated the frame pose values so SC plug and port axes are aligned - necessary for running CheatCode

After these changes I was able to get CheatCode to move the SC plug close to the port with the correct orientation. It was not able to plug it in yet but that should be addressed separately.

For testing, I'm launching sim with `sfp_sc_cable_reversed` cable at a slightly different `cable_z` height:

```
ros2 launch aic_bringup aic_gz_bringup.launch.py nic_card_mount_0_present:=false sc_port_0_present:=true ground_truth:=true spawn_task_board:=true spawn_cable:=true attach_cable_to_gripper:=true sfp_mount_rail_0_present:=true launch_rviz:=false cable_type:=sfp_sc_cable_reversed cable_z:=1.508
```

Run CheatCode

```
ros2 run aic_model aic_model --ros-args -p policy:=aic_example_policies.ros.CheatCode
```


Apply the following changes to `create_and_cancel_task.py` to create a goal with the SC plug and port, and run it:

<details><summary>create_and_cancel_task.diff</summary>

```diff
diff --git a/aic_model/test/create_and_cancel_task.py b/aic_model/test/create_and_cancel_task.py
index 7cde1e4..80ae065 100755
--- a/aic_model/test/create_and_cancel_task.py
+++ b/aic_model/test/create_and_cancel_task.py
@@ -77,11 +77,16 @@ class CreateAndCancelTaskNode(Node):
         goal_msg.task.id = "test_task"
         goal_msg.task.cable_type = "sfp_sc"
         goal_msg.task.cable_name = "cable_0"
-        goal_msg.task.plug_type = "sfp"
-        goal_msg.task.plug_name = "sfp_tip"
-        goal_msg.task.port_type = "sfp"
-        goal_msg.task.port_name = "sfp_port_0"
-        goal_msg.task.target_module_name = "nic_card_mount_0"
+        # goal_msg.task.plug_type = "sfp"
+        # goal_msg.task.plug_name = "sfp_tip"
+        # goal_msg.task.port_type = "sfp"
+        # goal_msg.task.port_name = "sfp_port_0"
+        # goal_msg.task.target_module_name = "nic_card_mount_0"
+        goal_msg.task.plug_type = "sc"
+        goal_msg.task.plug_name = "sc_tip"
+        goal_msg.task.port_type = "sc"
+        goal_msg.task.port_name = "sc_port_base"
+        goal_msg.task.target_module_name = "sc_port_0"
         goal_msg.task.time_limit = 300
         self.get_logger().info("Sending goal request...")
```
</details>

```
src/aic/aic_model/test/create_and_cancel_task.py
```

Here's the result so far. The plug moves close to the port but never quite get there. I played around with `z_offset` but haven't succeeded inserting it in yet.


<img width="523" height="585" alt="Screenshot 2026-02-13 at 3 51 38 PM" src="https://github.com/user-attachments/assets/062a7ec4-17b9-4f81-a6cb-facd757091ce" />
