### PR TITLE
Swap the symbolic text for the numeric one for compatability with podman compose

### DIFF
--- a/docker/aic_eval/Dockerfile
+++ b/docker/aic_eval/Dockerfile
@@ -7,7 +7,7 @@ RUN curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyri
 # Install dependencies
 RUN mkdir -p /ws_aic/src/aic
 COPY --chmod=644 aic.repos /ws_aic/src/aic/
-COPY --chmod=u=rwX,go=rX --parents **/package.xml /ws_aic/src/aic
+COPY --chmod=755 --parents **/package.xml /ws_aic/src/aic
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
   apt update && apt upgrade -y && \
   # undeclared deps


### PR DESCRIPTION
The current state yields an error `Error parsing chmod u=rwX,go=rX`,  happens because Podman's builder is stricter about the --chmod flag in the COPY command than the standard Docker engine. It doesn't recognize the symbolic notation (u=rwX...) in this specific context.
Updating this to have numeric representation.