### PR TITLE
Fix launch error when shutdown_on_aic_engine_exit is set to true

### DIFF
--- a/aic_bringup/launch/aic_gz_bringup.launch.py
+++ b/aic_bringup/launch/aic_gz_bringup.launch.py
@@ -236,10 +236,9 @@ def launch_setup(context, *args, **kwargs):
     shutdown_on_aic_engine_exit_handler = RegisterEventHandler(
         OnProcessExit(
             target_action=aic_engine,
-            on_exit=lambda event: [
+            on_exit=lambda event, context: [
                 Shutdown(
-                    reason="aic_engine exited",
-                    exit_code=event.returncode,
+                    reason=f"aic_engine exited with return code {event.returncode}"
                 )
             ],
         ),


### PR DESCRIPTION
When sim is launched with `shutdown_on_aic_engine_exit`, it is expected that launch will shut down once aic engine process is done. However, currently it just crashes due to a launch file error. 

```
[ERROR] [launch]: Caught exception in launch (see debug for traceback): launch_setup.<locals>.<lambda>() takes 1 positional argument but 2 were given
```

This PR fixes the error and launch should be shut down cleanly now:

```
[INFO] [launch]: process[aic_engine-5] was required: shutting down launched system
```

Fixes:
* Fixed `on_exit` callback to take 2 arguments 
* Removed `exit_code` as the `Shutdown` action does not accept this arg.