### PR TITLE
Tare force torque sensor upon controller activation

### DIFF
--- a/aic_bringup/launch/aic_gz_bringup.launch.py
+++ b/aic_bringup/launch/aic_gz_bringup.launch.py
@@ -209,26 +209,6 @@ def launch_setup(context, *args, **kwargs):
         condition=UnlessCondition(activate_joint_controller),
     )
 
-    tare_fts_service = ExecuteProcess(
-        cmd=[
-            "ros2",
-            "service",
-            "call",
-            "/aic_controller/tare_force_torque_sensor",
-            "std_srvs/srv/Trigger",
-            "{}",
-        ],
-        output="screen",
-    )
-
-    # Tare the force torque sensor upon controller activation
-    tare_fts_on_controller_activate = RegisterEventHandler(
-        OnProcessExit(
-            target_action=initial_joint_controller_spawner_started,
-            on_exit=[tare_fts_service],
-        )
-    )
-
     fts_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
@@ -426,7 +406,6 @@ def launch_setup(context, *args, **kwargs):
         delay_rviz_after_joint_state_broadcaster_spawner,
         initial_joint_controller_spawner_stopped,
         initial_joint_controller_spawner_started,
-        tare_fts_on_controller_activate,
         fts_broadcaster_spawner,
         aic_adapter,
         gz_ip_env,

--- a/docs/aic_controller.md
+++ b/docs/aic_controller.md
@@ -89,12 +89,12 @@ The controller publishes real-time data to `/aic_controller/controller_state` ([
 
 The controller provides a service to tare (zero) the force-torque sensor at `/aic_controller/tare_ft_sensor`. This service resets the current force/torque readings to zero, which is useful for calibrating the sensor or removing sensor bias. The tared offset is published in the [`ControllerState`](../aic_interfaces/aic_control_interfaces/msg/ControllerState.msg) message as `fts_tare_offset`.
 
+> **Note:** Before the start of each training episode (i.e. before teleoperation or spawning cables in the environment), it is important to tare the Force/Torque Sensor (F/T Sensor) for accurate force-torque feedback.
+
 ```bash
 # Tare the FT sensor
 ros2 service call /aic_controller/tare_ft_sensor std_srvs/srv/Trigger
 ```
-
-Before the start of each training episode, it is important to tare the  Force/Torque Sensor (F/T Sensor). This is already done on controller activation within the `tare_fts_on_controller_activate` event in the [aic_gz_bringup.launch.py](../aic_bringup/launch/aic_gz_bringup.launch.py) bringup.
 
 > **Important:** This service will **not be available** during the evaluation. The force-torque sensor readings are used for scoring, and participants cannot tare the sensor during competition runs.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -93,7 +93,7 @@
 - A snapshot of the robot's sensory environment (aic_model_interfaces/msg/Observation) including camera images, joint states, force measurements, and transform frames.
 
 **Force/Torque Sensor (F/T Sensor)**
-- Measures forces and torques applied during manipulation. Data published to `/axia80_m20/wrench` topic, enabling sensitive force feedback control.
+- Measures forces and torques applied during manipulation. Data published to `/axia80_m20/wrench` topic, enabling sensitive force feedback control. The F/T sensor is typically tared before each training episode, see [Taring before Training](../docs/scene_description.md#Taring-before-training) for more details.
 
 **Wrist Cameras**
 - Three RGB cameras mounted on the robot's wrist:

--- a/docs/scene_description.md
+++ b/docs/scene_description.md
@@ -123,9 +123,9 @@ To manually control the robot and get familiar with the environment:
 
 Before teleoperating, we recommend reading the [AIC Controller Guide](./aic_controller.md) to understand the controller used in the challenge.
 
-When using teleoperation to collect training data, ensure that the Force/Torque Sensor (F/T Sensor) is tared at the start of each training episode. This is already done upon controller activation via the `tare_fts_on_controller_activate` event in the [aic_gz_bringup.launch.py](../aic_bringup/launch/aic_gz_bringup.launch.py) bringup.
-
 See the [Robot Teleoperation Guide](../aic_utils/aic_teleoperation/README.md) for detailed instructions.
+
+When using teleoperation to collect training data, be sure to tare the Force/Torque sensors at the start of each training episode. See [Taring before Training](#Taring-before-training).
 
 > [!TIP]
 > If the robot can't seem to move when it's near an object, it might be in collision with that object even though it's not touching. To view the collision mesh for an object, right-click on it, click `View >`, and then `Collisions`.
@@ -146,6 +146,15 @@ The simulation includes a world plugin that automatically exports the complete w
 - **Plugin Configuration:** Defined in [`aic.sdf`](../aic_description/world/aic.sdf) with parameters:
   - `<save_world_path>`: Path where the world file is saved (default: `/tmp/aic.sdf`)
   - `<save_world_delay_s>`: Delay in simulation seconds before exporting (default: `0.0`)
+
+---
+
+## Taring before Training
+
+At the start of each training episode (i.e. before teleoperation and before spawning any cables in the environment), ensure that the Force/Torque Sensor (F/T Sensor) is tared using the following service call:
+```bash
+ros2 service call /aic_controller/tare_ft_sensor std_srvs/srv/Trigger
+```
 
 ---
 


### PR DESCRIPTION
# Overview
This PR adds taring of F/T sensor upon controller activation, so participants do not have to call it manually. 

Note: taring it again from `aic_engine` should pose no problems.
