### PR TITLE
Improve scoring performance by caching effector poses

### DIFF
--- a/aic_scoring/include/aic_scoring/ScoringTier2.hh
+++ b/aic_scoring/include/aic_scoring/ScoringTier2.hh
@@ -341,7 +341,7 @@ namespace aic_scoring
     /// and force
     private: std::vector<std::pair<double, Vector3Msg>> wrenches;
 
-    /// \brief End effector poses, pair is timestamp and translation
+    /// \brief End effector pose tf messages.
     private: std::vector<TransformStampedMsg> endEffectorPoses;
 
     /// \brief Non empty contact messages received from the simulator.

--- a/aic_scoring/src/ScoringTier2.cc
+++ b/aic_scoring/src/ScoringTier2.cc
@@ -391,7 +391,7 @@ void ScoringTier2::TfCallback(const TFMsg &_msg) {
   if (end_effector_pose.has_value()) {
     // It seems we can receive multiple different poses with the same timestamp
     // TODO(luca) consider throttling the robot state publisher
-    if (this->endEffectorPoses.size() > 0 &&
+    if (!this->endEffectorPoses.empty() &&
         this->endEffectorPoses.back().header.stamp ==
             end_effector_pose.value().header.stamp) {
       return;
@@ -611,6 +611,13 @@ Tier2Score::CategoryScore ScoringTier2::GetTrajectoryJerkScore() const {
       totalJerkTime += dt;
       accumLinearJerkMagnitude += jerkMag * dt;
     }
+  }
+
+  if (std::abs(totalJerkTime) < 1e-6) {
+    const std::string msg =
+        "Error computing jerk. Insufficient end-effector pose samples.";
+    RCLCPP_ERROR(this->node->get_logger(), msg.c_str());
+    return CategoryScore(0.0, msg);
   }
 
   double jerk = accumLinearJerkMagnitude / totalJerkTime;


### PR DESCRIPTION
"Fixes" https://github.com/intrinsic-dev/aic/issues/325

I quote fixes because it doesn't add any informing to users that the score is being calculated, but rather it dramatically increases performance so that it is not necessary anymore.
Previously on my machine scoring could take up to a few minutes, now it takes a few seconds.

Also, am I seeing a negative diff? Yes I am!

### So what happened?

We used to store timestamps for the TF lookups then iterate through them to find the state of the gripper at different points in time.
The issue is that TF lookup in the past is a fairly expensive operation, while if we just want to get the latest state of a transform it is _a lot_ faster. I'll spare you the call stack but (I believe) the root cause is [this shortcutting](https://github.com/ros2/geometry2/blob/2d8d19dc1a6341780f6a750b80e59384b133e99e/tf2/src/buffer_core.cpp#L345-L351) in the library that makes a 200+ LOC iterative graph traversal return immediately.
I changed the approach instead to cache the _end effector pose_ at each transform message. It should be pretty much the same thing, but a lot faster. 

### Why all this diff

I refactored the score computation functions to just be contained in a single function rather than two different functions that modify shared state. This made a lot of class variables unnecessary, together with their cleanup and bookkeeping.

### What's next

After discussions with @JohnTGZ I found out the `aic_controller` actually [publishes](https://github.com/intrinsic-dev/aic/blob/bc17cee8a5f25fcd92b622dce784f03a49b1fe1d/aic_interfaces/aic_control_interfaces/msg/ControllerState.msg#L8-L9) gripper/tcp velocity. We should see if changing our triple derive of position into a double derive of velocity and see if that improves jerk calculation.Z