### PR TITLE
Add Cable Moderator Plugin

### DIFF
--- a/aic_description/world/aic.sdf
+++ b/aic_description/world/aic.sdf
@@ -101,6 +101,7 @@
       name="gz::sim::systems::Physics">
       <engine><filename>gz-physics-bullet-featherstone-plugin</filename></engine>
     </plugin>
+
     <plugin
       filename="gz-sim-sensors-system"
       name="gz::sim::systems::Sensors">
@@ -117,6 +118,7 @@
         <debug_vis_mode>none</debug_vis_mode>
       </global_illumination>
     </plugin>
+
     <plugin filename="OffLimitContactsPlugin" name="aic_gazebo::OffLimitContactsPlugin">
       <model>ur5e</model>
       <update_rate>5</update_rate>
@@ -142,6 +144,19 @@
       filename="gz-sim-contact-system"
       name="gz::sim::systems::Contact">
     </plugin>
+
+    <plugin filename="CableModeratorPlugin" name="aic_gazebo::CableModeratorPlugin">
+      <cable>
+        <name>cable_0</name>
+        <cable_connection_0_link>lc_plug_link</cable_connection_0_link>
+        <cable_connection_0_port>nic_card_mount</cable_connection_0_port>
+        <cable_connection_1_link>sc_plug_link</cable_connection_1_link>
+        <cable_connection_1_port>sc_port_base</cable_connection_1_port>
+      </cable>
+      <end_effector_model>ur5e</end_effector_model>
+      <end_effector_link>ati/tool_link</end_effector_link>
+    </plugin>
+
 
     <gravity>0 0 -9.8</gravity>
 
@@ -212,6 +227,16 @@
       <name>floor</name>
       <static>true</static>
     </include>
+
+    <model name="cable_0">
+      <pose>0.172 0.024 1.518 0.4432 -0.48 1.3303</pose>
+      <static>false</static>
+      <self_collide>true</self_collide>
+      <include merge="true">
+        <uri>model://sfp_sc_cable</uri>
+      </include>
+    </model>
+
 
     <!-- Cable is now spawned via cable.sdf.xacro in launch file -->
     <!-- Task board and components are now spawned via task_board.urdf.xacro in launch file -->

--- a/aic_description/world/aic.sdf
+++ b/aic_description/world/aic.sdf
@@ -228,16 +228,6 @@
       <static>true</static>
     </include>
 
-    <model name="cable_0">
-      <pose>0.172 0.024 1.518 0.4432 -0.48 1.3303</pose>
-      <static>false</static>
-      <self_collide>true</self_collide>
-      <include merge="true">
-        <uri>model://sfp_sc_cable</uri>
-      </include>
-    </model>
-
-
     <!-- Cable is now spawned via cable.sdf.xacro in launch file -->
     <!-- Task board and components are now spawned via task_board.urdf.xacro in launch file -->
   </world>

--- a/aic_gazebo/CMakeLists.txt
+++ b/aic_gazebo/CMakeLists.txt
@@ -72,6 +72,24 @@ install(
   DESTINATION lib/${PROJECT_NAME}
 )
 
