### PR TITLE
Fix task board TF lookup failure

### DIFF
--- a/aic_scoring/src/ScoringTier2.cc
+++ b/aic_scoring/src/ScoringTier2.cc
@@ -382,7 +382,18 @@ void ScoringTier2::JointStateCallback(const JointStateMsg &_msg) { (void)_msg; }
 //////////////////////////////////////////////////
 void ScoringTier2::TfCallback(const TFMsg &_msg) {
   for (const auto &tf : _msg.transforms) {
-    this->tf2_buffer->setTransform(tf, "scoring", false);
+    // The task board TFs are bridged to non-static /tf topic so that it
+    // does not flood the /tf_static topic. Added workaround here to ensure
+    // that these task board related TFs are added to the tree as static TFs
+    // otherwise lookup could fail.
+    // \todo(iche033) This is a quick patch to resolve task board TF lookup
+    // failures. Consider implementing a proper fix that avoids checking every
+    // TF.
+    if (tf.child_frame_id.find("task_board") != std::string::npos) {
+      this->tf2_buffer->setTransform(tf, "scoring", true);
+    } else {
+      this->tf2_buffer->setTransform(tf, "scoring", false);
+    }
   }
   // TODO(luca) we should find a way to only push poses if the gripper pose
   // would have changed because of a new TF message, otherwise we might push


### PR DESCRIPTION
Addresses the issue mentioned in https://github.com/intrinsic-dev/aic/pull/367#issuecomment-3963460890, specifically:

> We only publish the task board TF at 1Hz, previously it was set as static so this wasn't an issue but if now we don't set it as static we might have cases where we get the message too late and try to "extrapolate from the past" to get its tf

So there is a chance that TF lookup for the task board components, e.g. the ports, fails. This PR adds a hot fix to ensure that we add all task board related TFs as static TFs in the tree. 

Test cmds:

sim:
```
ros2 launch aic_bringup aic_gz_bringup.launch.py launch_rviz:=false start_aic_engine:=true ground_truth:=false
```
policy:
```
ros2 run aic_model aic_model --ros-args -p use_sim_time:=true -p policy:=aic_example_policies.ros.WaveArm
```

