### PR TITLE
WaveArm: Check if observation exists before accessing it

### DIFF
--- a/aic_example_policies/aic_example_policies/ros/WaveArm.py
+++ b/aic_example_policies/aic_example_policies/ros/WaveArm.py
@@ -53,6 +53,11 @@ class WaveArm(Policy):
         while (self.time_now() - start_time) < timeout:
             self.sleep_for(0.25)
             observation = get_observation()
+
+            if observation is None:
+                self.get_logger().info("No observation received.")
+                continue
+
             t = (
                 observation.center_image.header.stamp.sec
                 + observation.center_image.header.stamp.nanosec / 1e9


### PR DESCRIPTION
To prevent aic_model from crashing if an observation hasn't arrived in time.

cc @codebot 