### PR TITLE
Add configurable stiffness and damping to set_pose_target

### DIFF
--- a/aic_model/aic_model/policy.py
+++ b/aic_model/aic_model/policy.py
@@ -32,7 +32,6 @@ from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
 from typing import Callable, Protocol
 
-
 GetObservationCallback = Callable[[], Observation]
 
 
@@ -88,7 +87,10 @@ class Policy(ABC):
         self.get_clock().sleep_for(Duration(seconds=duration_sec))
 
     def set_pose_target(
-        self, move_robot: MoveRobotCallback, pose: Pose, frame_id: str = "base_link",
+        self,
+        move_robot: MoveRobotCallback,
+        pose: Pose,
+        frame_id: str = "base_link",
         stiffness: list = [90.0, 90.0, 90.0, 50.0, 50.0, 50.0],
         damping: list = [50.0, 50.0, 50.0, 20.0, 20.0, 20.0],
     ) -> None:


### PR DESCRIPTION
Expose `stiffness` and `damping` as optional parameters on the `Policy.set_pose_target()` convenience method, instead of hardcoding them. Default values are unchanged (`[90, 90, 90, 50, 50, 50]` / `[50, 50, 50, 20, 20, 20]`), so existing callers are unaffected.

### Motivation

Several policies already need task-specific impedance values and work around the hardcoded defaults. With this change, policies can tune impedance while staying within the provided API.

### Test plan

- Reinstall and launch the eval environment.
- Verify that policies which do **not** pass stiffness/damping (WaveArm, CheatCode, DummyWave) behave identically to before; they pick up the unchanged defaults.
- Verify that a policy passing custom values, e.g.:
  ```python
  self.set_pose_target(
      move_robot, pose, "base_link",
      stiffness=[200.0, 200.0, 200.0, 50.0, 50.0, 50.0],
      damping=[80.0, 80.0, 80.0, 20.0, 20.0, 20.0],
  )
  ```
  produces a `MotionUpdate` message with the corresponding diagonal stiffness/damping matrices (confirm via `ros2 topic echo` on the controller command topic)

### Note

This came up while implementing my own policy; I needed to adjust impedance parameters as straightforward as possible so I added these optional parameters, and I think other participants would find it just as useful rather than having to construct `MotionUpdate` messages from scratch. If it doesn't fit the toolkit's design, feel free to close; the change is backward-compatible.