### PR TITLE
Fully qualify the base image URL to support Podman/OCI-compliant builders

### DIFF
--- a/docker/aic_model/Dockerfile
+++ b/docker/aic_model/Dockerfile
@@ -1,4 +1,4 @@
-FROM ros:kilted-ros-core AS build
+FROM docker.io/library/ros:kilted-ros-core AS build
 
 # Install pixi
 RUN apt update && apt install -y git && curl -fsSL https://pixi.sh/install.sh | bash


### PR DESCRIPTION
This prevents "unqualified-search" errors on systems where Docker Hub isn't the only configured registry. e.g I am using Podman and the existing url fails.