### PR TITLE
Reduce width of sc plug collision mesh from 0.009 to 0.0086

### DIFF
--- a/aic_assets/models/SC Plug/model.sdf
+++ b/aic_assets/models/SC Plug/model.sdf
@@ -16,7 +16,7 @@
         <pose>0.002539 0.006344 4e-06 0.0 0.0 0.0</pose>
         <geometry>
           <box>
-            <size>0.013722 0.0086 0.0073</size>
+            <size>0.013722 0.0087 0.0073</size>
           </box>
         </geometry>
       </collision>
@@ -24,7 +24,7 @@
         <pose>0.002539 -0.006344 4e-06 0.0 0.0 0.0</pose>
         <geometry>
           <box>
-            <size>0.013722 0.0086 0.0073</size>
+            <size>0.013722 0.0087 0.0073</size>
           </box>
         </geometry>
       </collision>


### PR DESCRIPTION
This PR makes a small change of reducing the width of the SC plug's collision mesh from `0.009` (or 9mm ) to  `0.0087` (or 8.7mm). This change increases the success rate of the `cheatcode` policy in trial 3, however if the controller is unable to close in on the y error, then it could still lead to situations such as the diagram shown below:

<img width="715" height="679" alt="image" src="https://github.com/user-attachments/assets/ee6312b1-8b2a-4f3f-a0cf-f4af6bb6919b" />

It was also noticed before this PR that the collision width was slightly larger than the visual mesh.