### PR TITLE
Point gz-physics to commit with nested model collision mesh removal fix

### DIFF
--- a/aic.repos
+++ b/aic.repos
@@ -110,8 +110,8 @@ repositories:
     version: 1f95a52c25a3adf11c53c8b7340135c5b4525376
   gazebo/gz-physics:
     type: git
-    url: https://github.com/gazebosim/gz-physics
-    version: 5c173ea69cde372d6e49f6200580459659166ce3
+    url: https://github.com/kaushikbalasundar/gz-physics.git
+    version: bc3a74a79e351770b66cf67102081228c2a4b90f
   gazebo/gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin

--- a/aic.repos
+++ b/aic.repos
@@ -110,7 +110,6 @@ repositories:
     version: 1f95a52c25a3adf11c53c8b7340135c5b4525376
   gazebo/gz-physics:
     type: git
-    url: https://github.com/kaushikbalasundar/gz-physics.git
     url: https://github.com/gazebosim/gz-physics
     version: 26d8e66ad113b4da6d21dc9dcedd40c509f75749
   gazebo/gz-plugin:

--- a/aic.repos
+++ b/aic.repos
@@ -111,7 +111,8 @@ repositories:
   gazebo/gz-physics:
     type: git
     url: https://github.com/kaushikbalasundar/gz-physics.git
-    version: bc3a74a79e351770b66cf67102081228c2a4b90f
+    url: https://github.com/gazebosim/gz-physics
+    version: 26d8e66ad113b4da6d21dc9dcedd40c509f75749
   gazebo/gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin


### PR DESCRIPTION
Point to a patched version of `gz-physics` that includes a fix for removing collision meshes from nested models. Please ensure that you build with this patch before testing. 

cc: @iche033 