+add_library(CableModeratorPlugin
+  SHARED
+  src/CableModeratorPlugin.cc
+)
+
+target_link_libraries(CableModeratorPlugin PRIVATE
+  gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER})
+
+install(
+  TARGETS CableModeratorPlugin
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(
+  TARGETS CableModeratorPlugin
+  DESTINATION lib/${PROJECT_NAME}
+)
+
 add_library(OffLimitContactsPlugin
   SHARED
   src/OffLimitContactsPlugin.cc

--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -1,0 +1,561 @@
+/*
+ * Copyright (C) 2026 Intrinsic Innovation LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "CableModeratorPlugin.hh"
+
+#include <gz/msgs/boolean.pb.h>
+#include <gz/msgs/stringmsg.pb.h>
+
+#include <functional>
+#include <gz/common/Console.hh>
+#include <gz/plugin/Register.hh>
+#include <gz/sim/Util.hh>
+#include <gz/sim/components/CanonicalLink.hh>
+#include <gz/sim/components/DetachableJoint.hh>
+#include <gz/sim/components/Link.hh>
+#include <gz/sim/components/Model.hh>
+#include <gz/sim/components/Name.hh>
+#include <gz/sim/components/ParentEntity.hh>
+#include <gz/sim/components/Pose.hh>
+#include <gz/sim/components/PoseCmd.hh>
+#include <gz/sim/components/World.hh>
+
+using namespace gz;
+using namespace sim;
+
+GZ_ADD_PLUGIN(aic_gazebo::CableModeratorPlugin, gz::sim::System,
+              aic_gazebo::CableModeratorPlugin::ISystemConfigure,
+              aic_gazebo::CableModeratorPlugin::ISystemPreUpdate,
+              aic_gazebo::CableModeratorPlugin::ISystemUpdate,
+              aic_gazebo::CableModeratorPlugin::ISystemPostUpdate,
+              aic_gazebo::CableModeratorPlugin::ISystemReset)
+
+namespace {
+
+/// \brief Default offset of gripper grasping point w.r.t. the end effector.
+const gz::math::Pose3d kEndEffectorOffset =
+    gz::math::Pose3d(0, 0.0, 0.165, 0, 0, 0);
+
+/// \brief Find link in a model
+/// \param[in] _modelName Name of model
+/// \param[in] _linkName Name of link to find
+/// \param[in] _ecm Entity component manager
+Entity findLinkInModel(const std::string& _modelName,
+                       const std::string& _linkName,
+                       const gz::sim::EntityComponentManager& _ecm) {
+  auto entitiesMatchingName = entitiesFromScopedName(_modelName, _ecm);
+
+  Entity modelEntity{kNullEntity};
+  if (entitiesMatchingName.size() == 1) {
+    modelEntity = *entitiesMatchingName.begin();
+  }
+  if (kNullEntity != modelEntity) {
+    return _ecm.EntityByComponents(components::Link(),
+                                   components::ParentEntity(modelEntity),
+                                   components::Name(_linkName));
+  } else {
+    // gzwarn << "Model " << _modelName << " could not be found.\n";
+  }
+  return kNullEntity;
+}
+
+}  // namespace
+
+namespace aic_gazebo {
+
+//////////////////////////////////////////////////
+void CableModeratorPlugin::Configure(const gz::sim::Entity& /*_entity*/,
+                            const std::shared_ptr<const sdf::Element>& _sdf,
+                            gz::sim::EntityComponentManager& _ecm,
+                            gz::sim::EventManager& _eventManager) {
+
+  gzdbg << "aic_gazebo::CableModeratorPlugin::Configure "
+        << std::endl;
+
+  auto cableElem = _sdf->FindElement("cable");
+  while (cableElem) {
+    CableConfig config;
+    auto nameElem = cableElem->FindElement("name");
+    if (nameElem) {
+      config.modelName = nameElem->Get<std::string>();
+    } else {
+      config.modelName = cableElem->Get<std::string>();
+    }
+
+    if (config.modelName.empty()) {
+      cableElem = cableElem->GetNextElement("cable");
+      continue;
+    }
+
+    if (cableElem->HasElement("cable_connection_0_link")) {
+      config.connection0LinkName = cableElem->Get<std::string>("cable_connection_0_link");
+    } else {
+      gzerr << "Missing <cable_connection_0_link> parameter." << std::endl;
+      cableElem = cableElem->GetNextElement("cable");
+      continue;
+    }
+
+    if (cableElem->HasElement("cable_connection_0_port")) {
+      config.connection0PortName = cableElem->Get<std::string>("cable_connection_0_port");
+    } else {
+      gzerr << "Missing <cable_connection_0_port> parameter." << std::endl;
+      cableElem = cableElem->GetNextElement("cable");
+      continue;
+    }
+
+    if (cableElem->HasElement("cable_connection_1_link")) {
+      config.connection1LinkName = cableElem->Get<std::string>("cable_connection_1_link");
+    } else {
+      gzerr << "Missing <cable_connection_1_link> parameter." << std::endl;
+      cableElem = cableElem->GetNextElement("cable");
+      continue;
+    }
+
+    if (cableElem->HasElement("cable_connection_1_port")) {
+      config.connection1PortName = cableElem->Get<std::string>("cable_connection_1_port");
+    } else {
+      gzerr << "Missing <cable_connection_1_port> parameter." << std::endl;
+      cableElem = cableElem->GetNextElement("cable");
+      continue;
+    }
+
+    this->cableConfigs.push_back(config);
+    cableElem = cableElem->GetNextElement("cable");
+  }
+
+  if (this->cableConfigs.empty()) {
+    gzerr << "Missing valid <cable> parameters." << std::endl;
+    return;
+  }
+
+  if (_sdf->HasElement("end_effector_model")) {
+    this->endEffectorModelName = _sdf->Get<std::string>("end_effector_model");
+  } else {
+    gzerr << "Missing <end_effector_model> parameter." << std::endl;
+    return;
+  }
+
+  if (_sdf->HasElement("end_effector_link")) {
+    this->endEffectorLinkName = _sdf->Get<std::string>("end_effector_link");
+  } else {
+    gzerr << "Missing <end_effector_link> parameter." << std::endl;
+    return;
+  }
+
+  this->endEffectorOffset =
+      _sdf->Get<math::Pose3d>("end_effector_offset", kEndEffectorOffset).first;
+
+  double delay = _sdf->Get<double>("create_connection_delay_s", 0.0).first;
+  this->createJointDelay = delay;
+
+  if (_sdf->HasElement("grasp_distance_threshold")) {
+    this->graspDistanceThreshold = _sdf->Get<double>("grasp_distance_threshold", 0.006).first;
+  }
+
+  this->creator = std::make_unique<SdfEntityCreator>(_ecm, _eventManager);
+
+  this->taskCompletionPub = this->node.Advertise<gz::msgs::StringMsg>(
+      "/cable_moderator/insertion_event");
+
+  gzmsg << "Cable transitioning to HARNESS state." << std::endl;
+  this->cableState = CableState::HARNESS;
+}
+
+//////////////////////////////////////////////////
+void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& _info,
+                            gz::sim::EntityComponentManager& _ecm) {
+  if (this->cableState == CableState::CABLE_REMOVED || this->cableState == CableState::COMPLETED)
+    return;
+
+  if (this->cableModels.empty()) {
+    if (!this->FindCableModels(_ecm))
+      return;
+
+    this->ToggleActiveCable(_ecm);
+  }
+
+  if (this->endEffectorLinkEntity == kNullEntity) {
+    this->endEffectorLinkEntity =
+        findLinkInModel(this->endEffectorModelName, endEffectorLinkName, _ecm);
+  }
+  if (this->endEffectorLinkEntity == kNullEntity)
+    return;
+
+
+  // if (this->cableConnection0LinkEntity == kNullEntity) {
+  //   this->cableConnection0LinkEntity =
+  //       findLinkInModel(this->cableModelName, this->cableConfigs[this->cableIndex - 1].connection0LinkName, _ecm);
+  // }
+
+  // if (this->cableConnection1LinkEntity == kNullEntity) {
+  //   this->cableConnection1LinkEntity =
+  //       findLinkInModel(this->cableModelName, this->cableConfigs[this->cableIndex - 1].connection1LinkName, _ecm);
+  // }
+
+  // if (this->endEffectorLinkEntity == kNullEntity ||
+  //     this->cableConnection0LinkEntity == kNullEntity ||
+  //     this->cableConnection1LinkEntity == kNullEntity)
+  //   return;
+
+  if (this->cableState == CableState::HARNESS) {
+    // Hold both connections of the cable in place
+    this->detachableJointStatic0Entity = this->MakeStatic(
+        this->cableConnection0LinkEntity, true, this->creator.get(), _ecm);
+    this->detachableJointStatic1Entity = this->MakeStatic(
+        this->cableConnection1LinkEntity, true, this->creator.get(), _ecm);
+
+    this->createJointDelayStartTime =
+        std::chrono::duration_cast<std::chrono::seconds>(_info.simTime).count();
+
+    gzmsg << "Cable transitioning to WAITING_CONN_0 state." << std::endl;
+    this->cableState = CableState::WAITING_CONN_0;
+  }
+
+  if (this->cableState == CableState::WAITING_CONN_0) {
+    if (this->HandleGrasping(this->cableConnection0LinkEntity,
+                             this->detachableJointStatic0Entity,
+                             this->detachableJoint0Entity, _ecm)) {
+      gzmsg << "Cable transitioning to ATTACHED_TO_GRIPPER_CONN_0 state." << std::endl;
+      this->cableState = CableState::ATTACHED_TO_GRIPPER_CONN_0;
+    }
+  }
+
+  if (this->cableState == CableState::ATTACHED_TO_GRIPPER_CONN_0) {
+    if (this->cableConnection0PortTopics.empty()) {
+      std::vector<std::string> allTopics;
+      this->node.TopicList(allTopics);
+
+      for (const auto& topic : allTopics) {
+        if (topic.find(this->cableConfigs[this->cableIndex - 1].connection0PortName) != std::string::npos) {
+          this->cableConnection0PortTopics.insert(topic);
+        }
+      }
+
+      if (this->cableConnection0PortTopics.empty()) return;
+
+      std::function<void(const msgs::Boolean&, const transport::MessageInfo&)>
+          callback = [this](const msgs::Boolean& _msg,
+                            const transport::MessageInfo& _info) {
+        size_t pos = _info.Topic().rfind("/");
+        this->touchEventCallbackNamespace = _info.Topic().substr(0, pos);
+        this->attachCableConnection0ToPort = _msg.data();
+        gzdbg << "Cable connection 0 touched: " << _msg.data()
+              << ". Topic: " << _info.Topic() << std::endl;
+      };
+
+      for (const auto& topic : this->cableConnection0PortTopics) {
+        this->cableConnection0PortSubs.emplace_back(
+            this->node.CreateSubscriber(topic, callback));
+      }
+    }
+
+    if (this->attachCableConnection0ToPort) {
+      gzmsg << "Cable transitioning to ATTACH_TO_PORT_CONN_0 state." << std::endl;
+      this->cableState = CableState::ATTACH_TO_PORT_CONN_0;
+    }
+  }
+
+  if (this->cableState == CableState::ATTACH_TO_PORT_CONN_0) {
+    if (this->detachableJoint0Entity != kNullEntity) {
+      _ecm.RequestRemoveEntity(this->detachableJoint0Entity);
+      this->detachableJoint0Entity = kNullEntity;
+    }
+
+    this->detachableJointStatic0Entity = this->MakeStatic(
+        this->cableConnection0LinkEntity, true, this->creator.get(), _ecm);
+    this->lockingJoints.push_back(this->detachableJointStatic0Entity);
+
+    gzmsg << "Cable transitioning to WAITING_CONN_1 state." << std::endl;
+    this->cableState = CableState::WAITING_CONN_1;
+  }
+
+  if (this->cableState == CableState::WAITING_CONN_1) {
+    if (this->HandleGrasping(this->cableConnection1LinkEntity,
+                             this->detachableJointStatic1Entity,
+                             this->detachableJoint1Entity, _ecm)) {
+      gzmsg << "Cable transitioning to ATTACHED_TO_GRIPPER_CONN_1 state." << std::endl;
+      this->cableState = CableState::ATTACHED_TO_GRIPPER_CONN_1;
+    }
+  }
+
+  if (this->cableState == CableState::ATTACHED_TO_GRIPPER_CONN_1) {
+    if (this->cableConnection1PortTopics.empty()) {
+      std::vector<std::string> allTopics;
+      this->node.TopicList(allTopics);
+
+      for (const auto& topic : allTopics) {
+        if (topic.find(this->cableConfigs[this->cableIndex - 1].connection1PortName) != std::string::npos) {
+          this->cableConnection1PortTopics.insert(topic);
+        }
+      }
+
+      if (this->cableConnection1PortTopics.empty()) return;
+
+      std::function<void(const msgs::Boolean&, const transport::MessageInfo&)>
+          callback = [this](const msgs::Boolean& _msg,
+                            const transport::MessageInfo& _info) {
+        size_t pos = _info.Topic().rfind("/");
+        this->touchEventCallbackNamespace = _info.Topic().substr(0, pos);
+        this->attachCableConnection1ToPort = _msg.data();
+        gzdbg << "Cable connection 1 touched: " << _msg.data()
+              << ". Topic: " << _info.Topic() << std::endl;
+      };
+
+      for (const auto& topic : this->cableConnection1PortTopics) {
+        this->cableConnection1PortSubs.emplace_back(
+            this->node.CreateSubscriber(topic, callback));
+      }
+    }
+
+    if (this->attachCableConnection1ToPort) {
+      gzmsg << "Cable transitioning to ATTACH_TO_PORT_CONN_1 state." << std::endl;
+      this->cableState = CableState::ATTACH_TO_PORT_CONN_1;
+    }
+  }
+
+  if (this->cableState == CableState::ATTACH_TO_PORT_CONN_1) {
+    if (this->detachableJoint1Entity != kNullEntity) {
+      _ecm.RequestRemoveEntity(this->detachableJoint1Entity);
+      this->detachableJoint1Entity = kNullEntity;
+    }
+
+    this->detachableJointStatic1Entity = this->MakeStatic(
+        this->cableConnection1LinkEntity, true, this->creator.get(), _ecm);
+    this->lockingJoints.push_back(this->detachableJointStatic1Entity);
+
+    gzmsg << "Cable transitioning to NEXT_CABLE state." << std::endl;
+    this->cableState = CableState::NEXT_CABLE;
+  }
+
+  if (this->cableState == CableState::NEXT_CABLE) {
+    this->cableConnection0PortTopics.clear();
+    this->cableConnection0PortSubs.clear();
+    this->attachCableConnection0ToPort = false;
+
+    this->cableConnection1PortTopics.clear();
+    this->cableConnection1PortSubs.clear();
+    this->attachCableConnection1ToPort = false;
+
+    if (this->cableIndex < this->cableModels.size()) {
+      if (this->ToggleActiveCable(_ecm)) {
+        gzmsg << "Cable transitioning to HARNESS state for next cable." << std::endl;
+        this->cableState = CableState::HARNESS;
+      } else {
+        gzmsg << "Failed to toggle active cable. Transitioning to COMPLETED state." << std::endl;
+        this->cableState = CableState::COMPLETED;
+      }
+    } else {
+      gz::msgs::StringMsg msg;
+      msg.set_data("all_cables_completed");
+      this->taskCompletionPub.Publish(msg);
+
+      gzmsg << "All cables processed. Transitioning to COMPLETED state." << std::endl;
+      this->cableState = CableState::COMPLETED;
+    }
+  }
+}
+
+//////////////////////////////////////////////////
+void CableModeratorPlugin::Update(const gz::sim::UpdateInfo& /*_info*/,
+                         gz::sim::EntityComponentManager& /*_ecm*/) {}
+
+//////////////////////////////////////////////////
+void CableModeratorPlugin::PostUpdate(const gz::sim::UpdateInfo& /*_info*/,
+                             const gz::sim::EntityComponentManager& /*_ecm*/) {}
+
+//////////////////////////////////////////////////
+void CableModeratorPlugin::Reset(const gz::sim::UpdateInfo& /*_info*/,
+                        gz::sim::EntityComponentManager& /*_ecm*/) {
+  gzdbg << "aic_gazebo::CableModeratorPlugin::Reset" << std::endl;
+}
+
+//////////////////////////////////////////////////
+bool CableModeratorPlugin::IsModelValid(const gz::sim::EntityComponentManager& _ecm) {
+  bool modelValid = true;
+  _ecm.EachRemoved<components::Model>(
+      [&](const Entity& _entity, const components::Model*) -> bool {
+        if (_entity == this->cableModel.Entity()) {
+          modelValid = false;
+          return false;
+        }
+        return true;
+      });
+
+  return modelValid;
+}
+
+//////////////////////////////////////////////////
+void CableModeratorPlugin::Cleanup(gz::sim::EntityComponentManager& _ecm) {
+  if (this->detachableJointStatic0Entity != kNullEntity)
+    _ecm.RequestRemoveEntity(this->detachableJointStatic0Entity);
+  if (this->detachableJointStatic1Entity != kNullEntity)
+    _ecm.RequestRemoveEntity(this->detachableJointStatic1Entity);
+  if (this->detachableJoint0Entity != kNullEntity)
+    _ecm.RequestRemoveEntity(this->detachableJoint0Entity);
+  if (this->detachableJoint1Entity != kNullEntity)
+    _ecm.RequestRemoveEntity(this->detachableJoint1Entity);
+
+  for (const auto& ent : this->lockingJoints) {
+    if (ent != kNullEntity) {
+      _ecm.RequestRemoveEntity(ent);
+    }
+  }
+
+  for (const auto& ent : this->staticEntities) {
+    if (ent != kNullEntity) {
+      _ecm.RequestRemoveEntity(ent);
+    }
+  }
+
+  this->staticEntities.clear();
+  this->lockingJoints.clear();
+}
+
+//////////////////////////////////////////////////
+Entity CableModeratorPlugin::MakeStatic(Entity _entity,
+                               bool _attachEntityAsParentOfJoint,
+                               SdfEntityCreator* _creator,
+                               EntityComponentManager& _ecm) {
+  Entity detachableJointEntity = kNullEntity;
+
+  static sdf::Model staticModelToSpawn;
+  if (staticModelToSpawn.LinkCount() == 0u) {
+    sdf::ElementPtr staticModelSDF(new sdf::Element);
+    sdf::initFile("model.sdf", staticModelSDF);
+    staticModelSDF->GetAttribute("name")->Set("static_model");
+    staticModelSDF->GetElement("static")->Set(true);
+    sdf::ElementPtr linkElem = staticModelSDF->AddElement("link");
+    linkElem->GetAttribute("name")->Set("static_link");
+    staticModelToSpawn.Load(staticModelSDF);
+  }
+
+  auto nameComp = _ecm.Component<components::Name>(_entity);
+  std::string staticEntName = nameComp->Data() + "__static__";
+  Entity staticEntity =
+      _ecm.EntityByComponents(components::Name(staticEntName));
+  if (staticEntity == kNullEntity) {
+    staticModelToSpawn.SetName(staticEntName);
+    staticEntity = _creator->CreateEntities(&staticModelToSpawn);
+    this->staticEntities.insert(staticEntity);
+    _creator->SetParent(staticEntity,
+                        _ecm.EntityByComponents(components::World()));
+  }
+
+  Entity staticLinkEntity = _ecm.EntityByComponents(
+      components::Link(), components::ParentEntity(staticEntity),
+      components::Name("static_link"));
+
+  if (staticLinkEntity == kNullEntity) return detachableJointEntity;
+
+  Entity parentLinkEntity;
+  Entity childLinkEntity;
+  if (_attachEntityAsParentOfJoint) {
+    parentLinkEntity = _entity;
+    childLinkEntity = staticLinkEntity;
+  } else {
+    parentLinkEntity = staticLinkEntity;
+    childLinkEntity = _entity;
+  }
+
+  detachableJointEntity = _ecm.CreateEntity();
+  _ecm.CreateComponent(detachableJointEntity,
+                       components::DetachableJoint(
+                           {parentLinkEntity, childLinkEntity, "fixed"}));
+
+  return detachableJointEntity;
+}
+
+//////////////////////////////////////////////////
+bool CableModeratorPlugin::HandleGrasping(gz::sim::Entity _connectionLinkEntity,
+                                          gz::sim::Entity& _detachableJointStaticEntity,
+                                          gz::sim::Entity& _detachableJointEntity,
+                                          gz::sim::EntityComponentManager& _ecm) {
+  auto eeLinkWorldPose = gz::sim::worldPose(this->endEffectorLinkEntity, _ecm);
+  auto eeLinkOffsetWorldPose = eeLinkWorldPose * this->endEffectorOffset;
+  auto connPose = gz::sim::worldPose(_connectionLinkEntity, _ecm);
+
+  std::cerr <<  "====== grasp dis " << eeLinkOffsetWorldPose.Pos().Distance(connPose.Pos())  << std::endl;
+  if (eeLinkOffsetWorldPose.Pos().Distance(connPose.Pos()) < this->graspDistanceThreshold) {
+    if (_detachableJointStaticEntity != kNullEntity) {
+      _ecm.RequestRemoveEntity(_detachableJointStaticEntity);
+      _detachableJointStaticEntity = kNullEntity;
+    }
+
+    _detachableJointEntity = _ecm.CreateEntity();
+    _ecm.CreateComponent(_detachableJointEntity,
+                         components::DetachableJoint(
+                             {this->endEffectorLinkEntity,
+                              _connectionLinkEntity, "fixed"}));
+    return true;
+  }
+  return false;
+}
+
+//////////////////////////////////////////////////
+bool CableModeratorPlugin::FindCableModels(
+    const gz::sim::EntityComponentManager& _ecm) {
+
+  for (const auto& config : this->cableConfigs) {
+    auto entitiesMatchingName = entitiesFromScopedName(config.modelName, _ecm);
+    Entity modelEntity{kNullEntity};
+    if (entitiesMatchingName.size() == 1) {
+      modelEntity = *entitiesMatchingName.begin();
+      this->cableModels.push_back(modelEntity);
+      gzmsg << " ============================================ Found cable model: " << config.modelName << std::endl;
+    }
+     else {
+      gzwarn << "Cable model " << config.modelName << " could not be found.\n";
+    }
+  }
+
+  if (this->cableModels.empty())
+    return false;
+  return true;
+}
+
+
+//////////////////////////////////////////////////
+bool CableModeratorPlugin::ToggleActiveCable(
+    const gz::sim::EntityComponentManager& _ecm) {
+
+  // TODO make prev cable static?
+
+  this->cableModel = Model(this->cableModels[this->cableIndex]);
+  this->cableModelName = this->cableModel.Name(_ecm);
+
+  if (!this->cableModel.Valid(_ecm))
+    return false;
+
+  const auto& config = this->cableConfigs[this->cableIndex];
+
+  this->cableConnection0LinkEntity =
+      findLinkInModel(this->cableModelName, config.connection0LinkName, _ecm);
+
+  this->cableConnection1LinkEntity =
+      findLinkInModel(this->cableModelName, config.connection1LinkName, _ecm);
+
+  if (this->cableConnection0LinkEntity == kNullEntity ||
+      this->cableConnection1LinkEntity == kNullEntity)
+    return false;
+
+  this->cableIndex++;
+
+  return true;
+}
+
+
+}  // namespace aic_gazebo

