### PR TITLE
Add launch argument for configuring gz verbosity level

### DIFF
--- a/aic.repos
+++ b/aic.repos
@@ -79,7 +79,7 @@ repositories:
   gazebo/ros_gz:
     type: git
     url: https://github.com/gazebosim/ros_gz.git
-    version: 2.1.12
+    version: c706e201cec93f037f0b9641bcea9ee07d83a058
   gazebo/gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake

--- a/aic_bringup/launch/aic_gz_bringup.launch.py
+++ b/aic_bringup/launch/aic_gz_bringup.launch.py
@@ -101,6 +101,7 @@ def launch_setup(context, *args, **kwargs):
     model_configure_timeout_seconds = LaunchConfiguration(
         "model_configure_timeout_seconds"
     )
+    gz_verbosity_level = LaunchConfiguration("gz_verbosity_level")
 
     gripper_initial_pos = "0.00655"
     cable_type_str = LaunchConfiguration("cable_type").perform(context)
@@ -346,6 +347,7 @@ def launch_setup(context, *args, **kwargs):
         container_name="ros_gz_container",
         create_own_container="True",
         use_composition="True",
+        verbosity_level=gz_verbosity_level,
     )
 
     gzgui = ExecuteProcess(
@@ -784,6 +786,13 @@ def generate_launch_description():
             "model_discovery_timeout_seconds",
             default_value="30",
             description="Timeout for discovering the participant model.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "gz_verbosity_level",
+            default_value="4",
+            description="Verbosity level of the Gazebo server (0=critical, 4=debug).",
         )
     )
     return LaunchDescription(


### PR DESCRIPTION
Allows user to set the gazebo verbosity level via command line. 

Note that the verbosity level feature was recently added upstream in ros_gz. So to use this feature, I cherry-picked https://github.com/gazebosim/ros_gz/commit/c706e201cec93f037f0b9641bcea9ee07d83a058 and applied it over the 2.1.12 tag. The ros_gz bridge package `aic.repos` file is now updated to point to this specific commit.

example usage:

```
ros2 launch aic_bringup aic_gz_bringup.launch.py start_aic_engine:=true gz_verbosity_level:=2
```