### PR TITLE
Update aic_scoring output when goal is canceled

### DIFF
--- a/aic_engine/src/aic_engine.cpp
+++ b/aic_engine/src/aic_engine.cpp
@@ -1375,20 +1375,14 @@ bool Engine::tasks_started(Trial& trial) {
     RCLCPP_INFO(this->node_->get_logger(), "Waiting for result...");
 
     // Cancel goal if time limit exceeded
-    // Wait for for task.time_limit by polling node clock so that
-    // use_sim_time is respected.
-    auto timeout_duration = rclcpp::Duration::from_seconds(task.time_limit);
-    while (result_future.wait_for(std::chrono::milliseconds(10)) !=
-           std::future_status::ready) {
-      if ((this->node_->now() - current_attempt.time_started.value()) >
-          timeout_duration) {
-        RCLCPP_ERROR(this->node_->get_logger(),
-                     "Task [%s] timed out after %ld seconds. Cancelling goal.",
-                     task.id.c_str(), task.time_limit);
-        insert_cable_action_client_->async_cancel_goal(goal_handle);
-        current_attempt.state = TaskState::TimeLimitExceeded;
-        return false;
-      }
+    if (result_future.wait_for(std::chrono::seconds(task.time_limit)) !=
+        std::future_status::ready) {
+      RCLCPP_ERROR(this->node_->get_logger(),
+                   "Task [%s] timed out after %ld seconds. Cancelling goal.",
+                   task.id.c_str(), task.time_limit);
+      insert_cable_action_client_->async_cancel_goal(goal_handle);
+      current_attempt.state = TaskState::TimeLimitExceeded;
+      return false;
     }
 
     auto result = result_future.get();


### PR DESCRIPTION
~~When running CheatCode with sim that has low RTF, I'm consistently getting goal cancellation requests. Looks like we were using`std::future::wait_for` to wait for task execution until `task_limit` time is reached, and that's done in wall clock time instead of sim time. I updated the logic to respect sim time by polling node clock time.~~

I also made one minor change to scoring to output a task is not completed message first if the task timed out.

~**To test**~

~Change the [time_limit](https://github.com/intrinsic-dev/aic/blob/c9500c0846af087c2876a0b85d0b45cd71c20d31/aic_engine/config/sample_config.yaml#L154) field in sample_config.yaml file for a trial to something small, e.g. `10`, and run sim with CheatCode (or other policies). Expand the RTF widget at the bottom right of the Gazebo render window, and pay attention to sim time. Verify that task now times out in sim time.~