### PR TITLE
Clarify support channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ Manages trial execution, validates participant models, and collects scoring data
 
 ## Support and Resources
 
-- **Issues**: Report bugs or request features via [GitHub Issues](https://github.com/intrinsic-dev/aic/issues).
-- **Discussions**: Join the community at [Open Robotics Discourse](https://discourse.openrobotics.org/c/competitions/ai-for-industry-challenge/).
+- **Discussions**: Engage in conversations and ask questions about the challenge on [Open Robotics Discourse](https://discourse.openrobotics.org/c/competitions/ai-for-industry-challenge/). The community is encouraged to participate in discussions and assist each other.
+- **Issues**: Report any bugs or technical issues via [GitHub Issues](https://github.com/intrinsic-dev/aic/issues). Please refrain from using the Issue tracker for general questions about the challenge.
 - **Event Page**: Visit the [AI for Industry Challenge](https://www.intrinsic.ai/events/ai-for-industry-challenge) for official updates.
 
 ---


### PR DESCRIPTION
Empahsize the use of Discourse for asking questions and discussions as opposed to tickets here that will be reserved for bugs.