### PR TITLE
Update Docker Compose File

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
     networks:
       - default
   model:
-    image: localhost/aic/aic_model
+    image: my-solution:v1
     build:
       dockerfile: docker/aic_model/Dockerfile
       context: ..


### PR DESCRIPTION
- Fix the entrypoint script name in the evaluation service docker-compose (`entrypoint.sh` instead of `entrypoint_eval.sh`).

- Update the model service image name in docker-compose to match the [documentation](https://github.com/intrinsic-dev/aic/blob/main/docs/submission.md#build-the-image)

Notes: The images build successfully and the services start correctly. However, the model service will still crash due to the issue described in PR #312 

@JCarosella for awareness