--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -78,13 +78,12 @@ Entity findLinkInModel(const std::string& _modelName,
 namespace aic_gazebo {
 
 //////////////////////////////////////////////////
-void CableModeratorPlugin::Configure(const gz::sim::Entity& /*_entity*/,
-                            const std::shared_ptr<const sdf::Element>& _sdf,
-                            gz::sim::EntityComponentManager& _ecm,
-                            gz::sim::EventManager& _eventManager) {
-
-  gzdbg << "aic_gazebo::CableModeratorPlugin::Configure "
-        << std::endl;
+void CableModeratorPlugin::Configure(
+    const gz::sim::Entity& /*_entity*/,
+    const std::shared_ptr<const sdf::Element>& _sdf,
+    gz::sim::EntityComponentManager& _ecm,
+    gz::sim::EventManager& _eventManager) {
+  gzdbg << "aic_gazebo::CableModeratorPlugin::Configure " << std::endl;
 
   auto cableElem = _sdf->FindElement("cable");
   while (cableElem) {
@@ -102,7 +101,8 @@ void CableModeratorPlugin::Configure(const gz::sim::Entity& /*_entity*/,
     }
 
     if (cableElem->HasElement("cable_connection_0_link")) {
-      config.connection0LinkName = cableElem->Get<std::string>("cable_connection_0_link");
+      config.connection0LinkName =
+          cableElem->Get<std::string>("cable_connection_0_link");
     } else {
       gzerr << "Missing <cable_connection_0_link> parameter." << std::endl;
       cableElem = cableElem->GetNextElement("cable");
@@ -110,7 +110,8 @@ void CableModeratorPlugin::Configure(const gz::sim::Entity& /*_entity*/,
     }
 
     if (cableElem->HasElement("cable_connection_0_port")) {
-      config.connection0PortName = cableElem->Get<std::string>("cable_connection_0_port");
+      config.connection0PortName =
+          cableElem->Get<std::string>("cable_connection_0_port");
     } else {
       gzerr << "Missing <cable_connection_0_port> parameter." << std::endl;
       cableElem = cableElem->GetNextElement("cable");
@@ -118,7 +119,8 @@ void CableModeratorPlugin::Configure(const gz::sim::Entity& /*_entity*/,
     }
 
     if (cableElem->HasElement("cable_connection_1_link")) {
-      config.connection1LinkName = cableElem->Get<std::string>("cable_connection_1_link");
+      config.connection1LinkName =
+          cableElem->Get<std::string>("cable_connection_1_link");
     } else {
       gzerr << "Missing <cable_connection_1_link> parameter." << std::endl;
       cableElem = cableElem->GetNextElement("cable");
@@ -126,7 +128,8 @@ void CableModeratorPlugin::Configure(const gz::sim::Entity& /*_entity*/,
     }
 
     if (cableElem->HasElement("cable_connection_1_port")) {
-      config.connection1PortName = cableElem->Get<std::string>("cable_connection_1_port");
+      config.connection1PortName =
+          cableElem->Get<std::string>("cable_connection_1_port");
     } else {
       gzerr << "Missing <cable_connection_1_port> parameter." << std::endl;
       cableElem = cableElem->GetNextElement("cable");
@@ -159,11 +162,11 @@ void CableModeratorPlugin::Configure(const gz::sim::Entity& /*_entity*/,
   this->endEffectorOffset =
       _sdf->Get<math::Pose3d>("end_effector_offset", kEndEffectorOffset).first;
 
-  double delay = _sdf->Get<double>("create_connection_delay_s", 0.0).first;
-  this->createJointDelay = delay;
-
   if (_sdf->HasElement("grasp_distance_threshold")) {
-    this->graspDistanceThreshold = _sdf->Get<double>("grasp_distance_threshold", 0.006).first;
+    this->graspDistanceThreshold =
+        _sdf->Get<double>("grasp_distance_threshold",
+                          this->graspDistanceThreshold)
+            .first;
   }
 
   this->creator = std::make_unique<SdfEntityCreator>(_ecm, _eventManager);
@@ -171,55 +174,31 @@ void CableModeratorPlugin::Configure(const gz::sim::Entity& /*_entity*/,
   this->taskCompletionPub = this->node.Advertise<gz::msgs::StringMsg>(
       "/cable_moderator/insertion_event");
 
-  gzmsg << "Cable transitioning to HARNESS state." << std::endl;
-  this->cableState = CableState::HARNESS;
+  gzmsg << "Initializing to NEXT_CABLE state." << std::endl;
+  this->cableState = CableState::NEXT_CABLE;
 }
 
 //////////////////////////////////////////////////
-void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& _info,
-                            gz::sim::EntityComponentManager& _ecm) {
-  if (this->cableState == CableState::CABLE_REMOVED || this->cableState == CableState::COMPLETED)
-    return;
+void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
+                                     gz::sim::EntityComponentManager& _ecm) {
+  if (this->cableState == CableState::COMPLETED) return;
 
   if (this->cableModels.empty()) {
-    if (!this->FindCableModels(_ecm))
-      return;
-
-    this->ToggleActiveCable(_ecm);
+    if (!this->FindCableModels(_ecm)) return;
   }
 
   if (this->endEffectorLinkEntity == kNullEntity) {
     this->endEffectorLinkEntity =
         findLinkInModel(this->endEffectorModelName, endEffectorLinkName, _ecm);
   }
-  if (this->endEffectorLinkEntity == kNullEntity)
-    return;
-
-
-  // if (this->cableConnection0LinkEntity == kNullEntity) {
-  //   this->cableConnection0LinkEntity =
-  //       findLinkInModel(this->cableModelName, this->cableConfigs[this->cableIndex - 1].connection0LinkName, _ecm);
-  // }
-
-  // if (this->cableConnection1LinkEntity == kNullEntity) {
-  //   this->cableConnection1LinkEntity =
-  //       findLinkInModel(this->cableModelName, this->cableConfigs[this->cableIndex - 1].connection1LinkName, _ecm);
-  // }
-
-  // if (this->endEffectorLinkEntity == kNullEntity ||
-  //     this->cableConnection0LinkEntity == kNullEntity ||
-  //     this->cableConnection1LinkEntity == kNullEntity)
-  //   return;
+  if (this->endEffectorLinkEntity == kNullEntity) return;
 
   if (this->cableState == CableState::HARNESS) {
     // Hold both connections of the cable in place
-    this->detachableJointStatic0Entity = this->MakeStatic(
-        this->cableConnection0LinkEntity, true, this->creator.get(), _ecm);
-    this->detachableJointStatic1Entity = this->MakeStatic(
-        this->cableConnection1LinkEntity, true, this->creator.get(), _ecm);
-
-    this->createJointDelayStartTime =
-        std::chrono::duration_cast<std::chrono::seconds>(_info.simTime).count();
+    this->detachableJointStatic0Entity =
+        this->MakeStatic(this->cableConnection0LinkEntity, true, _ecm);
+    this->detachableJointStatic1Entity =
+        this->MakeStatic(this->cableConnection1LinkEntity, true, _ecm);
 
     gzmsg << "Cable transitioning to WAITING_CONN_0 state." << std::endl;
     this->cableState = CableState::WAITING_CONN_0;
@@ -227,57 +206,37 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& _info,
 
   if (this->cableState == CableState::WAITING_CONN_0) {
     if (this->HandleGrasping(this->cableConnection0LinkEntity,
-                             this->detachableJointStatic0Entity,
-                             this->detachableJoint0Entity, _ecm)) {
-      gzmsg << "Cable transitioning to ATTACHED_TO_GRIPPER_CONN_0 state." << std::endl;
+                             this->detachableJointStatic0Entity, _ecm)) {
+      gzmsg << "Cable transitioning to ATTACHED_TO_GRIPPER_CONN_0 state."
+            << std::endl;
       this->cableState = CableState::ATTACHED_TO_GRIPPER_CONN_0;
     }
   }
 
   if (this->cableState == CableState::ATTACHED_TO_GRIPPER_CONN_0) {
-    if (this->cableConnection0PortTopics.empty()) {
-      std::vector<std::string> allTopics;
-      this->node.TopicList(allTopics);
-
-      for (const auto& topic : allTopics) {
-        if (topic.find(this->cableConfigs[this->cableIndex - 1].connection0PortName) != std::string::npos) {
-          this->cableConnection0PortTopics.insert(topic);
-        }
-      }
-
-      if (this->cableConnection0PortTopics.empty()) return;
-
-      std::function<void(const msgs::Boolean&, const transport::MessageInfo&)>
-          callback = [this](const msgs::Boolean& _msg,
-                            const transport::MessageInfo& _info) {
-        size_t pos = _info.Topic().rfind("/");
-        this->touchEventCallbackNamespace = _info.Topic().substr(0, pos);
-        this->attachCableConnection0ToPort = _msg.data();
-        gzdbg << "Cable connection 0 touched: " << _msg.data()
-              << ". Topic: " << _info.Topic() << std::endl;
-      };
-
-      for (const auto& topic : this->cableConnection0PortTopics) {
-        this->cableConnection0PortSubs.emplace_back(
-            this->node.CreateSubscriber(topic, callback));
-      }
+    if (this->cableConnectionPortSubs.empty()) {
+      this->CreatePortSubscribers(
+          this->cableConfigs[this->cableIndex - 1].connection0PortName);
     }
 
-    if (this->attachCableConnection0ToPort) {
-      gzmsg << "Cable transitioning to ATTACH_TO_PORT_CONN_0 state." << std::endl;
+    if (this->attachCableConnectionToPort) {
+      gzmsg << "Cable transitioning to ATTACH_TO_PORT_CONN_0 state."
+            << std::endl;
       this->cableState = CableState::ATTACH_TO_PORT_CONN_0;
     }
   }
 
   if (this->cableState == CableState::ATTACH_TO_PORT_CONN_0) {
-    if (this->detachableJoint0Entity != kNullEntity) {
-      _ecm.RequestRemoveEntity(this->detachableJoint0Entity);
-      this->detachableJoint0Entity = kNullEntity;
+    this->cableConnectionPortSubs.clear();
+    this->attachCableConnectionToPort = false;
+    this->touchEventCallbackNamespace = std::nullopt;
+    if (this->detachableJointGripperConnEntity != kNullEntity) {
+      _ecm.RequestRemoveEntity(this->detachableJointGripperConnEntity);
+      this->detachableJointGripperConnEntity = kNullEntity;
     }
 
-    this->detachableJointStatic0Entity = this->MakeStatic(
-        this->cableConnection0LinkEntity, true, this->creator.get(), _ecm);
-    this->lockingJoints.push_back(this->detachableJointStatic0Entity);
+    this->detachableJointStatic0Entity =
+        this->MakeStatic(this->cableConnection0LinkEntity, true, _ecm);
 
     gzmsg << "Cable transitioning to WAITING_CONN_1 state." << std::endl;
     this->cableState = CableState::WAITING_CONN_1;
@@ -285,77 +244,53 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& _info,
 
   if (this->cableState == CableState::WAITING_CONN_1) {
     if (this->HandleGrasping(this->cableConnection1LinkEntity,
-                             this->detachableJointStatic1Entity,
-                             this->detachableJoint1Entity, _ecm)) {
-      gzmsg << "Cable transitioning to ATTACHED_TO_GRIPPER_CONN_1 state." << std::endl;
+                             this->detachableJointStatic1Entity, _ecm)) {
+      gzmsg << "Cable transitioning to ATTACHED_TO_GRIPPER_CONN_1 state."
+            << std::endl;
       this->cableState = CableState::ATTACHED_TO_GRIPPER_CONN_1;
     }
   }
 
   if (this->cableState == CableState::ATTACHED_TO_GRIPPER_CONN_1) {
-    if (this->cableConnection1PortTopics.empty()) {
-      std::vector<std::string> allTopics;
-      this->node.TopicList(allTopics);
-
-      for (const auto& topic : allTopics) {
-        if (topic.find(this->cableConfigs[this->cableIndex - 1].connection1PortName) != std::string::npos) {
-          this->cableConnection1PortTopics.insert(topic);
-        }
-      }
-
-      if (this->cableConnection1PortTopics.empty()) return;
-
-      std::function<void(const msgs::Boolean&, const transport::MessageInfo&)>
-          callback = [this](const msgs::Boolean& _msg,
-                            const transport::MessageInfo& _info) {
-        size_t pos = _info.Topic().rfind("/");
-        this->touchEventCallbackNamespace = _info.Topic().substr(0, pos);
-        this->attachCableConnection1ToPort = _msg.data();
-        gzdbg << "Cable connection 1 touched: " << _msg.data()
-              << ". Topic: " << _info.Topic() << std::endl;
-      };
-
-      for (const auto& topic : this->cableConnection1PortTopics) {
-        this->cableConnection1PortSubs.emplace_back(
-            this->node.CreateSubscriber(topic, callback));
-      }
+    if (this->cableConnectionPortSubs.empty()) {
+      this->CreatePortSubscribers(
+          this->cableConfigs[this->cableIndex - 1].connection1PortName);
     }
 
-    if (this->attachCableConnection1ToPort) {
-      gzmsg << "Cable transitioning to ATTACH_TO_PORT_CONN_1 state." << std::endl;
+    if (this->attachCableConnectionToPort) {
+      gzmsg << "Cable transitioning to ATTACH_TO_PORT_CONN_1 state."
+            << std::endl;
       this->cableState = CableState::ATTACH_TO_PORT_CONN_1;
     }
   }
 
   if (this->cableState == CableState::ATTACH_TO_PORT_CONN_1) {
-    if (this->detachableJoint1Entity != kNullEntity) {
-      _ecm.RequestRemoveEntity(this->detachableJoint1Entity);
-      this->detachableJoint1Entity = kNullEntity;
+    if (this->detachableJointGripperConnEntity != kNullEntity) {
+      _ecm.RequestRemoveEntity(this->detachableJointGripperConnEntity);
+      this->detachableJointGripperConnEntity = kNullEntity;
     }
 
-    this->detachableJointStatic1Entity = this->MakeStatic(
-        this->cableConnection1LinkEntity, true, this->creator.get(), _ecm);
-    this->lockingJoints.push_back(this->detachableJointStatic1Entity);
+    this->detachableJointStatic1Entity =
+        this->MakeStatic(this->cableConnection1LinkEntity, true, _ecm);
 
     gzmsg << "Cable transitioning to NEXT_CABLE state." << std::endl;
     this->cableState = CableState::NEXT_CABLE;
   }
 
   if (this->cableState == CableState::NEXT_CABLE) {
-    this->cableConnection0PortTopics.clear();
-    this->cableConnection0PortSubs.clear();
-    this->attachCableConnection0ToPort = false;
-
-    this->cableConnection1PortTopics.clear();
-    this->cableConnection1PortSubs.clear();
-    this->attachCableConnection1ToPort = false;
+    this->cableConnectionPortSubs.clear();
+    this->attachCableConnectionToPort = false;
+    this->touchEventCallbackNamespace = std::nullopt;
 
     if (this->cableIndex < this->cableModels.size()) {
       if (this->ToggleActiveCable(_ecm)) {
-        gzmsg << "Cable transitioning to HARNESS state for next cable." << std::endl;
+        gzmsg << "Cable transitioning to HARNESS state for next cable."
+              << std::endl;
         this->cableState = CableState::HARNESS;
       } else {
-        gzmsg << "Failed to toggle active cable. Transitioning to COMPLETED state." << std::endl;
+        gzmsg << "Failed to toggle active cable. Transitioning to COMPLETED "
+                 "state."
+              << std::endl;
         this->cableState = CableState::COMPLETED;
       }
     } else {
@@ -363,7 +298,8 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& _info,
       msg.set_data("all_cables_completed");
       this->taskCompletionPub.Publish(msg);
 
-      gzmsg << "All cables processed. Transitioning to COMPLETED state." << std::endl;
+      gzmsg << "All cables processed. Transitioning to COMPLETED state."
+            << std::endl;
       this->cableState = CableState::COMPLETED;
     }
   }
@@ -371,31 +307,17 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& _info,
 
 //////////////////////////////////////////////////
 void CableModeratorPlugin::Update(const gz::sim::UpdateInfo& /*_info*/,
-                         gz::sim::EntityComponentManager& /*_ecm*/) {}
+                                  gz::sim::EntityComponentManager& /*_ecm*/) {}
 
 //////////////////////////////////////////////////
-void CableModeratorPlugin::PostUpdate(const gz::sim::UpdateInfo& /*_info*/,
-                             const gz::sim::EntityComponentManager& /*_ecm*/) {}
+void CableModeratorPlugin::PostUpdate(
+    const gz::sim::UpdateInfo& /*_info*/,
+    const gz::sim::EntityComponentManager& /*_ecm*/) {}
 
 //////////////////////////////////////////////////
 void CableModeratorPlugin::Reset(const gz::sim::UpdateInfo& /*_info*/,
-                        gz::sim::EntityComponentManager& /*_ecm*/) {
+                                 gz::sim::EntityComponentManager& /*_ecm*/) {
   gzdbg << "aic_gazebo::CableModeratorPlugin::Reset" << std::endl;
-}
-
-//////////////////////////////////////////////////
-bool CableModeratorPlugin::IsModelValid(const gz::sim::EntityComponentManager& _ecm) {
-  bool modelValid = true;
-  _ecm.EachRemoved<components::Model>(
-      [&](const Entity& _entity, const components::Model*) -> bool {
-        if (_entity == this->cableModel.Entity()) {
-          modelValid = false;
-          return false;
-        }
-        return true;
-      });
-
-  return modelValid;
 }
 
 //////////////////////////////////////////////////
@@ -404,16 +326,8 @@ void CableModeratorPlugin::Cleanup(gz::sim::EntityComponentManager& _ecm) {
     _ecm.RequestRemoveEntity(this->detachableJointStatic0Entity);
   if (this->detachableJointStatic1Entity != kNullEntity)
     _ecm.RequestRemoveEntity(this->detachableJointStatic1Entity);
-  if (this->detachableJoint0Entity != kNullEntity)
-    _ecm.RequestRemoveEntity(this->detachableJoint0Entity);
-  if (this->detachableJoint1Entity != kNullEntity)
-    _ecm.RequestRemoveEntity(this->detachableJoint1Entity);
-
-  for (const auto& ent : this->lockingJoints) {
-    if (ent != kNullEntity) {
-      _ecm.RequestRemoveEntity(ent);
-    }
-  }
+  if (this->detachableJointGripperConnEntity != kNullEntity)
+    _ecm.RequestRemoveEntity(this->detachableJointGripperConnEntity);
 
   for (const auto& ent : this->staticEntities) {
     if (ent != kNullEntity) {
@@ -422,14 +336,12 @@ void CableModeratorPlugin::Cleanup(gz::sim::EntityComponentManager& _ecm) {
   }
 
   this->staticEntities.clear();
-  this->lockingJoints.clear();
 }
 
 //////////////////////////////////////////////////
 Entity CableModeratorPlugin::MakeStatic(Entity _entity,
-                               bool _attachEntityAsParentOfJoint,
-                               SdfEntityCreator* _creator,
-                               EntityComponentManager& _ecm) {
+                                        bool _attachEntityAsParentOfJoint,
+                                        EntityComponentManager& _ecm) {
   Entity detachableJointEntity = kNullEntity;
 
   static sdf::Model staticModelToSpawn;
@@ -449,10 +361,10 @@ Entity CableModeratorPlugin::MakeStatic(Entity _entity,
       _ecm.EntityByComponents(components::Name(staticEntName));
   if (staticEntity == kNullEntity) {
     staticModelToSpawn.SetName(staticEntName);
-    staticEntity = _creator->CreateEntities(&staticModelToSpawn);
+    staticEntity = this->creator->CreateEntities(&staticModelToSpawn);
     this->staticEntities.insert(staticEntity);
-    _creator->SetParent(staticEntity,
-                        _ecm.EntityByComponents(components::World()));
+    this->creator->SetParent(staticEntity,
+                             _ecm.EntityByComponents(components::World()));
   }
 
   Entity staticLinkEntity = _ecm.EntityByComponents(
@@ -463,6 +375,8 @@ Entity CableModeratorPlugin::MakeStatic(Entity _entity,
 
   Entity parentLinkEntity;
   Entity childLinkEntity;
+  // TODO(anyone) This function is never called with this argument set as false
+  // Check if we need it or we can remove it.
   if (_attachEntityAsParentOfJoint) {
     parentLinkEntity = _entity;
     childLinkEntity = staticLinkEntity;
@@ -480,26 +394,27 @@ Entity CableModeratorPlugin::MakeStatic(Entity _entity,
 }
 
 //////////////////////////////////////////////////
-bool CableModeratorPlugin::HandleGrasping(gz::sim::Entity _connectionLinkEntity,
-                                          gz::sim::Entity& _detachableJointStaticEntity,
-                                          gz::sim::Entity& _detachableJointEntity,
-                                          gz::sim::EntityComponentManager& _ecm) {
+bool CableModeratorPlugin::HandleGrasping(
+    gz::sim::Entity _connectionLinkEntity,
+    gz::sim::Entity& _detachableJointStaticEntity,
+    gz::sim::EntityComponentManager& _ecm) {
   auto eeLinkWorldPose = gz::sim::worldPose(this->endEffectorLinkEntity, _ecm);
   auto eeLinkOffsetWorldPose = eeLinkWorldPose * this->endEffectorOffset;
   auto connPose = gz::sim::worldPose(_connectionLinkEntity, _ecm);
 
-  std::cerr <<  "====== grasp dis " << eeLinkOffsetWorldPose.Pos().Distance(connPose.Pos())  << std::endl;
-  if (eeLinkOffsetWorldPose.Pos().Distance(connPose.Pos()) < this->graspDistanceThreshold) {
+  if (eeLinkOffsetWorldPose.Pos().Distance(connPose.Pos()) <
+      this->graspDistanceThreshold) {
+    // TODO(anyone) Add check for gripper joint state to make sure it is closed.
     if (_detachableJointStaticEntity != kNullEntity) {
       _ecm.RequestRemoveEntity(_detachableJointStaticEntity);
       _detachableJointStaticEntity = kNullEntity;
     }
 
-    _detachableJointEntity = _ecm.CreateEntity();
-    _ecm.CreateComponent(_detachableJointEntity,
-                         components::DetachableJoint(
-                             {this->endEffectorLinkEntity,
-                              _connectionLinkEntity, "fixed"}));
+    this->detachableJointGripperConnEntity = _ecm.CreateEntity();
+    _ecm.CreateComponent(
+        this->detachableJointGripperConnEntity,
+        components::DetachableJoint(
+            {this->endEffectorLinkEntity, _connectionLinkEntity, "fixed"}));
     return true;
   }
   return false;
@@ -508,45 +423,72 @@ bool CableModeratorPlugin::HandleGrasping(gz::sim::Entity _connectionLinkEntity,
 //////////////////////////////////////////////////
 bool CableModeratorPlugin::FindCableModels(
     const gz::sim::EntityComponentManager& _ecm) {
-
   for (const auto& config : this->cableConfigs) {
     auto entitiesMatchingName = entitiesFromScopedName(config.modelName, _ecm);
     Entity modelEntity{kNullEntity};
     if (entitiesMatchingName.size() == 1) {
       modelEntity = *entitiesMatchingName.begin();
       this->cableModels.push_back(modelEntity);
-      gzmsg << " ============================================ Found cable model: " << config.modelName << std::endl;
-    }
-     else {
+    } else {
       gzwarn << "Cable model " << config.modelName << " could not be found.\n";
     }
   }
 
-  if (this->cableModels.empty())
+  if (this->cableModels.size() != this->cableConfigs.size()) {
+    this->cableModels.clear();
     return false;
+  }
   return true;
 }
 
+//////////////////////////////////////////////////
+void CableModeratorPlugin::CreatePortSubscribers(const std::string& _portName) {
+  std::vector<std::string> allTopics;
+  this->node.TopicList(allTopics);
+
+  std::function<void(const msgs::Boolean&, const transport::MessageInfo&)>
+      callback = [this](const msgs::Boolean& _msg,
+                        const transport::MessageInfo& _info) {
+        size_t pos = _info.Topic().rfind("/");
+        // TODO(luca) If we only ever receive true boolean messages consider
+        // removing the atomic bool and only having the namespace as a
+        // std::optional
+        // TODO(luca) Protect the namespace with a mutex since it can't be
+        // atomic and it is set in a separate thread.
+        // TODO(luca) Check if we need the namespace at all, it is used to check
+        // if we plugged into the right port but this might be done by another
+        // plugin (scoring)
+        this->touchEventCallbackNamespace = _info.Topic().substr(0, pos);
+        this->attachCableConnectionToPort = _msg.data();
+        gzdbg << "Cable connection touched: " << _msg.data()
+              << ". Topic: " << _info.Topic() << std::endl;
+      };
+
+  for (const auto& topic : allTopics) {
+    if (topic.find(_portName) != std::string::npos &&
+        topic.find("touched") != std::string::npos) {
+      this->cableConnectionPortSubs.emplace_back(
+          this->node.CreateSubscriber(topic, callback));
+    }
+  }
+}
 
 //////////////////////////////////////////////////
 bool CableModeratorPlugin::ToggleActiveCable(
     const gz::sim::EntityComponentManager& _ecm) {
-
-  // TODO make prev cable static?
-
+  // TODO(anyone) make previous cable (including all links) static?
   this->cableModel = Model(this->cableModels[this->cableIndex]);
-  this->cableModelName = this->cableModel.Name(_ecm);
+  const auto cableModelName = this->cableModel.Name(_ecm);
 
-  if (!this->cableModel.Valid(_ecm))
-    return false;
+  if (!this->cableModel.Valid(_ecm)) return false;
 
   const auto& config = this->cableConfigs[this->cableIndex];
 
   this->cableConnection0LinkEntity =
-      findLinkInModel(this->cableModelName, config.connection0LinkName, _ecm);
+      findLinkInModel(cableModelName, config.connection0LinkName, _ecm);
 
   this->cableConnection1LinkEntity =
-      findLinkInModel(this->cableModelName, config.connection1LinkName, _ecm);
+      findLinkInModel(cableModelName, config.connection1LinkName, _ecm);
 
   if (this->cableConnection0LinkEntity == kNullEntity ||
       this->cableConnection1LinkEntity == kNullEntity)
@@ -556,6 +498,5 @@ bool CableModeratorPlugin::ToggleActiveCable(
 
   return true;
 }
-
 
 }  // namespace aic_gazebo

--- a/aic_gazebo/src/CableModeratorPlugin.hh
+++ b/aic_gazebo/src/CableModeratorPlugin.hh
@@ -1,0 +1,265 @@
+/*
+ * Copyright (C) 2026 Intrinsic Innovation LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef AIC_GAZEBO__CABLE_MODERATOR_PLUGIN_HH_
+#define AIC_GAZEBO__CABLE_MODERATOR_PLUGIN_HH_
+
+#include <atomic>
+#include <chrono>
+#include <unordered_set>
+
+#include <gz/transport/Node.hh>
+#include <gz/sim/EventManager.hh>
+#include <gz/sim/Model.hh>
+#include <gz/sim/SdfEntityCreator.hh>
+#include <gz/sim/System.hh>
+
+namespace aic_gazebo
+{
+  /// \brief State of the cable
+  enum class CableState {
+    /// \brief Harnessed to the world, i.e. made static
+    /// before creating connections
+    INITIALIZATION,
+
+    /// \brief Harnessed to the world, i.e. made static
+    /// before creating connections
+    HARNESS,
+
+    /// \brief Waiting for end effector to approach connection 0
+    WAITING_CONN_0,
+
+    /// \brief Connection 0 attached to gripper, wait for touch
+    ATTACHED_TO_GRIPPER_CONN_0,
+
+    /// \brief Detach connection 0 from gripper, make static
+    ATTACH_TO_PORT_CONN_0,
+
+    /// \brief Waiting for end effector to approach connection 1
+    WAITING_CONN_1,
+
+    /// \brief Connection 1 attached to gripper, wait for touch
+    ATTACHED_TO_GRIPPER_CONN_1,
+
+    /// \brief Detach connection 1 from gripper, make static
+    ATTACH_TO_PORT_CONN_1,
+
+    /// \brief Move to the next cable
+    NEXT_CABLE,
+
+    /// \brief Task complete - cable connections are completed
+    COMPLETED,
+
+    /// \brief Cable model is removed.
+    CABLE_REMOVED,
+  };
+
+  /// \brief Configuration for a cable
+  struct CableConfig {
+    /// \brief Name of the cable model
+    std::string modelName;
+
+    /// \brief Name of the cable connection 0 link
+    std::string connection0LinkName;
+
+    /// \brief Name of the cable connection 0 port
+    std::string connection0PortName;
+
+    /// \brief Name of the cable connection 1 link
+    std::string connection1LinkName;
+
+    /// \brief Name of the cable connection 1 port
+    std::string connection1PortName;
+  };
+
+  /// \brief Plugin for initializing the cable
+  /// It waits for end-effector / port to be ready before creating connections
+  /// with them using detachable joints.
+  class CableModeratorPlugin:
+    public gz::sim::System,
+    public gz::sim::ISystemConfigure,
+    public gz::sim::ISystemPreUpdate,
+    public gz::sim::ISystemUpdate,
+    public gz::sim::ISystemPostUpdate,
+    public gz::sim::ISystemReset
+  {
+    // Documentation inherited
+    public: void Configure(const gz::sim::Entity &_entity,
+                           const std::shared_ptr<const sdf::Element> &_element,
+                           gz::sim::EntityComponentManager &_ecm,
+                           gz::sim::EventManager &_eventManager) override;
+
+    // Documentation inherited
+    public: void PreUpdate(const gz::sim::UpdateInfo &_info,
+                           gz::sim::EntityComponentManager &_ecm) override;
+
+    // Documentation inherited
+    public: void Update(const gz::sim::UpdateInfo &_info,
+                        gz::sim::EntityComponentManager &_ecm) override;
+
+    // Documentation inherited
+    public: void PostUpdate(const gz::sim::UpdateInfo &_info,
+                          const gz::sim::EntityComponentManager &_ecm) override;
+
+    // Documentation inherited
+    public: void Reset(const gz::sim::UpdateInfo &_info,
+                       gz::sim::EntityComponentManager &_ecm) override;
+
+    /// \brief Check if model entity is removed
+    /// \param[in] _ecm Immutable reference to the Entity Component Manager.
+    private: bool IsModelValid(const gz::sim::EntityComponentManager& _ecm);
+
+    /// \brief Clean up entities created by this plugin
+    /// \param[in] _ecm Mutable reference to the Entity Component Manager.
+    private: void Cleanup(gz::sim::EntityComponentManager& _ecm);
+
+    /// \brief Make an entity static by spawning a static model and attaching
+    /// the entity to a static model
+    /// \param[in] _attachEntityAsParentOfJoint True to attach entity as parent of
+    /// the detachable joint.
+    /// \param[in] _creator Sdf entity creator for creating a static model
+    /// \param[in] _ecm Entity component manager
+    private: gz::sim::Entity MakeStatic(gz::sim::Entity _entity,
+                             bool _attachEntityAsParentOfJoint,
+                             gz::sim::SdfEntityCreator* _creator,
+                             gz::sim::EntityComponentManager& _ecm);
+
+    /// \brief Check end effector distance to connection and handle grasping
+    /// \param[in] _connectionLinkEntity The connection link to check
+    /// \param[in, out] _detachableJointStaticEntity The static joint holding it (removed if grasped)
+    /// \param[in, out] _detachableJointEntity The dynamic joint created for the grasp
+    /// \param[in] _ecm Entity Component Manager
+    /// \return True if grasped, false otherwise
+    private: bool HandleGrasping(gz::sim::Entity _connectionLinkEntity,
+                                 gz::sim::Entity& _detachableJointStaticEntity,
+                                 gz::sim::Entity& _detachableJointEntity,
+                                 gz::sim::EntityComponentManager& _ecm);
+
+    private: bool ToggleActiveCable(const gz::sim::EntityComponentManager& _ecm);
+
+    private: bool FindCableModels(const gz::sim::EntityComponentManager& _ecm);
+
+    /// \brief Entity of attachment link in the end effector model
+    private: gz::sim::Entity endEffectorLinkEntity{gz::sim::kNullEntity};
+
+    /// \brief Connection 0 link entity in the cable model
+    private: gz::sim::Entity cableConnection0LinkEntity{gz::sim::kNullEntity};
+
+    /// \brief Connection 1 link entity in the cable model
+    private: gz::sim::Entity cableConnection1LinkEntity{gz::sim::kNullEntity};
+
+    /// \brief Detachable joint entity for connection 0
+    private: gz::sim::Entity detachableJoint0Entity{gz::sim::kNullEntity};
+
+    /// \brief Detachable joint entity for connection 1
+    private: gz::sim::Entity detachableJoint1Entity{gz::sim::kNullEntity};
+
+    /// \brief Detachable joint entity for making cable connection 0 static
+    private: gz::sim::Entity detachableJointStatic0Entity{gz::sim::kNullEntity};
+
+    /// \brief Detachable joint entity for making cable connection 1 static
+    private: gz::sim::Entity detachableJointStatic1Entity{gz::sim::kNullEntity};
+
+    /// \brief A list of cable configurations
+    private: std::vector<CableConfig> cableConfigs;
+
+    /// \brief The current active cable model.
+    private: gz::sim::Model cableModel;
+
+    /// \brief Name of the cable model that is currently active.
+    private: std::string cableModelName;
+
+    /// \brief Index of cable model that is currently active.
+    private: std::size_t cableIndex{0u};
+
+    /// \brief Entity offset for end effector
+    private: gz::math::Pose3d endEffectorOffset;
+
+    /// \brief Entities of the cable models
+    private: std::vector<gz::sim::Entity> cableModels;
+
+    /// \brief Name of the end effector model
+    private: std::string endEffectorModelName;
+
+    /// \brief Name of the end effector link
+    private: std::string endEffectorLinkName;
+
+    /// \brief Name of the target model for connection 1
+    private: std::string connection1ModelName;
+
+    /// \brief Distance threshold for grasping the cable connection
+    private: double graspDistanceThreshold{0.05};
+
+    /// \brief Delay in seconds for creating the connection joints.
+    private: double createJointDelay{0.0};
+
+    /// \brief Delay in seconds for locking end-effector after insertion.
+    private: double lockEndEffectorDelay{0.0};
+
+    /// \brief Start time for delay in creating connection joints.
+    private: double createJointDelayStartTime{0.0};
+
+    /// \brief Start time for delay in locking end effector after insertion.
+    private: double lockEndEffectorDelayStartTime{0.0};
+
+    /// \brief Sdf entity creator for spawning static entities
+    /// Used for holding cable connections in place
+    private: std::unique_ptr<gz::sim::SdfEntityCreator> creator{nullptr};
+
+    /// \brief Current state of the cable
+    private: CableState cableState{CableState::INITIALIZATION};
+
+    /// \brief Name of the cable connection 0 port topic
+    private: std::unordered_set<std::string> cableConnection0PortTopics;
+
+    /// \brief Cable connection 0 port subscribers
+    private: std::vector<gz::transport::Node::Subscriber>
+        cableConnection0PortSubs;
+
+    /// \brief Task completion event publisher
+    private: gz::transport::Node::Publisher taskCompletionPub;
+
+    /// \brief Whether to attach cable connection 0 to port
+    /// This is set on cableConnection0PortSub callback
+    private: std::atomic<bool> attachCableConnection0ToPort{false};
+
+    /// \brief Name of the cable connection 1 port topic
+    private: std::unordered_set<std::string> cableConnection1PortTopics;
+
+    /// \brief Cable connection 1 port subscribers
+    private: std::vector<gz::transport::Node::Subscriber>
+        cableConnection1PortSubs;
+
+    /// \brief Whether to attach cable connection 1 to port
+    /// This is set on cableConnection1PortSub callback
+    private: std::atomic<bool> attachCableConnection1ToPort{false};
+
+    /// \brief Static entities (detachable joints used for locking) 
+    /// that are added for cleanup.
+    private: std::vector<gz::sim::Entity> lockingJoints;
+
+    /// \brief Topic in which the touch event is received
+    private: std::string touchEventCallbackNamespace;
+
+    /// \brief Gazebo transport node
+    private: gz::transport::Node node;
+
+    /// \brief Static entities created by this plugin
+    private: std::unordered_set<gz::sim::Entity> staticEntities;
+};
+}
+#endif

--- a/aic_gazebo/src/CableModeratorPlugin.hh
+++ b/aic_gazebo/src/CableModeratorPlugin.hh
@@ -63,9 +63,6 @@ namespace aic_gazebo
 
     /// \brief Task complete - cable connections are completed
     COMPLETED,
-
-    /// \brief Cable model is removed.
-    CABLE_REMOVED,
   };
 
   /// \brief Configuration for a cable
@@ -129,29 +126,36 @@ namespace aic_gazebo
 
     /// \brief Make an entity static by spawning a static model and attaching
     /// the entity to a static model
-    /// \param[in] _attachEntityAsParentOfJoint True to attach entity as parent of
-    /// the detachable joint.
-    /// \param[in] _creator Sdf entity creator for creating a static model
+    /// \param[in] _attachEntityAsParentOfJoint True to attach entity as parent
+    /// of the detachable joint.
     /// \param[in] _ecm Entity component manager
     private: gz::sim::Entity MakeStatic(gz::sim::Entity _entity,
                              bool _attachEntityAsParentOfJoint,
-                             gz::sim::SdfEntityCreator* _creator,
                              gz::sim::EntityComponentManager& _ecm);
 
     /// \brief Check end effector distance to connection and handle grasping
     /// \param[in] _connectionLinkEntity The connection link to check
-    /// \param[in, out] _detachableJointStaticEntity The static joint holding it (removed if grasped)
-    /// \param[in, out] _detachableJointEntity The dynamic joint created for the grasp
+    /// \param[in, out] _detachableJointStaticEntity The static joint holding
+    ///  it (removed if grasped)
     /// \param[in] _ecm Entity Component Manager
     /// \return True if grasped, false otherwise
     private: bool HandleGrasping(gz::sim::Entity _connectionLinkEntity,
                                  gz::sim::Entity& _detachableJointStaticEntity,
-                                 gz::sim::Entity& _detachableJointEntity,
                                  gz::sim::EntityComponentManager& _ecm);
 
-    private: bool ToggleActiveCable(const gz::sim::EntityComponentManager& _ecm);
+    /// \brief Toggle active cable. Done by setting internal vairables to keep
+    /// track of the connection link entities of the next cable in the queue
+    /// \param[in] _ecm Entity Component Manager
+    private: bool ToggleActiveCable(
+        const gz::sim::EntityComponentManager& _ecm);
 
+    /// \brief Find Cable model entities based on their names
+    /// \param[in] _ecm Entity Component Manager
     private: bool FindCableModels(const gz::sim::EntityComponentManager& _ecm);
+
+    /// \brief Initialize port contact subscribers for the given port
+    /// \param[in] _portName The name of the port to subscribe to for contacts
+    private: void CreatePortSubscribers(const std::string& _portName);
 
     /// \brief Entity of attachment link in the end effector model
     private: gz::sim::Entity endEffectorLinkEntity{gz::sim::kNullEntity};
@@ -162,11 +166,9 @@ namespace aic_gazebo
     /// \brief Connection 1 link entity in the cable model
     private: gz::sim::Entity cableConnection1LinkEntity{gz::sim::kNullEntity};
 
-    /// \brief Detachable joint entity for connection 0
-    private: gz::sim::Entity detachableJoint0Entity{gz::sim::kNullEntity};
-
-    /// \brief Detachable joint entity for connection 1
-    private: gz::sim::Entity detachableJoint1Entity{gz::sim::kNullEntity};
+    /// \brief Detachable joint entity for gripper connection
+    private: gz::sim::Entity detachableJointGripperConnEntity{
+        gz::sim::kNullEntity};
 
     /// \brief Detachable joint entity for making cable connection 0 static
     private: gz::sim::Entity detachableJointStatic0Entity{gz::sim::kNullEntity};
@@ -179,9 +181,6 @@ namespace aic_gazebo
 
     /// \brief The current active cable model.
     private: gz::sim::Model cableModel;
-
-    /// \brief Name of the cable model that is currently active.
-    private: std::string cableModelName;
 
     /// \brief Index of cable model that is currently active.
     private: std::size_t cableIndex{0u};
@@ -198,23 +197,8 @@ namespace aic_gazebo
     /// \brief Name of the end effector link
     private: std::string endEffectorLinkName;
 
-    /// \brief Name of the target model for connection 1
-    private: std::string connection1ModelName;
-
     /// \brief Distance threshold for grasping the cable connection
     private: double graspDistanceThreshold{0.05};
-
-    /// \brief Delay in seconds for creating the connection joints.
-    private: double createJointDelay{0.0};
-
-    /// \brief Delay in seconds for locking end-effector after insertion.
-    private: double lockEndEffectorDelay{0.0};
-
-    /// \brief Start time for delay in creating connection joints.
-    private: double createJointDelayStartTime{0.0};
-
-    /// \brief Start time for delay in locking end effector after insertion.
-    private: double lockEndEffectorDelayStartTime{0.0};
 
     /// \brief Sdf entity creator for spawning static entities
     /// Used for holding cable connections in place
@@ -223,37 +207,20 @@ namespace aic_gazebo
     /// \brief Current state of the cable
     private: CableState cableState{CableState::INITIALIZATION};
 
-    /// \brief Name of the cable connection 0 port topic
-    private: std::unordered_set<std::string> cableConnection0PortTopics;
-
-    /// \brief Cable connection 0 port subscribers
+    /// \brief Cable connection port subscribers
     private: std::vector<gz::transport::Node::Subscriber>
-        cableConnection0PortSubs;
+        cableConnectionPortSubs;
 
     /// \brief Task completion event publisher
     private: gz::transport::Node::Publisher taskCompletionPub;
 
-    /// \brief Whether to attach cable connection 0 to port
-    /// This is set on cableConnection0PortSub callback
-    private: std::atomic<bool> attachCableConnection0ToPort{false};
-
-    /// \brief Name of the cable connection 1 port topic
-    private: std::unordered_set<std::string> cableConnection1PortTopics;
-
-    /// \brief Cable connection 1 port subscribers
-    private: std::vector<gz::transport::Node::Subscriber>
-        cableConnection1PortSubs;
-
-    /// \brief Whether to attach cable connection 1 to port
-    /// This is set on cableConnection1PortSub callback
-    private: std::atomic<bool> attachCableConnection1ToPort{false};
-
-    /// \brief Static entities (detachable joints used for locking) 
-    /// that are added for cleanup.
-    private: std::vector<gz::sim::Entity> lockingJoints;
+    /// \brief Whether to attach cable connection to the port
+    /// This is set on cableConnectionPortSub callback
+    private: std::atomic<bool> attachCableConnectionToPort{false};
 
     /// \brief Topic in which the touch event is received
-    private: std::string touchEventCallbackNamespace;
+    /// This is set on cableConnectionPortSub callback
+    private: std::optional<std::string> touchEventCallbackNamespace;
 
     /// \brief Gazebo transport node
     private: gz::transport::Node node;


### PR DESCRIPTION
Add a new `CableModeratorPlugin` for managing cable insertion tasks for multiple cables for phase 1. This replaces `CablePlugin` that is used in quals.

The is a World plugin, which is now added to the `aic.sdf` world file. The plugin currently just manage one cable, see SDF params below. We can tell it to manage multiple cables by adding more `<cable>` SDF elements.

```xml
    <plugin filename="CableModeratorPlugin" name="aic_gazebo::CableModeratorPlugin">
      <cable>
        <name>cable_0</name>
        <cable_connection_0_link>lc_plug_link</cable_connection_0_link>
        <cable_connection_0_port>nic_card_mount</cable_connection_0_port>
        <cable_connection_1_link>sc_plug_link</cable_connection_1_link>
        <cable_connection_1_port>sc_port_base</cable_connection_1_port>
      </cable>
      <end_effector_model>ur5e</end_effector_model>
      <end_effector_link>ati/tool_link</end_effector_link>
    </plugin>
```

**To Test**

See instructions in #468 (in the **Test it!** section)