### PR TITLE
Always set RMW_IMPLEMENTATION in pixi_env_setup.sh

### DIFF
--- a/pixi_env_setup.sh
+++ b/pixi_env_setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
 set -e
 
-export RMW_IMPLEMENTATION="${RMW_IMPLEMENTATION:-rmw_zenoh_cpp}"
+export RMW_IMPLEMENTATION=rmw_zenoh_cpp
 export ZENOH_CONFIG_OVERRIDE="transport/shared_memory/enabled=false"


### PR DESCRIPTION
Fixes #415  . Always set `RMW_IMPLEMENTATION=rmw_zenoh_cpp` since the Challenge is always using Zenoh.