### PR TITLE
Fix tare_ft_sensor references in documenation by renaming

### DIFF
--- a/docs/aic_controller.md
+++ b/docs/aic_controller.md
@@ -90,13 +90,13 @@ The controller publishes real-time data to `/aic_controller/controller_state` ([
 
 #### Force-Torque Sensor Tare
 
-The controller provides a service to tare (zero) the force-torque sensor at `/aic_controller/tare_ft_sensor`. This service resets the current force/torque readings to zero, which is useful for calibrating the sensor or removing sensor bias. The tared offset is published in the [`ControllerState`](../aic_interfaces/aic_control_interfaces/msg/ControllerState.msg) message as `fts_tare_offset`.
+The controller provides a service to tare (zero) the force-torque sensor at `/aic_controller/tare_force_torque_sensor`. This service resets the current force/torque readings to zero, which is useful for calibrating the sensor or removing sensor bias. The tared offset is published in the [`ControllerState`](../aic_interfaces/aic_control_interfaces/msg/ControllerState.msg) message as `fts_tare_offset`.
 
 > **Note:** Before the start of each training episode (i.e. before teleoperation or spawning cables in the environment), it is important to tare the Force/Torque Sensor (F/T Sensor) for accurate force-torque feedback.
 
 ```bash
 # Tare the FT sensor
-ros2 service call /aic_controller/tare_ft_sensor std_srvs/srv/Trigger
+ros2 service call /aic_controller/tare_force_torque_sensor std_srvs/srv/Trigger
 ```
 
 > **Important:** This service will **not be available** during the evaluation. The force-torque sensor readings are used for scoring, and participants cannot tare the sensor during competition runs.

--- a/docs/aic_interfaces.md
+++ b/docs/aic_interfaces.md
@@ -87,4 +87,4 @@ The Insertion Policy controls the robot by publishing to the following topics.
 | Service Name | Service Type | Description |
 | :--- | :--- | :--- |
 | `/aic_controller/change_target_mode` | `aic_control_interfaces/srv/ChangeTargetMode` | Select the target mode (Cartesian or joint) to define the expected input. The controller will subscribe to either `/aic_controller/pose_commands` or `/aic_controller/joint_commands` accordingly. |
-| `/aic_controller/tare_ft_sensor` | `std_srvs/srv/Trigger` | Service to tare the force/torque sensor. This service will be disabled during evaluation. The evaluation system will automatically call this service before the cable is spawned in the environment. |
+| `/aic_controller/tare_force_torque_sensor` | `std_srvs/srv/Trigger` | Service to tare the force/torque sensor. This service will be disabled during evaluation. The evaluation system will automatically call this service before the cable is spawned in the environment. |

--- a/docs/scene_description.md
+++ b/docs/scene_description.md
@@ -157,7 +157,7 @@ The simulation includes a world plugin that automatically exports the complete w
 
 At the start of each training episode (i.e. before teleoperation and before spawning any cables in the environment), ensure that the Force/Torque Sensor (F/T Sensor) is tared using the following service call:
 ```bash
-ros2 service call /aic_controller/tare_ft_sensor std_srvs/srv/Trigger
+ros2 service call /aic_controller/tare_force_torque_sensor std_srvs/srv/Trigger
 ```
 
 ---


### PR DESCRIPTION
Just some minor re-naming in the documentation: `tare_ft_sensor` wasn't used in the code, it should be `tare_force_torque_sensor`.