### PR TITLE
Allow users to report a bug with template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,6 @@ contact_links:
   - name: Known issues
     url: https://github.com/intrinsic-dev/aic/issues?q=is%3Aissue+state%3Aopen+label%3A%22known+issue%22
     about: Check existing known issues before opening a new ticket.
+  - name: Report a bug
+    url: https://github.com/intrinsic-dev/aic/issues/new?template=bug_report.yml
+    about: Report a bug or technical issue.


### PR DESCRIPTION
#364 was merged which added a template but we don't actually allow users to create a ticket according to that template