### PR TITLE
Fix URDF header include (.h vs .hpp) to compile aic_controller in ROS 2 Jazzy

### DIFF
--- a/aic_controller/include/aic_controller/actions/gravity_compensation_action.hpp
+++ b/aic_controller/include/aic_controller/actions/gravity_compensation_action.hpp
@@ -28,7 +28,7 @@
 
 #include "rclcpp/node_interfaces/node_logging_interface.hpp"
 
-// The versions conditioning is added here to support the 
+// The versions conditioning is added here to support the
 // source-compatibility with ROS 2 Jazzy
 #include "rclcpp/version.h"
 #if RCLCPP_VERSION_GTE(29, 0, 0)

--- a/aic_controller/include/aic_controller/aic_controller.hpp
+++ b/aic_controller/include/aic_controller/aic_controller.hpp
@@ -40,7 +40,7 @@
 #include "semantic_components/force_torque_sensor.hpp"
 #include "tf2_eigen/tf2_eigen.hpp"
 
-// The versions conditioning is added here to support the 
+// The versions conditioning is added here to support the
 // source-compatibility with ROS 2 Jazzy
 #include "rclcpp/version.h"
 #if RCLCPP_VERSION_GTE(29, 0, 0)


### PR DESCRIPTION
## Problem
The urdf package has transitioned its primary header from .h to .hpp in recent releases.
- ROS 2 Jazzy (and older) relies on urdf/model.h.
- ROS 2 Kilted (matching rclcpp versions > 29.0.0) requires urdf/model.hpp.

## Solution
Added a conditional preprocessor check to include the correct header based on the rclcpp version. This allows the package to build seamlessly across both distributions.

## Changes
Updated ```aic_controller/include/aic_controller/actions/gravity_compensation_action.hpp``` and ```aic_controller/include/aic_controller/actions/gravity_compensation_action.hpp``` to use conditional inclusion for urdf/model.

Verified builds in both ROS 2 Jazzy and ROS 2 Kilted environments.

[Reference](https://github.com/ros-controls/ros2_control/issues/1977#issuecomment-2571333716)