### PR TITLE
Take 3: Fix unsupported default key in issue template 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,7 +22,7 @@ body:
     id: os
     attributes:
       label: OS
-      default: Ubuntu 24.04
+      placeholder: Ubuntu 24.04
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,3 @@ contact_links:
   - name: Known issues
     url: https://github.com/intrinsic-dev/aic/issues?q=is%3Aissue+state%3Aopen+label%3A%22known+issue%22
     about: Check existing known issues before opening a new ticket.
-  - name: Report a bug
-    url: https://github.com/intrinsic-dev/aic/issues/new?template=bug_report.yml
-    about: Report a bug or technical issue.


### PR DESCRIPTION
Turns out the real reason was unsupported `default` key in the config. By default GitHub automatically scans the .github/ISSUE_TEMPLATE/ directory for any templates so we don't need to add this to the config.