### PR TITLE
Disable zenoh shared memory in the pixi environment setup script

### DIFF
--- a/pixi_env_setup.sh
+++ b/pixi_env_setup.sh
@@ -2,4 +2,4 @@
 set -e
 
 export RMW_IMPLEMENTATION="${RMW_IMPLEMENTATION:-rmw_zenoh_cpp}"
-export ZENOH_CONFIG_OVERRIDE="${ZENOH_CONFIG_OVERRIDE:-transport/shared_memory/enabled=true;transport/shared_memory/transport_optimization/pool_size=536870912}"
+export ZENOH_CONFIG_OVERRIDE="transport/shared_memory/enabled=false"


### PR DESCRIPTION
Shared memory transport seems to not work out-of-the-box in docker. To avoid confusion when running inside docker, this PR adjusts the Zenoh configuration to explicitly disable shared memory.