### PR TITLE
fix docker compose up

### DIFF
--- a/pixi_env_setup.sh
+++ b/pixi_env_setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
 set -e
 
-export RMW_IMPLEMENTATION="${RMW_IMPLEMENTATION:-rmw_zenoh_cpp}"
+export RMW_IMPLEMENTATION=rmw_zenoh_cpp
 export ZENOH_CONFIG_OVERRIDE="${ZENOH_CONFIG_OVERRIDE:-transport/shared_memory/enabled=false}"


### PR DESCRIPTION
096b6d28134c78ad950fa928bcd04dbd3d070321 cause a regression, breaking local test run with `docker compose up`. It is important that `ZENOH_CONFIG_OVERRIDE` is not overwritten else the config set by the container will be ignored.