### PR TITLE
Don't give points for non completed tasks

### DIFF
--- a/aic_scoring/include/aic_scoring/ScoringTier2.hh
+++ b/aic_scoring/include/aic_scoring/ScoringTier2.hh
@@ -254,8 +254,10 @@ namespace aic_scoring
     private: void ControllerStateCallback(const ControllerStateMsg& _msg);
 
     /// \brief Calculates score related with the gripper trajectory jerk.
+    /// \param[in] _tier3 The result of tier3 scoring.
     /// \return Scoring for the trajectory jerk score.
-    private: Tier2Score::CategoryScore GetTrajectoryJerkScore() const;
+    private: Tier2Score::CategoryScore GetTrajectoryJerkScore(
+       const Tier3Score &_tier3) const;
 
     /// \brief Calculates score for trajectory efficiency (path length).
     /// \param[in] _minPathLength Minimum path length for max score (meters).
@@ -263,7 +265,8 @@ namespace aic_scoring
     /// \param[in] _tier3 The result of tier3 scoring.
     /// \return Scoring for the trajectory efficiency category.
     private: Tier2Score::CategoryScore GetTrajectoryEfficiencyScore(
-        double _minPathLength) const;
+        double _minPathLength,
+        const Tier3Score &_tier3) const;
 
     /// \brief Gets the transform for the specified entity at the requested time.
     /// \param[in] _t the time point to get the transform.

--- a/aic_scoring/src/ScoringTier2.cc
+++ b/aic_scoring/src/ScoringTier2.cc
@@ -253,8 +253,6 @@ std::pair<Tier2Score, Tier3Score> ScoringTier2::ComputeScore() {
   this->TfStaticCallback(msg);
 
   this->state = State::Idle;
-  tier2_score.add_category_score("trajectory smoothness",
-                                 this->GetTrajectoryJerkScore());
   // Compute initial plug-port distance for trajectory efficiency scoring.
   // The robot must travel at least this distance, so it becomes the minimum
   // path length for a perfect score.
@@ -272,12 +270,14 @@ std::pair<Tier2Score, Tier3Score> ScoringTier2::ComputeScore() {
   tier2_score.add_category_score("insertion force",
                                  this->GetInsertionForceScore());
   tier2_score.add_category_score("contacts", this->GetContactsScore());
-  tier2_score.add_category_score(
-      "trajectory efficiency",
-      this->GetTrajectoryEfficiencyScore(minPathLength));
   tier3_score = this->ComputeTier3Score();
   tier2_score.add_category_score("duration",
                                  this->GetTaskDurationScore(tier3_score));
+  tier2_score.add_category_score("trajectory smoothness",
+                                 this->GetTrajectoryJerkScore(tier3_score));
+  tier2_score.add_category_score(
+      "trajectory efficiency",
+      this->GetTrajectoryEfficiencyScore(minPathLength, tier3_score));
   return {tier2_score, tier3_score};
 }
 
@@ -516,13 +516,25 @@ static double CalculateInverseProportionalScore(const double max_score,
 }
 
 //////////////////////////////////////////////////
-Tier2Score::CategoryScore ScoringTier2::GetTrajectoryJerkScore() const {
+Tier2Score::CategoryScore ScoringTier2::GetTrajectoryJerkScore(
+    const Tier3Score &_tier3) const {
   using CategoryScore = Tier2Score::CategoryScore;
 
   const double kMaxJerkScore = 5.0;
   const double kMinJerkScore = 0.0;
   const double kMaxJerkValue = 25000.0;
   const double kMinJerkValue = 0.0;
+
+  if (!this->task_end_time.has_value()) {
+    return CategoryScore(0, "Task not completed.");
+  }
+
+  if (_tier3.total_score() <= 0) {
+    return CategoryScore(
+        0,
+        "Plug is not within max bounding radius from target port, "
+        "not assigning jerk bonus");
+  }
 
   // Debug output
   // std::cout << "(" << _tf.transform.translation.x << " " <<
@@ -636,8 +648,19 @@ Tier2Score::CategoryScore ScoringTier2::GetTrajectoryJerkScore() const {
 
 //////////////////////////////////////////////////
 Tier2Score::CategoryScore ScoringTier2::GetTrajectoryEfficiencyScore(
-    double _minPathLength) const {
+    double _minPathLength, const Tier3Score &_tier3) const {
   using CategoryScore = Tier2Score::CategoryScore;
+
+  if (!this->task_end_time.has_value()) {
+    return CategoryScore(0, "Task not completed.");
+  }
+
+  if (_tier3.total_score() <= 0) {
+    return CategoryScore(
+        0,
+        "Plug is not within max bounding radius from target port, "
+        "not assigning efficiency bonus");
+  }
 
   double totalPathLength = 0.0;
   for (std::size_t i = 1; i < this->endEffectorPoses.size(); ++i) {
@@ -705,7 +728,7 @@ Tier3Score ScoringTier2::GetDistanceScore() const {
   const double kEntranceXYTol = 0.005;
 
   if (!this->task_end_time.has_value()) {
-    return Tier3Score(0, "Time computation failed, task end time not set");
+    return Tier3Score(0, "Task not completed.");
   }
 
   const auto end_time =
@@ -782,6 +805,10 @@ Tier3Score ScoringTier2::ComputeTier3Score() const {
   // in GetDistanceScore (and up to kMaxInsertionScore)
   constexpr double kInsertionCompletionScore = 60.0;
   constexpr double kInsertionPenalty = -10.0;
+
+  if (!this->task_end_time.has_value()) {
+    return Tier3Score(0, "Task not completed.");
+  }
 
   // Check if insertion is completed or not
   std::stringstream sstream;
@@ -922,7 +949,7 @@ Tier2Score::CategoryScore ScoringTier2::GetTaskDurationScore(
   }
 
   if (!this->task_end_time.has_value()) {
-    return CategoryScore(0, "Time computation failed, task end time not set");
+    return CategoryScore(0, "Task not completed.");
   }
 
   const rclcpp::Duration task_duration =


### PR DESCRIPTION
As noted in https://github.com/intrinsic-dev/aic/pull/307#discussion_r2838845943, this PR makes sure we don't give points to users that don't perform the task.

Bonuses for trajectory efficiency, jerk and task time are all "gated" on getting at least within the bounding box of the port. Users that don't even get in the vicinity of the port will get 0 points to make sure that naive solution of immediately returning success don't score a lot of points.

I also made sure that failing a task (which happens when users explicitly report "failure" in their action goal callback) doesn't assign any points to these bonuses.