### PR TITLE
Supporting configuring model_configure_timeout_seconds param

### DIFF
--- a/aic_bringup/launch/aic_gz_bringup.launch.py
+++ b/aic_bringup/launch/aic_gz_bringup.launch.py
@@ -98,6 +98,9 @@ def launch_setup(context, *args, **kwargs):
     model_discovery_timeout_seconds = LaunchConfiguration(
         "model_discovery_timeout_seconds"
     )
+    model_configure_timeout_seconds = LaunchConfiguration(
+        "model_configure_timeout_seconds"
+    )
 
     gripper_initial_pos = "0.00655"
     cable_type_str = LaunchConfiguration("cable_type").perform(context)
@@ -245,6 +248,7 @@ def launch_setup(context, *args, **kwargs):
                 "config_file_path": aic_engine_config_file,
                 "use_sim_time": True,
                 "model_discovery_timeout_seconds": model_discovery_timeout_seconds,
+                "model_configure_timeout_seconds": model_configure_timeout_seconds,
             },
         ],
         condition=IfCondition(start_aic_engine),
@@ -765,6 +769,13 @@ def generate_launch_description():
                 [FindPackageShare("aic_engine"), "config", "sample_config.yaml"]
             ),
             description="Absolute path to YAML file with the AIC engine configuration.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "model_configure_timeout_seconds",
+            default_value="60",
+            description="Timeout for model configuration checks.",
         )
     )
 

--- a/aic_engine/README.md
+++ b/aic_engine/README.md
@@ -59,7 +59,7 @@ ros2 run aic_engine aic_engine --ros-args \
   -p ground_truth:=false \
   -p endpoint_ready_timeout_seconds:=10 \
   -p model_discovery_timeout_seconds:=30 \
-  -p model_configure_timeout_seconds:=60
+  -p model_configure_timeout_seconds:=60 \
   -p use_sim_time:=true
 ```
 

--- a/aic_engine/README.md
+++ b/aic_engine/README.md
@@ -59,7 +59,7 @@ ros2 run aic_engine aic_engine --ros-args \
   -p ground_truth:=false \
   -p endpoint_ready_timeout_seconds:=10 \
   -p model_discovery_timeout_seconds:=30 \
-  -p model_configuration_timeout_seconds:=60
+  -p model_configure_timeout_seconds:=60
   -p use_sim_time:=true
 ```
 


### PR DESCRIPTION
Example usage:

```bash
ros2 launch aic_bringup aic_gz_bringup.launch.py start_aic_engine:=true model_configure_timeout_seconds:=90
```