### PR TITLE
OpenXR handtracking support for Isaac Lab

### DIFF
--- a/aic_utils/aic_isaac/README.md
+++ b/aic_utils/aic_isaac/README.md
@@ -168,6 +168,14 @@ isaaclab -p aic/aic_utils/aic_isaac/aic_isaaclab/scripts/teleop.py \
 ```
 
 Teleoperate the robot with VR hand tracking (requires OpenXR/SteamVR):
+
+> [!NOTE]
+> You must set the `XR_RUNTIME_JSON` environment variable to point to your SteamVR OpenXR runtime JSON before launching.
+> Find the path on your system and export it, e.g.:
+> ```bash
+> export XR_RUNTIME_JSON=/home/user/.steam/debian-installation/steamapps/common/SteamVR/steamxr_linux64.json
+> ```
+
 ```bash
 isaaclab -p aic/aic_utils/aic_isaac/aic_isaaclab/scripts/teleop.py \
     --task AIC-Task-v0 --num_envs 1 --teleop_device handtracking

--- a/aic_utils/aic_isaac/README.md
+++ b/aic_utils/aic_isaac/README.md
@@ -167,6 +167,12 @@ isaaclab -p aic/aic_utils/aic_isaac/aic_isaaclab/scripts/teleop.py \
     --task AIC-Task-v0 --num_envs 1 --teleop_device keyboard --enable_cameras
 ```
 
+Teleoperate the robot with VR hand tracking (requires OpenXR/SteamVR):
+```bash
+isaaclab -p aic/aic_utils/aic_isaac/aic_isaaclab/scripts/teleop.py \
+    --task AIC-Task-v0 --num_envs 1 --teleop_device handtracking
+```
+
 > [!NOTE]
 > You can tune the keyboard teleop sensitivity by updating `aic_isaaclab/source/aic_task/aic_task/tasks/manager_based/aic_task/aic_task_env_config.py`:
 > ```python

--- a/aic_utils/aic_isaac/README.md
+++ b/aic_utils/aic_isaac/README.md
@@ -167,7 +167,18 @@ isaaclab -p aic/aic_utils/aic_isaac/aic_isaaclab/scripts/teleop.py \
     --task AIC-Task-v0 --num_envs 1 --teleop_device keyboard --enable_cameras
 ```
 
-Teleoperate the robot with VR hand tracking (requires OpenXR/SteamVR):
+> [!NOTE]
+> You can tune the keyboard teleop sensitivity by updating `aic_isaaclab/source/aic_task/aic_task/tasks/manager_based/aic_task/aic_task_env_config.py`:
+> ```python
+> "keyboard": Se3KeyboardCfg(
+>     pos_sensitivity=0.08,
+>     rot_sensitivity=0.05,
+>     gripper_term=False,
+>     sim_dev=self.sim.device,
+> ),
+> ```
+
+Teleoperate the robot with VR hand tracking (with OpenXR/SteamVR):
 
 > [!NOTE]
 > You must set the `XR_RUNTIME_JSON` environment variable to point to your SteamVR OpenXR runtime JSON before launching.
@@ -180,17 +191,6 @@ Teleoperate the robot with VR hand tracking (requires OpenXR/SteamVR):
 isaaclab -p aic/aic_utils/aic_isaac/aic_isaaclab/scripts/teleop.py \
     --task AIC-Task-v0 --num_envs 1 --teleop_device handtracking
 ```
