### PR TITLE
RunACT: Add check for observation before accessing it

### DIFF
--- a/aic_example_policies/aic_example_policies/ros/RunACT.py
+++ b/aic_example_policies/aic_example_policies/ros/RunACT.py
@@ -253,6 +253,11 @@ class RunACT(Policy):
 
             # 1. Get & Process Observation
             observation_msg = get_observation()
+
+            if observation_msg is None:
+                self.get_logger().info("No observation received.")
+                continue
+
             obs_tensors = self.prepare_observations(observation_msg)
 
             # 2. Model Inference


### PR DESCRIPTION
Same as #376 but for RunACT instead of WaveArm. The other example policies are good.