### PR TITLE
Fix SpaceMouse device not stored in AICSpaceMouseTeleop.connect()

### DIFF
--- a/aic_utils/lerobot_robot_aic/lerobot_robot_aic/aic_teleop.py
+++ b/aic_utils/lerobot_robot_aic/lerobot_robot_aic/aic_teleop.py
@@ -261,7 +261,7 @@ class AICSpaceMouseTeleop(Teleoperator):
                 "Calibration not supported, ensure the robot is calibrated before running teleop."
             )
 
-        self._device_open_success = pyspacemouse.open(
+        self._device = pyspacemouse.open(
             dof_callback=None,
             # button_callback_arr=[
             #     pyspacemouse.ButtonCallback([0], self._button_callback),  # Button 1
@@ -269,6 +269,9 @@ class AICSpaceMouseTeleop(Teleoperator):
             # ],
             device=self.config.device,
         )
+
+        if self._device is None:
+            raise RuntimeError("Failed to open SpaceMouse device")
 
         self._executor = SingleThreadedExecutor()
         self._executor.add_node(self._node)


### PR DESCRIPTION
### Problem

In `AICSpaceMouseTeleop.connect()`, the result of `pyspacemouse.open()` was assigned to `_device_open_success`, but `_device` was never initialized.

However, `get_action()` checks:

```python
if not self.is_connected or not self._device:
    raise DeviceNotConnectedError()
```

Since `_device` remained `None`, `DeviceNotConnectedError` was always raised, even though the SpaceMouse was successfully opened.

### Reproduction

Running

```bash
$ pixi run lerobot-teleoperate --robot.type=aic_controller --robot.id=aic \
--teleop.type=aic_spacemouse --teleop.id=aic \
--robot.teleop_target_mode=cartesian --robot.teleop_frame_id=base_link \
--display_data=true
```

Resulted in:

```
Traceback (most recent call last):
  File "~/IsaacLab/aic/.pixi/envs/default/bin/lerobot-teleoperate", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "~/IsaacLab/aic/.pixi/envs/default/lib/python3.12/site-packages/lerobot/scripts/lerobot_teleoperate.py", line 240, in main
    teleoperate()
  File "~/IsaacLab/aic/.pixi/envs/default/lib/python3.12/site-packages/lerobot/configs/parser.py", line 233, in wrapper_inner
    response = fn(cfg, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/IsaacLab/aic/.pixi/envs/default/lib/python3.12/site-packages/lerobot/scripts/lerobot_teleoperate.py", line 218, in teleoperate
    teleop_loop(
  File "~/IsaacLab/aic/.pixi/envs/default/lib/python3.12/site-packages/lerobot/scripts/lerobot_teleoperate.py", line 160, in teleop_loop
    raw_action = teleop.get_action()
                 ^^^^^^^^^^^^^^^^^^^
  File "~/IsaacLab/aic/.pixi/envs/default/lib/python3.12/site-packages/lerobot_robot_aic/aic_teleop.py", line 296, in get_action
    raise DeviceNotConnectedError()
lerobot.utils.errors.DeviceNotConnectedError: This device is not connected. Try calling `connect()` first.

```

### Fix

Store the returned SpaceMouseDevice in `self._device` instead of `_device_open_success`, and validate that it is not `None`.

This ensures `get_action()` correctly detects an active connection.

### Tested
- 3Dconnexion SpaceMouse Compact
- pyspacemouse 2.0.0