### PR TITLE
lerobot-record: Prevent KeyError by populating cam_obs with initial placeholder frames

### DIFF
--- a/aic_utils/lerobot_robot_aic/lerobot_robot_aic/aic_robot_aic_controller.py
+++ b/aic_utils/lerobot_robot_aic/lerobot_robot_aic/aic_robot_aic_controller.py
@@ -349,13 +349,8 @@ class AICRobotAICController(Robot):
             "joint_positions.6": joint_positions[6],
         }
 
-        # 1. Initialize with placeholders to ensure all keys exist (prevents KeyError)
-        cam_obs: dict[str, NDArray[Any]] = {
-            cam_key: np.zeros(shape, dtype=np.uint8)
-            for cam_key, shape in self._cameras_ft.items()
-        }
-
-        # 2. Try to fill placeholders with real data
+        # Capture images from cameras
+        cam_obs: dict[str, NDArray[Any]] = {}
         for cam_key, cam in self.cameras.items():
             try:
                 data = cam.async_read(timeout_ms=2000)
@@ -373,7 +368,10 @@ class AICRobotAICController(Robot):
                         cam_obs[cam_key] = data
                 else:
                     logger.debug(
-                        f"Camera {cam_key} data is empty, using all-black placeholder."
+                        f"Camera {cam_key} data is empty (camera not ready yet?), using all-black placeholder."
+                    )
+                    cam_obs[cam_key] = np.zeros(
+                        self._cameras_ft[cam_key], dtype=np.uint8
                     )
             except Exception as e:
                 logger.error(f"Failed to read camera {cam_key}: {e}")


### PR DESCRIPTION
When running this command:
`pixi run lerobot-record --robot.type=aic_controller --robot.id=aic --teleop.id=aic --dataset.single_task="insert cable" --dataset.push_to_hub=false --dataset.private=true --play_sounds=false --display_data=false --teleop.type=aic_keyboard_ee --dataset.repo_id=grkw/test`

I was getting this error:
```
File "/home/aic/ws_aic/src/aic/.pixi/envs/default/lib/python3.12/site-packages/lerobot/scripts/lerobot_record.py", line 332, in record_loop
observation_frame = build_dataset_frame(dataset.features, obs_processed, prefix=OBS_STR)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/aic/ws_aic/src/aic/.pixi/envs/default/lib/python3.12/site-packages/lerobot/datasets/utils.py", line 693, in build_dataset_frame
frame[key] = values[key.removeprefix(f"{prefix}.images.")]
~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'left_camera'
```
I noticed that before commit https://github.com/intrinsic-dev/aic/commit/dfaf9dec640f50735a1875321e0b6079f0b97750, lerobot-record runs successfully (if I remove the gripper_target key).

But interesting to note that @Yadunund wasn't getting this error when testing on OSX.

@koonpeng I saw you changed how the get_observation method handles empty or unready camera data; you added this safety check:
```
data = cam.async_read(timeout_ms=2000)
if data.size == 0:
    logging.debug("camera data is empty, device not ready yet?")
    continue  # <--- THIS IS THE CULPRIT
```

Gemini explanation:

When data.size == 0 (which is common during the first few frames of startup), the code executes continue. This means cam_key (e.g., 'left_camera') is never added to the cam_obs dictionary.

However, your observation_features still claims that left_camera exists. When LeRobot’s recording script tries to build a data frame, it looks for left_camera, doesn't find it in the dictionary because you skipped it, and throws the KeyError.

In your old driver, you didn't have that if data.size == 0: continue check, so it likely just passed whatever the camera returned (even if empty or a placeholder) into the dictionary, satisfying the key requirement.

You need to ensure that every camera key defined in your config is always present in the observation dictionary, even if the image hasn't arrived yet.

LeRobot's lerobot_record.py script validates the observation against the features spec. If your observation_features says there are 3 cameras, get_observation must return a dictionary with exactly those 3 keys every single time.