### PR TITLE
fix: missing `$` in entrypoint.sh when checking for AIC_MODEL_PASSWD

### DIFF
--- a/docker/aic_eval/Dockerfile
+++ b/docker/aic_eval/Dockerfile
@@ -43,7 +43,7 @@ should_enable_acl() {
 
 # prepare the credentials file
 if should_enable_acl; then
-  if [[ ! (-n "$AIC_EVAL_PASSWD" && -n "AIC_MODEL_PASSWD") ]]; then
+  if [[ ! (-n "$AIC_EVAL_PASSWD" && -n "$AIC_MODEL_PASSWD") ]]; then
     echo "AIC_EVAL_PASSWD, AIC_MODEL_PASSWD must be provided"
     exit 1
   fi


### PR DESCRIPTION
Hello, I saw this bug while I was looking through the Dockerfile. I assume that this issue likely doesn't have any impact since ACL isn't enabled in dev and the password is probably always set in prod/eval. 