### PR TITLE
Add tf2_ros dependency to package.xml and update pixi.toml for tf2-ros-py

### DIFF
--- a/aic_model/package.xml
+++ b/aic_model/package.xml
@@ -16,8 +16,8 @@
   <depend>rclpy</depend>
   <depend>sensor_msgs</depend>
   <depend>std_srvs</depend>
-  <depend>trajectory_msgs</depend>
   <depend>tf2_ros</depend>
+  <depend>trajectory_msgs</depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/pixi.lock
+++ b/pixi.lock
@@ -4977,8 +4977,8 @@ packages:
   - ros-kilted-rclpy
   - ros-kilted-sensor-msgs
   - ros-kilted-std-srvs
-  - ros-kilted-trajectory-msgs
   - ros-kilted-tf2-ros
+  - ros-kilted-trajectory-msgs
   - ros2-distro-mutex
   - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - libgcc >=15

--- a/pixi.toml
+++ b/pixi.toml
@@ -26,9 +26,9 @@ ros-kilted-rclpy = "*"
 ros-kilted-ros-core = "*"
 ros-kilted-sensor-msgs = "*"                                                           # lerobot_robot_ros
 ros-kilted-std-msgs = "*"                                                              # lerobot_robot_ros
-ros-kilted-std-srvs = "*"                                                              # lerobot_robot_ros
+ros-kilted-std-srvs = "*"
+ros-kilted-tf2-ros-py = "*"
 setuptools = ">=71.0.0,<81.0.0"                                                        # required by lerobot==0.4.3
-ros-kilted-tf2-ros-py = ">=0.41.6,<0.42"
 
 [pypi-dependencies]
 lerobot = "==0.4.3"


### PR DESCRIPTION
After pulling the latest changes from main, I can't launch the WaveArm policy. 
The `pixi run ros2 run aic_model aic_model --ros-args -p policy:=aic_example_policies.ros.WaveArm` command fails because the tf2_ros library is missing from the environment.

<img width="476" height="96" alt="image" src="https://github.com/user-attachments/assets/55d92578-1aa0-4748-80c1-c597221f28ed" />

It was solved adding the library with `pixi add ros-kilted-tf2-ros-py` (added too to the package.xml).

I don't know why it wasn't failing before, but aic_model is using tf2_ros and it is not listed as a dependency.

@JCarosella for awareness