### PR TITLE
Restore contact between sc plug and port to enable collisions in Mujoco

### DIFF
--- a/aic_utils/aic_mujoco/scripts/add_cable_plugin.py
+++ b/aic_utils/aic_mujoco/scripts/add_cable_plugin.py
@@ -748,13 +748,13 @@ def main():
                 sc_port_link_name = candidate
                 break
 
-        if sc_port_link_name:
-            world_spec.add_exclude(
-                bodyname1=sc_port_link_name, bodyname2="sc_plug_link"
-            )
-            print(f"Added exclusion: {sc_port_link_name} <-> sc_plug_link")
-        else:
-            print("Warning: Could not find sc_port link for exclusion.")
+            if sc_port_link_name:
+                world_spec.add_exclude(
+                    bodyname1=sc_port_link_name, bodyname2="sc_plug_link"
+                )
+                print(f"Added exclusion: {sc_port_link_name} <-> sc_plug_link")
+            else:
+                print("Warning: Could not find sc_port link for exclusion.")
         world_spec.add_exclude(bodyname1="cable_end_0", bodyname2="link_1")
         print("Added exclusion: cable_end_0 <-> link_1")
 


### PR DESCRIPTION
The `add_cable_plugin.py` script disabled collisions between the `sc_plug` and `sc_port` for the reversed cable configuration. This isn't necessary since the collision mesh of the port is designed to allow insertion into the port while preventing it elsewhere along the port surface. 

Testing:

Follow the workflow in this [`README.md`](https://github.com/intrinsic-dev/aic/blob/main/aic_utils/aic_mujoco/README.md) to regenerate the MJCF assets and scene definition for the gazebo cable launched with `cable_type:=sfp_sc_cable_reversed`. Then use `aic_teleoperation` to insert into the `sc_port` to confirm collision on surfaces other than the port. 