-
-> [!NOTE]
-> You can tune the keyboard teleop sensitivity by updating `aic_isaaclab/source/aic_task/aic_task/tasks/manager_based/aic_task/aic_task_env_config.py`:
-> ```python
-> "keyboard": Se3KeyboardCfg(
->     pos_sensitivity=0.08,
->     rot_sensitivity=0.05,
->     gripper_term=False,
->     sim_dev=self.sim.device,
-> ),
-> ```
 
 For data collection:
 ```bash

--- a/aic_utils/aic_isaac/aic_isaaclab/scripts/record_demos.py
+++ b/aic_utils/aic_isaac/aic_isaaclab/scripts/record_demos.py
@@ -170,8 +170,9 @@ def main() -> None:
     env_cfg.recorders.dataset_export_mode = DatasetExportMode.EXPORT_SUCCEEDED_ONLY
 
     if args_cli.xr:
-        from xr_utils import remove_xr_cameras
+        from xr_utils import configure_xr_env, remove_xr_cameras
 
+        env_cfg = configure_xr_env(env_cfg)
         env_cfg = remove_xr_cameras(env_cfg)
         env_cfg.sim.render.antialiasing_mode = "DLSS"
 

--- a/aic_utils/aic_isaac/aic_isaaclab/scripts/record_demos.py
+++ b/aic_utils/aic_isaac/aic_isaaclab/scripts/record_demos.py
@@ -67,13 +67,19 @@ parser.add_argument(
 AppLauncher.add_app_launcher_args(parser)
 args_cli = parser.parse_args()
 
-app_launcher = AppLauncher(args_cli)
+app_launcher_args = vars(args_cli)
+if "handtracking" in args_cli.teleop_device.lower():
+    app_launcher_args["xr"] = True
+
+app_launcher = AppLauncher(app_launcher_args)
 simulation_app = app_launcher.app
 
 """Rest everything follows."""
 
 import logging
 import os
+import queue
+import threading
 import time
 from collections.abc import Callable
 
@@ -162,6 +168,12 @@ def main() -> None:
     env_cfg.recorders.dataset_export_dir_path = output_dir
     env_cfg.recorders.dataset_filename = output_file_name
     env_cfg.recorders.dataset_export_mode = DatasetExportMode.EXPORT_SUCCEEDED_ONLY
+
+    if args_cli.xr:
+        from xr_utils import remove_xr_cameras
+
+        env_cfg = remove_xr_cameras(env_cfg)
+        env_cfg.sim.render.antialiasing_mode = "DLSS"
 
     # Create environment
     env = gym.make(args_cli.task, cfg=env_cfg).unwrapped
@@ -253,12 +265,42 @@ def main() -> None:
     env.reset()
     teleop_interface.reset()
 
+    command_queue: queue.SimpleQueue[str] | None = None
+    stop_event: threading.Event | None = None
+    if args_cli.xr:
+        from xr_utils import spawn_stdin_reader
+
+        command_queue = queue.SimpleQueue()
+        stop_event = threading.Event()
+        spawn_stdin_reader(command_queue, stop_event)
+
     print(f"Using teleop device: {teleop_interface}")
-    print("Recording demonstrations. Press 'R' to reset/discard current episode.")
+    if args_cli.xr:
+        print("Recording demonstrations. Hotkeys: s=start, p=pause, r=reset, q=quit")
+    else:
+        print("Recording demonstrations. Press 'R' to reset/discard current episode.")
     print(f"Recorded 0 successful demonstrations so far.")
 
     with contextlib.suppress(KeyboardInterrupt) and torch.inference_mode():
         while simulation_app.is_running():
+            if stop_event is not None and stop_event.is_set():
+                break
+
+            if command_queue is not None:
+                while True:
+                    try:
+                        cmd = command_queue.get_nowait()
+                    except queue.Empty:
+                        break
+                    if cmd == "s":
+                        start_recording()
+                    elif cmd == "p":
+                        stop_recording()
+                    elif cmd == "r":
+                        reset_recording()
+                    elif cmd == "q":
+                        stop_event.set()
+
             action = teleop_interface.advance()
             actions = action.repeat(env.num_envs, 1)
 

--- a/aic_utils/aic_isaac/aic_isaaclab/scripts/teleop.py
+++ b/aic_utils/aic_isaac/aic_isaaclab/scripts/teleop.py
@@ -107,7 +107,16 @@ def main() -> None:
         )
 
     if args_cli.xr:
-        env_cfg = remove_camera_configs(env_cfg)
+        try:
+            env_cfg = remove_camera_configs(env_cfg)
+        except AttributeError:
+            # AIC observation terms use *_rgb names instead of *_camera
+            for attr in ("center_camera", "left_camera", "right_camera"):
+                if hasattr(env_cfg.scene, attr):
+                    setattr(env_cfg.scene, attr, None)
+            for attr in ("center_rgb", "left_rgb", "right_rgb"):
+                if hasattr(env_cfg.observations.policy, attr):
+                    delattr(env_cfg.observations.policy, attr)
         env_cfg.sim.render.antialiasing_mode = "DLSS"
 
     try:

--- a/aic_utils/aic_isaac/aic_isaaclab/scripts/teleop.py
+++ b/aic_utils/aic_isaac/aic_isaaclab/scripts/teleop.py
@@ -259,6 +259,15 @@ def main() -> None:
                 if teleoperation_active:
                     actions = action.repeat(env.num_envs, 1)
                     env.step(actions)
+                    # #########Debug prints for sensors
+                    # step_count += 1
+                    # if step_count % 120 == 0:
+                    #     joint_pos = env.scene["robot"].data.joint_pos[0]
+                    #     joint_names = env.scene["robot"].joint_names
+                    #     print(f"\n[step {step_count}] Joint positions:")
+                    #     for name, pos in zip(joint_names, joint_pos):
+                    #         print(f"  {name}: {pos.item():.5f}")
+                    # ###################################################################
                 else:
                     env.sim.render()
 

--- a/aic_utils/aic_isaac/aic_isaaclab/scripts/teleop.py
+++ b/aic_utils/aic_isaac/aic_isaaclab/scripts/teleop.py
@@ -108,8 +108,9 @@ def main() -> None:
         )
 
     if args_cli.xr:
-        from xr_utils import remove_xr_cameras
+        from xr_utils import configure_xr_env, remove_xr_cameras
 
+        env_cfg = configure_xr_env(env_cfg)
         env_cfg = remove_xr_cameras(env_cfg)
         env_cfg.sim.render.antialiasing_mode = "DLSS"
 

--- a/aic_utils/aic_isaac/aic_isaaclab/scripts/teleop.py
+++ b/aic_utils/aic_isaac/aic_isaaclab/scripts/teleop.py
@@ -56,6 +56,8 @@ simulation_app = app_launcher.app
 """Rest everything follows."""
 
 import logging
+import queue
+import threading
 
 import gymnasium as gym
 import torch
@@ -68,7 +70,6 @@ from isaaclab.devices import (
     Se3SpaceMouse,
     Se3SpaceMouseCfg,
 )
-from isaaclab.devices.openxr import remove_camera_configs
 from isaaclab.devices.teleop_device_factory import create_teleop_device
 from isaaclab.envs import ManagerBasedRLEnvCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
@@ -107,16 +108,9 @@ def main() -> None:
         )
 
     if args_cli.xr:
-        try:
-            env_cfg = remove_camera_configs(env_cfg)
-        except AttributeError:
-            # AIC observation terms use *_rgb names instead of *_camera
-            for attr in ("center_camera", "left_camera", "right_camera"):
-                if hasattr(env_cfg.scene, attr):
-                    setattr(env_cfg.scene, attr, None)
-            for attr in ("center_rgb", "left_rgb", "right_rgb"):
-                if hasattr(env_cfg.observations.policy, attr):
-                    delattr(env_cfg.observations.policy, attr)
+        from xr_utils import remove_xr_cameras
+
+        env_cfg = remove_xr_cameras(env_cfg)
         env_cfg.sim.render.antialiasing_mode = "DLSS"
 
     try:
@@ -224,10 +218,39 @@ def main() -> None:
     env.reset()
     teleop_interface.reset()
 
-    print("Teleoperation started. Press 'R' to reset the environment.")
+    # For XR sessions, start a background stdin reader for terminal hotkeys
+    # (hand-tracking devices do not emit START/STOP/RESET messages).
+    command_queue: queue.SimpleQueue[str] | None = None
+    stop_event: threading.Event | None = None
+    if args_cli.xr:
+        from xr_utils import spawn_stdin_reader
 
-    step_count = 0
+        command_queue = queue.SimpleQueue()
+        stop_event = threading.Event()
+        spawn_stdin_reader(command_queue, stop_event)
+        print("Teleoperation started. Hotkeys: s=start, p=pause, r=reset, q=quit")
+    else:
+        print("Teleoperation started. Press 'R' to reset the environment.")
+
     while simulation_app.is_running():
+        if stop_event is not None and stop_event.is_set():
+            break
+
+        if command_queue is not None:
+            while True:
+                try:
+                    cmd = command_queue.get_nowait()
+                except queue.Empty:
+                    break
+                if cmd == "s":
+                    start_teleoperation()
+                elif cmd == "p":
+                    stop_teleoperation()
+                elif cmd == "r":
+                    reset_recording_instance()
+                elif cmd == "q":
+                    stop_event.set()
+
         try:
             with torch.inference_mode():
                 action = teleop_interface.advance()
@@ -235,15 +258,6 @@ def main() -> None:
                 if teleoperation_active:
                     actions = action.repeat(env.num_envs, 1)
                     env.step(actions)
-                    # #########Debug prints for sensors
-                    # step_count += 1
-                    # if step_count % 120 == 0:
-                    #     joint_pos = env.scene["robot"].data.joint_pos[0]
-                    #     joint_names = env.scene["robot"].joint_names
-                    #     print(f"\n[step {step_count}] Joint positions:")
-                    #     for name, pos in zip(joint_names, joint_pos):
-                    #         print(f"  {name}: {pos.item():.5f}")
-                    # ###################################################################
                 else:
                     env.sim.render()
 

--- a/aic_utils/aic_isaac/aic_isaaclab/scripts/xr_utils.py
+++ b/aic_utils/aic_isaac/aic_isaaclab/scripts/xr_utils.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Utilities for XR (OpenXR/SteamVR) teleop sessions."""
+
+from __future__ import annotations
+
+import queue
+import select
+import sys
+import termios
+import threading
+import tty
+
+
+def spawn_stdin_reader(
+    command_queue: queue.SimpleQueue[str],
+    stop_event: threading.Event,
+) -> threading.Thread:
+    """Read single-key commands from stdin without blocking the simulation loop.
+
+    XR hand-tracking devices do not emit Isaac Lab START/STOP/RESET messages,
+    so this thread provides terminal hotkeys as a fallback control channel.
+    """
+
+    def _reader() -> None:
+        if not sys.stdin.isatty():
+            return
+        fd = sys.stdin.fileno()
+        old_settings = termios.tcgetattr(fd)
+        try:
+            tty.setcbreak(fd)
+            while not stop_event.is_set():
+                ready, _, _ = select.select([sys.stdin], [], [], 0.1)
+                if ready:
+                    ch = sys.stdin.read(1)
+                    if ch:
+                        command_queue.put(ch.lower())
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+
+    thread = threading.Thread(target=_reader, name="xr-stdin-reader", daemon=True)
+    thread.start()
+    return thread
+
+
+def remove_xr_cameras(env_cfg):
+    """Remove camera scene entries and observation terms for XR sessions.
+
+    Isaac Lab's ``remove_camera_configs`` expects ``*_camera`` observation names.
+    AIC uses ``*_rgb`` instead, so this handles both naming conventions.
+    """
+    from isaaclab.devices.openxr import remove_camera_configs
+
+    try:
+        return remove_camera_configs(env_cfg)
+    except AttributeError:
+        for attr in ("center_camera", "left_camera", "right_camera"):
+            if hasattr(env_cfg.scene, attr):
+                setattr(env_cfg.scene, attr, None)
+        for attr in ("center_rgb", "left_rgb", "right_rgb"):
+            if hasattr(env_cfg.observations.policy, attr):
+                delattr(env_cfg.observations.policy, attr)
+        return env_cfg

--- a/aic_utils/aic_isaac/aic_isaaclab/scripts/xr_utils.py
+++ b/aic_utils/aic_isaac/aic_isaaclab/scripts/xr_utils.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Utilities for XR (OpenXR/SteamVR) teleop sessions."""
 
 from __future__ import annotations

--- a/aic_utils/aic_isaac/aic_isaaclab/scripts/xr_utils.py
+++ b/aic_utils/aic_isaac/aic_isaaclab/scripts/xr_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import queue
 import select
 import sys
@@ -39,6 +40,20 @@ def spawn_stdin_reader(
     thread = threading.Thread(target=_reader, name="xr-stdin-reader", daemon=True)
     thread.start()
     return thread
+
+
+def configure_xr_env(env_cfg):
+    """Apply XR-specific environment overrides.
+
+    The robot base is rotated 180 degrees around Z but the retargeter outputs
+    world-frame deltas.  Fold the rotation into shoulder_pan_joint so the
+    robot root frame aligns with the world frame.
+    """
+    robot_cfg = env_cfg.scene.robot
+    robot_cfg.init_state.rot = (1.0, 0.0, 0.0, 0.0)
+    orig_pan = robot_cfg.init_state.joint_pos.get("shoulder_pan_joint", 0.0)
+    robot_cfg.init_state.joint_pos["shoulder_pan_joint"] = orig_pan + math.pi
+    return env_cfg
 
 
 def remove_xr_cameras(env_cfg):

--- a/aic_utils/aic_isaac/aic_isaaclab/scripts/xr_utils.py
+++ b/aic_utils/aic_isaac/aic_isaaclab/scripts/xr_utils.py
@@ -49,6 +49,8 @@ def configure_xr_env(env_cfg):
     world-frame deltas.  Fold the rotation into shoulder_pan_joint so the
     robot root frame aligns with the world frame.
     """
+    env_cfg.actions.arm_action.scale = 0.5
+
     robot_cfg = env_cfg.scene.robot
     robot_cfg.init_state.rot = (1.0, 0.0, 0.0, 0.0)
     orig_pan = robot_cfg.init_state.joint_pos.get("shoulder_pan_joint", 0.0)

--- a/aic_utils/aic_isaac/aic_isaaclab/source/aic_task/aic_task/tasks/manager_based/aic_task/aic_task_env_cfg.py
+++ b/aic_utils/aic_isaac/aic_isaaclab/source/aic_task/aic_task/tasks/manager_based/aic_task/aic_task_env_cfg.py
@@ -5,7 +5,7 @@
 
 import math
 import os
-from dataclasses import MISSING
+from dataclasses import MISSING, field
 
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
@@ -26,7 +26,9 @@ from isaaclab.utils import configclass
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.noise import AdditiveUniformNoiseCfg as Unoise
 from isaaclab.sensors import TiledCameraCfg
-from isaaclab.devices import DevicesCfg
+from isaaclab.devices import DevicesCfg, OpenXRDevice, OpenXRDeviceCfg
+from isaaclab.devices.openxr import XrCfg
+from isaaclab.devices.openxr.retargeters import Se3RelRetargeterCfg
 from isaaclab.devices.keyboard import Se3KeyboardCfg
 from isaaclab.devices.spacemouse import Se3SpaceMouseCfg
 from isaaclab.devices.gamepad import Se3GamepadCfg
@@ -547,6 +549,12 @@ class RewardsCfg:
 class AICTaskEnvCfg(ManagerBasedRLEnvCfg):
     """AIC task env: UR5e robot and custom scene."""
 
+    xr: XrCfg = field(
+        default_factory=lambda: XrCfg(
+            anchor_pos=(0.0, -0.4, -1.15),
+            anchor_rot=(0.866, 0.0, 0.0, -0.5),
+        )
+    )
     # Scene settings
     scene: AICTaskSceneCfg = AICTaskSceneCfg(num_envs=1, env_spacing=4.0)
     # Basic settings
@@ -621,6 +629,20 @@ class AICTaskEnvCfg(ManagerBasedRLEnvCfg):
         # Teleop device configuration
         self.teleop_devices = DevicesCfg(
             devices={
+                "handtracking": OpenXRDeviceCfg(
+                    xr_cfg=self.xr,
+                    retargeters=[
+                        Se3RelRetargeterCfg(
+                            bound_hand=OpenXRDevice.TrackingTarget.HAND_RIGHT,
+                            zero_out_xy_rotation=True,
+                            use_wrist_position=True,
+                            alpha_pos=0.8,
+                            alpha_rot=0.8,
+                            sim_device=self.sim.device,
+                        ),
+                    ],
+                    sim_device=self.sim.device,
+                ),
                 "keyboard": Se3KeyboardCfg(
                     pos_sensitivity=0.08,
                     rot_sensitivity=0.05,


### PR DESCRIPTION
## Summary

Adds OpenXR hand-tracking teleop support for the AIC environment for Isaac, alongside the existing keyboard, spacemouse, and gamepad devices.

### What's included

- `XrCfg` and `OpenXRDeviceCfg` with `Se3RelRetargeter` added to the environment config
- `xr_utils.py` — shared helpers for XR sessions (camera removal, robot base-frame alignment, stdin reader)
- XR-specific runtime overrides in `teleop.py` and `record_demos.py` (only active when `--teleop_device handtracking`)
- Robot base-frame realignment so world-frame deltas from the retargeter map correctly to the DifferentialIK base frame
- IK action scale override (0.05 → 0.5) for hand-tracking responsiveness

### Hacky bit — terminal hotkeys

Added a stdin reader thread that listens for single-key hotkeys (`s`/`p`/`r`/`q`) when XR is active. It works, but it's not the cleanest solution — ideally the OpenXR device itself would emit these via controller buttons or hand gestures. Open to better approaches here.

### Setup

Requires `XR_RUNTIME_JSON` environment variable pointing to your SteamVR runtime JSON before launching:

```bash
export XR_RUNTIME_JSON=/home/user/.steam/debian-installation/steamapps/common/SteamVR/steamxr_linux64.json
```

```bash
isaaclab -p aic/aic_utils/aic_isaac/aic_isaaclab/scripts/teleop.py \
    --task AIC-Task-v0 --num_envs 1 --teleop_device handtracking
```

Figured this might be useful for anyone looking to do VR teleop data collection with the AIC environment.
