### PR TITLE
Update lerobot to fix pixi environment conflicts (#467)

### DIFF
--- a/aic_model/package.xml
+++ b/aic_model/package.xml
@@ -11,7 +11,6 @@
   <depend>aic_model_interfaces</depend>
   <depend>aic_task_interfaces</depend>
   <depend>geometry_msgs</depend>
-  <depend>lifecycle</depend>
   <depend>lifecycle_msgs</depend>
   <depend>rclpy</depend>
   <depend>sensor_msgs</depend>

--- a/pixi.lock
+++ b/pixi.lock
@@ -15,6 +15,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.1-h2d2dd48_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.13-h2c9d079_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.2-h8b1a151_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.10.12-h4bacb7b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.26.3-hc87160b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.11.5-h6d69fc9_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.4-h8b1a151_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.10-h8b1a151_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
@@ -26,7 +35,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/console_bridge-1.0.2-h924138e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cppcheck-2.18.3-py312h014360a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.5-py312ha4b625e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
@@ -35,7 +44,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/empy-3.3.4-pyh9f0ad1d_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/evdev-1.9.3-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.0.1-gpl_h558b6b9_911.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.0.1-gpl_hcddb375_914.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-builtins-3.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-comprehensions-3.17.0-pyhd8ed1ab_0.conda
@@ -47,12 +56,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.17.1-h27c8c51_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/foonathan-memory-0.7.3-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.1-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.5-h2b0a6b4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glslang-16.2.0-h96af755_1.conda
@@ -60,56 +68,56 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.17.0-h84d6215_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.3.2-h6083320_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_106.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.1.0-h6083320_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/imath-3.2.2-hde8ca8f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/intel-gmmlib-22.9.0-hb700be7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/intel-media-driver-25.3.4-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/intel-media-driver-26.1.5-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/isort-5.13.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.8-he3c4edf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.9-h1588d4d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-parser-0.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/level-zero-1.28.0-hb700be7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20250512.1-cxx17_hba17884_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/level-zero-1.28.2-hb700be7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libacl-2.3.2-h0f662aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.4-h96ad9f0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.3.0-h316e467_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.4.1-hcfa2d63_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-5_h4a7cf45_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-h3ff7636_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-5_h0358290_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp21.1-21.1.8-default_h99862b1_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-21.1.8-default_h746c552_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-hb8b1518_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.18.0-h4e3cde8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.0-default_h99862b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.0-default_h746c552_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.19.0-hcf29cc6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.3-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.5-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.1-h73754d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.3-h6548e54_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.4-h6548e54_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
@@ -121,36 +129,36 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.2-ha09017c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-5_h47877c9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.11.0-5_h6ae95b6_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm21-21.1.8-hf7376ad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.2-hf7376ad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.12.0-qt6_py312h52d6ec5_612.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.13.0-qt6_py312h10ee65c_605.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2025.4.1-hb56ce9e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2025.4.1-hd85de46_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2025.4.1-hd85de46_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2025.4.1-hd41364c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2025.4.1-hb56ce9e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2025.4.1-hb56ce9e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2025.4.1-hb56ce9e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2025.4.1-hd41364c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2025.4.1-h1862bb8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2025.4.1-h1862bb8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2025.4.1-hecca717_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2025.4.1-h0767aad_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2025.4.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2026.0.0-hb56ce9e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2026.0.0-hd85de46_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2026.0.0-hd85de46_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2026.0.0-hd41364c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2026.0.0-hb56ce9e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2026.0.0-hb56ce9e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2026.0.0-hb56ce9e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2026.0.0-hd41364c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2026.0.0-h7a07914_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2026.0.0-h7a07914_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2026.0.0-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2026.0.0-h78e8023_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2026.0.0-hecca717_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.55-h421ea60_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.2-hb80d175_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.31.1-h49aed37_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.60.0-h61e6d4b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.56-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.3-h9abb657_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.33.5-h2b00c02_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.1-h4c96295_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.2-hf4e2dac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_17.conda
@@ -165,7 +173,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.23.0-he1eb515_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpl-2.15.0-h54a6638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpl-2.16.0-h54a6638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.15.2-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.341.0-h5279c79_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
@@ -176,22 +184,21 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-he237659_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.43-h711ed8c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzenohc-1.7.2-hfad6b34_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lttng-ust-2.13.9-hf5eda4c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.0.2-py312h63ddcf0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mccabe-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-25.2.1-h728ac57_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.2-py312h33ff503_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-25.8.2-he4ff34a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.2.6-py312h72c5963_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2025.06.13-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/opencv-4.12.0-qt6_py312h7bb6282_612.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.4.4-h40f6f1d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.4.9-h40f6f1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.26.0-h8d634f6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.26.3-h8d634f6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-hbde042b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
@@ -204,7 +211,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.12.0-qt6_py312h598be00_612.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.13.0-qt6_py312h3a6da57_605.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
@@ -217,192 +224,193 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.10.2-hb82b983_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.7.1-h8fae777_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.10.2-pl5321h16c4a6b_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.8.1-h1fbca29_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.6-hb9d3cd8_1.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-action-msgs-2.3.0-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-actionlib-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-auto-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-copyright-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-core-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-cppcheck-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-cpplint-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-definitions-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-dependencies-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-include-directories-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-interfaces-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-libraries-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-link-flags-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-targets-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-flake8-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-gen-version-h-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-gmock-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-gtest-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-include-directories-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-libraries-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-lint-cmake-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-pep257-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-pytest-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-python-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-ros-0.14.7-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-ros-core-0.14.7-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-target-dependencies-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-test-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-uncrustify-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-version-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-xmllint-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-copyright-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cppcheck-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cpplint-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-flake8-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-index-cpp-1.11.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-index-python-1.11.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-lint-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-lint-auto-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-lint-cmake-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-lint-common-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-package-0.17.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-pep257-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-uncrustify-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-xmllint-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-builtin-interfaces-2.3.0-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-class-loader-2.8.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-common-interfaces-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-composition-interfaces-2.3.0-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-console-bridge-vendor-1.8.0-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-control-msgs-6.7.0-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-cyclonedds-0.10.5-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-diagnostic-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-fastcdr-2.3.3-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-fastdds-3.2.3-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-foonathan-memory-vendor-1.3.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-geometry-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-gmock-vendor-1.15.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-gtest-vendor-1.15.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-iceoryx-binding-c-2.0.5-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-iceoryx-hoofs-2.0.5-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-iceoryx-posh-2.0.5-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-3.8.7-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-ros-0.28.5-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-testing-3.8.7-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-testing-ament-cmake-3.8.7-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-testing-ros-0.28.5-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-xml-3.8.7-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-yaml-3.8.7-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-libstatistics-collector-2.0.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-libyaml-vendor-1.7.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-lifecycle-0.36.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-lifecycle-msgs-2.3.0-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-message-filters-7.1.5-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-moveit-msgs-2.7.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-nav-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-object-recognition-msgs-2.0.0-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-octomap-msgs-2.0.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-osrf-pycommon-2.1.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-pluginlib-5.6.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-10.1.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-action-10.1.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-interfaces-2.3.0-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-lifecycle-10.1.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-logging-interface-3.2.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-logging-spdlog-3.2.4-np2py312h918b84f_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-yaml-param-parser-10.1.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rclcpp-29.5.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rclcpp-action-29.5.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rclcpp-components-29.5.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rclcpp-lifecycle-29.5.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rclpy-9.1.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcpputils-2.13.5-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcutils-6.9.9-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-7.8.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-connextdds-1.1.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-connextdds-common-1.1.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-cyclonedds-cpp-4.0.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-dds-common-5.0.0-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-cpp-9.3.3-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-dynamic-cpp-9.3.3-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-shared-cpp-9.3.3-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-implementation-3.0.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-implementation-cmake-7.8.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-security-common-7.8.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-test-fixture-0.14.7-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-test-fixture-implementation-0.14.7-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-zenoh-cpp-0.6.6-np2py312ha80d210_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros-core-0.12.0-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros-environment-4.3.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros-workspace-1.0.3-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2action-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2cli-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2cli-common-extensions-0.4.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2component-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2doctor-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2interface-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2launch-0.28.5-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2lifecycle-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2multicast-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2node-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2param-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2pkg-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2plugin-5.6.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2run-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2service-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2topic-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosgraph-msgs-2.3.0-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-adapter-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-cli-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-cmake-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-core-generators-0.3.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-core-runtime-0.3.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-default-generators-1.7.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-default-runtime-1.7.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-dynamic-typesupport-0.3.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-dynamic-typesupport-fastrtps-0.4.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-generator-c-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-generator-cpp-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-generator-py-0.24.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-generator-type-description-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-parser-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-pycommon-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-c-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-cpp-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-py-0.14.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-c-3.3.3-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-cpp-3.3.3-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-fastrtps-c-3.8.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-fastrtps-cpp-3.8.2-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-interface-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-introspection-c-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-introspection-cpp-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rpyutils-0.6.3-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rti-connext-dds-cmake-module-1.1.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-sensor-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-service-msgs-2.3.0-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-shape-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-spdlog-vendor-1.7.0-np2py312h918b84f_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-sros2-0.15.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-sros2-cmake-0.15.4-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-statistics-msgs-2.3.0-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-std-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-std-srvs-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-stereo-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tf2-0.41.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tf2-msgs-0.41.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tf2-py-0.41.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tf2-ros-0.41.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tf2-ros-py-0.41.6-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tinyxml2-vendor-0.10.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tracetools-8.6.0-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-trajectory-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-type-description-interfaces-2.3.0-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-uncrustify-vendor-3.1.0-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-unique-identifier-msgs-2.7.0-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-visualization-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-zenoh-cpp-vendor-0.6.6-np2py312ha80d210_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros2-distro-mutex-0.13.0-kilted_15.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-action-msgs-2.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-actionlib-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-auto-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-copyright-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-core-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-cppcheck-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-cpplint-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-definitions-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-dependencies-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-include-directories-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-interfaces-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-libraries-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-link-flags-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-targets-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-flake8-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-gen-version-h-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-gmock-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-gtest-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-include-directories-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-libraries-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-lint-cmake-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-pep257-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-pytest-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-python-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-ros-0.14.7-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-ros-core-0.14.7-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-target-dependencies-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-test-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-uncrustify-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-version-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-xmllint-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-copyright-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cppcheck-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cpplint-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-flake8-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-index-cpp-1.11.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-index-python-1.11.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-lint-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-lint-auto-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-lint-cmake-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-lint-common-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-package-0.17.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-pep257-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-uncrustify-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-xmllint-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-builtin-interfaces-2.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-class-loader-2.8.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-common-interfaces-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-composition-interfaces-2.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-console-bridge-vendor-1.8.0-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-control-msgs-6.8.0-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-cyclonedds-0.10.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-diagnostic-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-fastcdr-2.3.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-fastdds-3.2.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-foonathan-memory-vendor-1.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-geometry-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-gmock-vendor-1.15.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-gtest-vendor-1.15.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-iceoryx-binding-c-2.0.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-iceoryx-hoofs-2.0.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-iceoryx-posh-2.0.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-3.8.7-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-ros-0.28.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-testing-3.8.7-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-testing-ament-cmake-3.8.7-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-testing-ros-0.28.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-xml-3.8.7-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-yaml-3.8.7-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-libstatistics-collector-2.0.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-libyaml-vendor-1.7.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-lifecycle-msgs-2.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-message-filters-7.1.6-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-moveit-msgs-2.7.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-nav-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-object-recognition-msgs-2.0.0-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-octomap-msgs-2.0.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-osrf-pycommon-2.1.6-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-pluginlib-5.6.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-10.1.4-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-action-10.1.4-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-interfaces-2.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-lifecycle-10.1.4-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-logging-interface-3.2.4-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-logging-spdlog-3.2.4-np2py312h918b84f_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-yaml-param-parser-10.1.4-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rclcpp-29.5.7-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rclcpp-action-29.5.7-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rclcpp-components-29.5.7-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rclcpp-lifecycle-29.5.7-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rclpy-9.1.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcpputils-2.13.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcutils-6.9.10-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-7.8.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-connextdds-1.1.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-connextdds-common-1.1.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-cyclonedds-cpp-4.0.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-dds-common-5.0.0-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-cpp-9.3.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-dynamic-cpp-9.3.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-shared-cpp-9.3.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-implementation-3.0.6-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-implementation-cmake-7.8.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-security-common-7.8.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-test-fixture-0.14.7-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-test-fixture-implementation-0.14.7-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-zenoh-cpp-0.6.6-np2py312ha80d210_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros-core-0.12.0-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros-environment-4.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros-workspace-1.0.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2action-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2cli-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2cli-common-extensions-0.4.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2component-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2doctor-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2interface-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2launch-0.28.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2lifecycle-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2multicast-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2node-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2param-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2pkg-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2plugin-5.6.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2run-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2service-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2topic-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosgraph-msgs-2.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-adapter-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-cli-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-cmake-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-core-generators-0.3.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-core-runtime-0.3.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-default-generators-1.7.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-default-runtime-1.7.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-dynamic-typesupport-0.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-dynamic-typesupport-fastrtps-0.4.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-generator-c-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-generator-cpp-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-generator-py-0.24.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-generator-rs-0.4.11-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-generator-type-description-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-parser-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-pycommon-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-c-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-cpp-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-py-0.14.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-c-3.3.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-cpp-3.3.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-fastrtps-c-3.8.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-fastrtps-cpp-3.8.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-interface-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-introspection-c-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-introspection-cpp-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rpyutils-0.6.3-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rti-connext-dds-cmake-module-1.1.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-sensor-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-service-msgs-2.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-shape-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-spdlog-vendor-1.7.0-np2py312h918b84f_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-sros2-0.15.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-sros2-cmake-0.15.5-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-statistics-msgs-2.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-std-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-std-srvs-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-stereo-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tf2-0.41.6-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tf2-msgs-0.41.6-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tf2-py-0.41.6-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tf2-ros-0.41.6-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tf2-ros-py-0.41.6-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tinyxml2-vendor-0.10.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tracetools-8.6.0-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-trajectory-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-type-description-interfaces-2.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-uncrustify-vendor-3.1.0-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-unique-identifier-msgs-2.7.0-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-visualization-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-zenoh-cpp-vendor-0.6.6-np2py312ha80d210_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros2-distro-mutex-0.14.0-kilted_17.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rosdistro-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rospkg-1.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.1-h1cbb8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.4.0-h3b84278_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.10.2-pyh332efcf_0.conda
@@ -412,7 +420,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.17.0-hab81395_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/spirv-tools-2026.1-hb700be7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-4.0.0-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-4.0.1-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml2-11.0.0-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
@@ -472,7 +480,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/86/f6/a62cbbf13f0ac80a70f71b1672feba90fdb21fd7abd8dbf25c0105fb6fa3/aiohttp-3.13.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ac/13/37737ef2193e83862ccacff23580c39de251da456a1bf0459e762cca273c/av-15.1.0-cp312-cp312-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl
@@ -496,19 +506,22 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/3f/efeb7c6801c46e11bd666a5180f0d615f74f72264212f74f39586c6fda9d/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/56/d3/ea5f088e3638dbab12e5c20d6559d5b3bdaeaa1f2af74e526e6815836285/gymnasium-1.2.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d6/d8/f87ea6f42456254b48915970ed98e993110521e9263472840174d32c880d/hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/92/cf3ab0b652b082e66876d08da57fcc6fa2f0e6c70dfbbafbd470bb73eb47/hf_xet-1.2.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/31/a0/651f93d154cb72323358bf2bbae3e642bdb5d2f1bfc874d096f7cb159fa0/huggingface_hub-0.35.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/df/9a/a24b26dc8a65f0ecc0fe5be981a19e61e7ca963b85e062c083f3a9100529/hf_xet-1.4.3-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3d/af/10a89c54937dccf6c10792770f362d96dd67aedfde108e6e1fd7a0836789/huggingface_hub-1.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/fe/301e0936b79bcab4cacc7548bf2853fc28dced0a578bab1f7ef53c9aa75b/imageio-2.37.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/ce/ff/3b59672c47c6284e8005b42e84ceba13864aa0f39f067c973d1af02f5d91/InquirerPy-0.3.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/62/d9ba6323b9202dd2fe166beab8a86d29465c41a0288cbe229fac60c1ab8d/jsonlines-4.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d9/c9/c38f0bfe33527d1b139f67850d6a4c113d42d630cbf4846d02e3d6372d97/lerobot-0.4.3-py3-none-any.whl
-      - pypi: git+https://github.com/koonpeng/lerobot-ros?subdirectory=lerobot_robot_ros&rev=b4a635fc5264266bd1575f07d54be3d4bbd620e0#b4a635fc5264266bd1575f07d54be3d4bbd620e0
-      - pypi: git+https://github.com/koonpeng/lerobot-ros?subdirectory=lerobot_teleoperator_devices&rev=b4a635fc5264266bd1575f07d54be3d4bbd620e0#b4a635fc5264266bd1575f07d54be3d4bbd620e0
+      - pypi: https://files.pythonhosted.org/packages/60/8e/8e3763ad36ba0efb9ba0381ae06d328b54081587b45b0c1d049b26ed8d8c/lerobot-0.5.1-py3-none-any.whl
+      - pypi: git+https://github.com/koonpeng/lerobot-ros?subdirectory=lerobot_robot_ros&rev=87708d0ae14a724bca78f8ae9d55448332509a57#87708d0ae14a724bca78f8ae9d55448332509a57
+      - pypi: git+https://github.com/koonpeng/lerobot-ros?subdirectory=lerobot_teleoperator_devices&rev=87708d0ae14a724bca78f8ae9d55448332509a57#87708d0ae14a724bca78f8ae9d55448332509a57
+      - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c8/8a/229e4db3692be55532e155e2ca6a1363752243ee79df0e7e22ba00f716cf/mujoco-3.5.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
@@ -532,10 +545,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/56/9a/fff8376f8e3d084cd1530e1ef7b879bb7d6d265620c95c1b322725c694f4/nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bf/2e/9211f09bedb04f9832122942de8b051804b31a39cfbad199a819bb88d9f3/pandas-3.0.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/8c/d7/8ff98376b1acc4503253b685ea09981697385ce344d4e3935c2af49e044d/pfzy-0.3.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ff/79/6df7b2ee763d619cda2fb4fea498e5f79d984dae304d45a8999b80d6cf5c/pillow-12.1.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/e3/1eddccb2c39ecfbe09b3add42a04abcc3fa5b468aa4224998ffb8a7e9c8f/platformdirs-4.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/46/4b/3aae6835b8e5f44ea6a68348ad90f78134047b503765087be2f9912140ea/propcache-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c6/6f/8f9eb40c2328d66e8b097777ddcf38494115ff9f1b5bc9754ba46991191e/pyarrow-23.0.0-cp312-cp312-manylinux_2_28_x86_64.whl
@@ -551,8 +562,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/dd/df/0d722c030c82faa1d331d1921ee268a4e8fb55ca8b9042c9341c352f17fa/regex-2026.1.15-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f5/86/0b9c8f56398b4fc85f8e99279907c258413a297e5603f8f2537fe5806e51/rerun_sdk-0.26.2-cp39-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ca/63/2c6daf59d86b1c30600bff679d039f57fd1932af82c43c0bde1cbc55e8d4/sentry_sdk-2.52.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl
@@ -562,11 +575,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/17/8b/155f99042f9319bd7759536779b2a5b67cbd4f89c380854670850f89a2f4/torchvision-0.22.1-cp312-cp312-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/5f/950fb373bf9c01ad4eb5a8cd5eaf32cdf9e238c02f9293557a2129b9c4ac/triton-3.3.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/70/c8/1b758bd903afee000f023cd03f335ff328a21b3914f9f9deda49b1e57723/wandb-0.24.2-py3-none-manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/4f/426f91b96701ec2f37bb2b8cec664eff4f658a11f3fa9d94f0a887ea6d2b/xxhash-3.6.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/0f/0d52c98b8a885aeda831224b78f3be7ec2e1aa4a62091f9f9188c3c65b56/yarl-1.22.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       osx-arm64:
@@ -592,7 +605,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/double-conversion-3.4.0-haf25636_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/empy-3.3.4-pyh9f0ad1d_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-8.0.1-gpl_h751538b_111.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-8.0.1-gpl_ha5d8480_114.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-builtins-3.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-comprehensions-3.17.0-pyhd8ed1ab_0.conda
@@ -615,24 +628,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.14-hec049ff_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gtest-1.17.0-ha393de7_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-12.3.2-h3103d1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.1.0-h3103d1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.6-nompi_had3affe_106.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.2-h38cb7af_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/imath-3.2.2-h3470cca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/isort-5.13.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.8-hc0e5025_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.9-h7543a42_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lame-3.100-h1a8c8d9_1003.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-parser-0.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-hd64df32_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20250512.1-cxx17_hd41c47c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20260107.1-cxx17_h2062a1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.5-h8664d51_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.4-hcbd7ca7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.3.0-hde9513d_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.4.1-hfce71f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-5_h51639a9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-hc919400_1.conda
@@ -645,10 +658,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.25-hc11a715_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.4-hf6b4638_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.5-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.1-hce30654_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.1-h6da58f4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.3-hdfa99f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_18.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_18.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_18.conda
@@ -664,28 +677,28 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm19-19.1.7-h8e0c9ce_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm21-21.1.8-h8e0c9ce_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.2-h8088a28_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.67.0-hc438710_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h8f3e76b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libntlm-1.8-h5505292_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libogg-1.3.5-h48c0fde_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.30-openmp_ha158390_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.12.0-qt6_py312h74f5ed3_612.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2025.4.1-h3e6d54f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2025.4.1-h3e6d54f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2025.4.1-h2406d2e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2025.4.1-h2406d2e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2025.4.1-h85cbfa6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2025.4.1-h85cbfa6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2025.4.1-h7fb59aa_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2025.4.1-h7fb59aa_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2025.4.1-hf6b4638_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2025.4.1-hf92d75f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2025.4.1-hf6b4638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.13.0-qt6_py312hc9399c9_605.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2026.0.0-h3e6d54f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2026.0.0-h3e6d54f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2026.0.0-h2406d2e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2026.0.0-h2406d2e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2026.0.0-h85cbfa6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2026.0.0-h85cbfa6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2026.0.0-h41365f2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2026.0.0-h41365f2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2026.0.0-hf6b4638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2026.0.0-hc295da0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2026.0.0-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopus-1.6.1-h1a92334_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.55-h132b30e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.56-h132b30e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-18.2-h6caddbb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.31.1-h98f38fd_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-h4a5acfd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.60.0-h9001022_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.51.2-h1ae2325_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.52.0-h1ae2325_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.1-h4030677_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libusb-1.0.29-hbc156a2_0.conda
@@ -698,16 +711,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.1-h8d039ee_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxslt-1.1.43-hb2570ba_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzenohc-1.7.2-h2b5bd82_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.0-hc7d1edf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lxml-6.0.2-py312h447b5cf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mccabe-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-25.2.1-he11bded_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.2-py312he281c53_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/opencv-4.12.0-qt6_py312h5b798a3_612.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openexr-3.4.5-he0ec429_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-25.8.2-h7039424_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.2.6-py312h7c1f314_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openexr-3.4.9-he0ec429_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openh264-2.6.0-hb5b2745_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjph-0.26.3-h2a4d681_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openldap-2.6.10-hbe55e7a_0.conda
@@ -721,7 +733,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py312hb3ab3e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pugixml-1.15-hd3d436d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/py-opencv-4.12.0-qt6_py312he92a2c1_612.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/py-opencv-4.13.0-qt6_py312hf453e02_605.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
@@ -735,189 +747,189 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py312h04c11ed_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qt6-main-6.10.2-h9aec236_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rav1e-0.7.1-h0716509_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rav1e-0.8.1-h8246384_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.6-h5505292_1.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-action-msgs-2.3.0-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-actionlib-msgs-5.5.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-2.7.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-auto-2.7.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-copyright-0.19.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-core-2.7.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-cppcheck-0.19.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-cpplint-0.19.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-definitions-2.7.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-dependencies-2.7.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-include-directories-2.7.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-interfaces-2.7.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-libraries-2.7.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-link-flags-2.7.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-targets-2.7.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-flake8-0.19.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-gen-version-h-2.7.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-gmock-2.7.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-gtest-2.7.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-include-directories-2.7.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-libraries-2.7.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-lint-cmake-0.19.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-pep257-0.19.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-pytest-2.7.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-python-2.7.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-ros-0.14.7-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-ros-core-0.14.7-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-target-dependencies-2.7.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-test-2.7.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-uncrustify-0.19.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-version-2.7.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-xmllint-0.19.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-copyright-0.19.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cppcheck-0.19.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cpplint-0.19.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-flake8-0.19.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-index-cpp-1.11.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-index-python-1.11.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-lint-0.19.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-lint-auto-0.19.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-lint-cmake-0.19.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-lint-common-0.19.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-package-0.17.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-pep257-0.19.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-uncrustify-0.19.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-xmllint-0.19.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-builtin-interfaces-2.3.0-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-class-loader-2.8.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-common-interfaces-5.5.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-composition-interfaces-2.3.0-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-console-bridge-vendor-1.8.0-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-control-msgs-6.7.0-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-cyclonedds-0.10.5-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-diagnostic-msgs-5.5.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-fastcdr-2.3.3-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-fastdds-3.2.3-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-foonathan-memory-vendor-1.3.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-geometry-msgs-5.5.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-gmock-vendor-1.15.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-gtest-vendor-1.15.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-iceoryx-binding-c-2.0.5-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-iceoryx-hoofs-2.0.5-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-iceoryx-posh-2.0.5-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-3.8.7-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-ros-0.28.5-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-testing-3.8.7-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-testing-ament-cmake-3.8.7-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-testing-ros-0.28.5-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-xml-3.8.7-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-yaml-3.8.7-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-libstatistics-collector-2.0.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-libyaml-vendor-1.7.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-lifecycle-0.36.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-lifecycle-msgs-2.3.0-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-message-filters-7.1.5-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-moveit-msgs-2.7.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-nav-msgs-5.5.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-object-recognition-msgs-2.0.0-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-octomap-msgs-2.0.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-osrf-pycommon-2.1.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-pluginlib-5.6.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-10.1.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-action-10.1.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-interfaces-2.3.0-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-lifecycle-10.1.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-logging-interface-3.2.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-logging-spdlog-3.2.4-np2py312h13c16a8_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-yaml-param-parser-10.1.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rclcpp-29.5.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rclcpp-action-29.5.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rclcpp-components-29.5.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rclcpp-lifecycle-29.5.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rclpy-9.1.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcpputils-2.13.5-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcutils-6.9.9-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-7.8.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-connextdds-1.1.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-connextdds-common-1.1.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-cyclonedds-cpp-4.0.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-dds-common-5.0.0-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-fastrtps-cpp-9.3.3-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-fastrtps-dynamic-cpp-9.3.3-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-fastrtps-shared-cpp-9.3.3-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-implementation-3.0.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-implementation-cmake-7.8.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-security-common-7.8.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-test-fixture-0.14.7-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-test-fixture-implementation-0.14.7-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-zenoh-cpp-0.6.6-np2py312h682da20_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros-core-0.12.0-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros-environment-4.3.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros-workspace-1.0.3-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2action-0.38.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2cli-0.38.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2cli-common-extensions-0.4.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2component-0.38.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2doctor-0.38.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2interface-0.38.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2launch-0.28.5-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2lifecycle-0.38.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2multicast-0.38.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2node-0.38.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2param-0.38.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2pkg-0.38.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2plugin-5.6.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2run-0.38.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2service-0.38.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2topic-0.38.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosgraph-msgs-2.3.0-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-adapter-4.9.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-cli-4.9.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-cmake-4.9.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-core-generators-0.3.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-core-runtime-0.3.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-default-generators-1.7.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-default-runtime-1.7.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-dynamic-typesupport-0.3.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-dynamic-typesupport-fastrtps-0.4.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-generator-c-4.9.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-generator-cpp-4.9.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-generator-py-0.24.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-generator-type-description-4.9.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-parser-4.9.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-pycommon-4.9.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-runtime-c-4.9.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-runtime-cpp-4.9.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-runtime-py-0.14.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-c-3.3.3-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-cpp-3.3.3-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-fastrtps-c-3.8.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-fastrtps-cpp-3.8.2-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-interface-4.9.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-introspection-c-4.9.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-introspection-cpp-4.9.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rpyutils-0.6.3-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rti-connext-dds-cmake-module-1.1.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-sensor-msgs-5.5.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-service-msgs-2.3.0-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-shape-msgs-5.5.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-spdlog-vendor-1.7.0-np2py312h13c16a8_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-sros2-0.15.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-sros2-cmake-0.15.4-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-statistics-msgs-2.3.0-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-std-msgs-5.5.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-std-srvs-5.5.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-stereo-msgs-5.5.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tf2-0.41.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tf2-msgs-0.41.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tf2-py-0.41.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tf2-ros-0.41.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tf2-ros-py-0.41.6-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tinyxml2-vendor-0.10.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tracetools-8.6.0-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-trajectory-msgs-5.5.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-type-description-interfaces-2.3.0-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-uncrustify-vendor-3.1.0-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-unique-identifier-msgs-2.7.0-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-visualization-msgs-5.5.1-np2py312h50b1e4c_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-zenoh-cpp-vendor-0.6.6-np2py312h682da20_15.conda
-      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros2-distro-mutex-0.13.0-kilted_15.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-action-msgs-2.3.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-actionlib-msgs-5.5.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-2.7.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-auto-2.7.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-copyright-0.19.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-core-2.7.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-cppcheck-0.19.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-cpplint-0.19.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-definitions-2.7.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-dependencies-2.7.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-include-directories-2.7.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-interfaces-2.7.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-libraries-2.7.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-link-flags-2.7.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-targets-2.7.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-flake8-0.19.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-gen-version-h-2.7.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-gmock-2.7.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-gtest-2.7.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-include-directories-2.7.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-libraries-2.7.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-lint-cmake-0.19.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-pep257-0.19.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-pytest-2.7.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-python-2.7.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-ros-0.14.7-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-ros-core-0.14.7-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-target-dependencies-2.7.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-test-2.7.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-uncrustify-0.19.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-version-2.7.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-xmllint-0.19.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-copyright-0.19.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cppcheck-0.19.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cpplint-0.19.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-flake8-0.19.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-index-cpp-1.11.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-index-python-1.11.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-lint-0.19.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-lint-auto-0.19.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-lint-cmake-0.19.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-lint-common-0.19.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-package-0.17.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-pep257-0.19.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-uncrustify-0.19.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-xmllint-0.19.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-builtin-interfaces-2.3.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-class-loader-2.8.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-common-interfaces-5.5.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-composition-interfaces-2.3.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-console-bridge-vendor-1.8.0-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-control-msgs-6.8.0-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-cyclonedds-0.10.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-diagnostic-msgs-5.5.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-fastcdr-2.3.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-fastdds-3.2.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-foonathan-memory-vendor-1.3.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-geometry-msgs-5.5.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-gmock-vendor-1.15.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-gtest-vendor-1.15.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-iceoryx-binding-c-2.0.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-iceoryx-hoofs-2.0.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-iceoryx-posh-2.0.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-3.8.7-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-ros-0.28.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-testing-3.8.7-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-testing-ament-cmake-3.8.7-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-testing-ros-0.28.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-xml-3.8.7-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-yaml-3.8.7-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-libstatistics-collector-2.0.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-libyaml-vendor-1.7.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-lifecycle-msgs-2.3.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-message-filters-7.1.6-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-moveit-msgs-2.7.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-nav-msgs-5.5.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-object-recognition-msgs-2.0.0-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-octomap-msgs-2.0.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-osrf-pycommon-2.1.6-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-pluginlib-5.6.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-10.1.4-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-action-10.1.4-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-interfaces-2.3.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-lifecycle-10.1.4-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-logging-interface-3.2.4-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-logging-spdlog-3.2.4-np2py312h13c16a8_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-yaml-param-parser-10.1.4-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rclcpp-29.5.7-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rclcpp-action-29.5.7-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rclcpp-components-29.5.7-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rclcpp-lifecycle-29.5.7-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rclpy-9.1.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcpputils-2.13.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcutils-6.9.10-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-7.8.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-connextdds-1.1.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-connextdds-common-1.1.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-cyclonedds-cpp-4.0.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-dds-common-5.0.0-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-fastrtps-cpp-9.3.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-fastrtps-dynamic-cpp-9.3.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-fastrtps-shared-cpp-9.3.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-implementation-3.0.6-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-implementation-cmake-7.8.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-security-common-7.8.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-test-fixture-0.14.7-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-test-fixture-implementation-0.14.7-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-zenoh-cpp-0.6.6-np2py312h682da20_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros-core-0.12.0-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros-environment-4.3.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros-workspace-1.0.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2action-0.38.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2cli-0.38.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2cli-common-extensions-0.4.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2component-0.38.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2doctor-0.38.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2interface-0.38.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2launch-0.28.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2lifecycle-0.38.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2multicast-0.38.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2node-0.38.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2param-0.38.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2pkg-0.38.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2plugin-5.6.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2run-0.38.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2service-0.38.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2topic-0.38.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosgraph-msgs-2.3.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-adapter-4.9.6-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-cli-4.9.6-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-cmake-4.9.6-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-core-generators-0.3.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-core-runtime-0.3.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-default-generators-1.7.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-default-runtime-1.7.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-dynamic-typesupport-0.3.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-dynamic-typesupport-fastrtps-0.4.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-generator-c-4.9.6-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-generator-cpp-4.9.6-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-generator-py-0.24.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-generator-rs-0.4.11-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-generator-type-description-4.9.6-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-parser-4.9.6-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-pycommon-4.9.6-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-runtime-c-4.9.6-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-runtime-cpp-4.9.6-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-runtime-py-0.14.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-c-3.3.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-cpp-3.3.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-fastrtps-c-3.8.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-fastrtps-cpp-3.8.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-interface-4.9.6-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-introspection-c-4.9.6-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-introspection-cpp-4.9.6-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rpyutils-0.6.3-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rti-connext-dds-cmake-module-1.1.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-sensor-msgs-5.5.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-service-msgs-2.3.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-shape-msgs-5.5.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-spdlog-vendor-1.7.0-np2py312h13c16a8_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-sros2-0.15.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-sros2-cmake-0.15.5-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-statistics-msgs-2.3.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-std-msgs-5.5.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-std-srvs-5.5.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-stereo-msgs-5.5.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tf2-0.41.6-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tf2-msgs-0.41.6-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tf2-py-0.41.6-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tf2-ros-0.41.6-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tf2-ros-py-0.41.6-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tinyxml2-vendor-0.10.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tracetools-8.6.0-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-trajectory-msgs-5.5.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-type-description-interfaces-2.3.1-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-uncrustify-vendor-3.1.0-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-unique-identifier-msgs-2.7.0-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-visualization-msgs-5.5.2-np2py312h50b1e4c_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-zenoh-cpp-vendor-0.6.6-np2py312h682da20_17.conda
+      - conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros2-distro-mutex-0.14.0-kilted_17.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rosdistro-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rospkg-1.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sdl2-2.32.56-h248ca61_0.conda
@@ -929,7 +941,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/spdlog-1.17.0-ha0f8610_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/spirv-tools-2026.1-h4ddebb9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-4.0.0-h0cb729a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-4.0.1-h0cb729a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2022.3.0-h4ddebb9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tinyxml2-11.0.0-ha1acc90_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
@@ -964,7 +976,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/43/4be01406b78e1be8320bb8316dc9c42dbab553d281c40364e0f862d5661c/aiohttp-3.13.3-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/58/de78b276d20db6ffcd4371283df771721a833ba525a3d57e753d00a9fe79/av-15.1.0-cp312-cp312-macosx_13_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
@@ -988,19 +1002,22 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b6/a6/6ea2f73ad4474896d9e38b3ffbe6ffd5a802c738392269e99e8c6621a461/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/56/d3/ea5f088e3638dbab12e5c20d6559d5b3bdaeaa1f2af74e526e6815836285/gymnasium-1.2.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/41/ba/8d9fd9f1083525edfcb389c93738c802f3559cb749324090d7109c8bf4c2/hf_transfer-0.1.9-cp38-abi3-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/c0/e5/a2f3eaae09da57deceb16a96ebe9ae1f6f7b9b94145a9cd3c3f994e7782a/hf_xet-1.3.1-cp37-abi3-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/31/a0/651f93d154cb72323358bf2bbae3e642bdb5d2f1bfc874d096f7cb159fa0/huggingface_hub-0.35.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0b/f8/7aacb8e5f4a7899d39c787b5984e912e6c18b11be136ef13947d7a66d265/hf_xet-1.4.3-cp37-abi3-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3d/af/10a89c54937dccf6c10792770f362d96dd67aedfde108e6e1fd7a0836789/huggingface_hub-1.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/fe/301e0936b79bcab4cacc7548bf2853fc28dced0a578bab1f7ef53c9aa75b/imageio-2.37.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/40/5c/f3d8a657d362cc93b81aab8feda487317da5b5d31c0e1fdfd5e986e55d17/imageio_ffmpeg-0.6.0-py3-none-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/ce/ff/3b59672c47c6284e8005b42e84ceba13864aa0f39f067c973d1af02f5d91/InquirerPy-0.3.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/62/d9ba6323b9202dd2fe166beab8a86d29465c41a0288cbe229fac60c1ab8d/jsonlines-4.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d9/c9/c38f0bfe33527d1b139f67850d6a4c113d42d630cbf4846d02e3d6372d97/lerobot-0.4.3-py3-none-any.whl
-      - pypi: git+https://github.com/koonpeng/lerobot-ros?subdirectory=lerobot_robot_ros&rev=b4a635fc5264266bd1575f07d54be3d4bbd620e0#b4a635fc5264266bd1575f07d54be3d4bbd620e0
-      - pypi: git+https://github.com/koonpeng/lerobot-ros?subdirectory=lerobot_teleoperator_devices&rev=b4a635fc5264266bd1575f07d54be3d4bbd620e0#b4a635fc5264266bd1575f07d54be3d4bbd620e0
+      - pypi: https://files.pythonhosted.org/packages/60/8e/8e3763ad36ba0efb9ba0381ae06d328b54081587b45b0c1d049b26ed8d8c/lerobot-0.5.1-py3-none-any.whl
+      - pypi: git+https://github.com/koonpeng/lerobot-ros?subdirectory=lerobot_robot_ros&rev=87708d0ae14a724bca78f8ae9d55448332509a57#87708d0ae14a724bca78f8ae9d55448332509a57
+      - pypi: git+https://github.com/koonpeng/lerobot-ros?subdirectory=lerobot_teleoperator_devices&rev=87708d0ae14a724bca78f8ae9d55448332509a57#87708d0ae14a724bca78f8ae9d55448332509a57
+      - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e1/d4/d0032323f58a9b8080b8464c6aade8d5ac2e101dbed1de64a38b3913b446/mujoco-3.5.0-cp312-cp312-macosx_11_0_arm64.whl
@@ -1010,10 +1027,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7c/f1/e2567ffc8951ab371db2e40b2fe068e36b81d8cf3260f06ae508700e5504/pandas-3.0.1-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/8c/d7/8ff98376b1acc4503253b685ea09981697385ce344d4e3935c2af49e044d/pfzy-0.3.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/71/5026395b290ff404b836e636f51d7297e6c83beceaa87c592718747e670f/pillow-12.1.1-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/48/31/05e764397056194206169869b50cf2fee4dbbbc71b344705b9c0d878d4d8/platformdirs-4.9.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/b6/5c9a0e42df4d00bfb4a3cbbe5cf9f54260300c88a0e9af1f47ca5ce17ac0/propcache-0.4.1-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/a2/6b/e48dfc1191bc5b52950246275bf4089773e91cb5ba3592621723cdddca62/protobuf-6.33.5-cp39-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/9a/4b/4166bb5abbfe6f750fc60ad337c43ecf61340fa52ab386da6e8dbf9e63c4/pyarrow-23.0.1-cp312-cp312-macosx_12_0_arm64.whl
@@ -1033,8 +1048,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f9/87/3997fc72dc59233426ef2e18dfdd105bb123812fff740ee9cc348f1a3243/regex-2026.2.19-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2b/3d/d8dd0af9c287a85d51ec99d69406cc4b94a9feb1d6f192d3bbcaac9f0b81/rerun_sdk-0.26.2-cp39-abi3-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/47/d4/2fdf854bc3b9c7f55219678f812600a20a138af2dd847d99004994eada8f/sentry_sdk-2.53.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl
@@ -1043,11 +1060,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/02/52/23145c2a6580f0753104f257067db0cf68e1ba105408777ec54ce686c1f0/torchcodec-0.5-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/02/90/f4e99a5112dc221cf68a485e853cc3d9f3f1787cb950b895f3ea26d1ea98/torchvision-0.22.1-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/82/5299fa22faf2dd55f33f05c26bf908b11ea4d25f32ac270d4bf838b0d97e/wandb-0.24.2-py3-none-macosx_12_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/35/0429ee11d035fc33abe32dca1b2b69e8c18d236547b9a9b72c1929189b9a/xxhash-3.6.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/ba/f5/0601483296f09c3c65e303d60c070a5c19fcdbc72daa061e96170785bc7d/yarl-1.22.0-cp312-cp312-macosx_11_0_arm64.whl
 packages:
@@ -1215,6 +1232,11 @@ packages:
   purls: []
   size: 584660
   timestamp: 1768327524772
+- pypi: https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl
+  name: annotated-doc
+  version: 0.0.4
+  sha256: 571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
   name: annotated-types
   version: 0.7.0
@@ -1222,6 +1244,16 @@ packages:
   requires_dist:
   - typing-extensions>=4.0.0 ; python_full_version < '3.9'
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl
+  name: anyio
+  version: 4.13.0
+  sha256: 08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708
+  requires_dist:
+  - exceptiongroup>=1.0.2 ; python_full_version < '3.11'
+  - idna>=2.8
+  - typing-extensions>=4.5 ; python_full_version < '3.13'
+  - trio>=0.32.0 ; extra == 'trio'
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
   sha256: b08ef033817b5f9f76ce62dfcac7694e7b6b4006420372de22494503decac855
   md5: 346722a0be40f6edc53f12640d301338
@@ -1281,6 +1313,129 @@ packages:
   version: 15.1.0
   sha256: 40c5df37f4c354ab8190c6fd68dab7881d112f527906f64ca73da4c252a58cee
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.1-h2d2dd48_2.conda
+  sha256: 292aa18fe6ab5351710e6416fbd683eaef3aa5b1b7396da9350ff08efc660e4f
+  md5: 675ea6d90900350b1dcfa8231a5ea2dd
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.12.6,<0.12.7.0a0
+  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  - aws-c-cal >=0.9.13,<0.9.14.0a0
+  - aws-c-http >=0.10.12,<0.10.13.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 134426
+  timestamp: 1774274932726
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.13-h2c9d079_1.conda
+  sha256: f21d648349a318f4ae457ea5403d542ba6c0e0343b8642038523dd612b2a5064
+  md5: 3c3d02681058c3d206b562b2e3bc337f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.12.6,<0.12.7.0a0
+  - libgcc >=14
+  - openssl >=3.5.4,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 56230
+  timestamp: 1764593147526
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda
+  sha256: 926a5b9de0a586e88669d81de717c8dd3218c51ce55658e8a16af7e7fe87c833
+  md5: e36ad70a7e0b48f091ed6902f04c23b8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 239605
+  timestamp: 1763585595898
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.2-h8b1a151_0.conda
+  sha256: 1838bdc077b77168416801f4715335b65e9223f83641a2c28644f8acd8f9db0e
+  md5: f16f498641c9e05b645fe65902df661a
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.12.6,<0.12.7.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 22278
+  timestamp: 1767790836624
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.10.12-h4bacb7b_1.conda
+  sha256: c6f910d400ef9034493988e8cd37bd4712e42d85921122bcda4ba68d4614b131
+  md5: 7bc920933e5fb225aba86a788164a8f1
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-cal >=0.9.13,<0.9.14.0a0
+  - aws-c-compression >=0.3.2,<0.3.3.0a0
+  - aws-c-common >=0.12.6,<0.12.7.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 225868
+  timestamp: 1774270031584
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.26.3-hc87160b_0.conda
+  sha256: c66ebb7815949db72bab7c86bf477197e4bc6937c381cf32248bdd1ce496db00
+  md5: dde6a3e4fe6bb2ecd2a7050dd1e701fb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - aws-c-cal >=0.9.13,<0.9.14.0a0
+  - s2n >=1.7.1,<1.7.2.0a0
+  - aws-c-common >=0.12.6,<0.12.7.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 181624
+  timestamp: 1773868304737
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.11.5-h6d69fc9_5.conda
+  sha256: c15869656f5fbebe27cc5aa58b23831f75d85502d324fedd7ee7e552c79b495d
+  md5: 4c5c16bf1133dcfe100f33dd4470998e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-checksums >=0.2.10,<0.2.11.0a0
+  - aws-c-common >=0.12.6,<0.12.7.0a0
+  - aws-c-http >=0.10.12,<0.10.13.0a0
+  - openssl >=3.5.5,<4.0a0
+  - aws-c-auth >=0.10.1,<0.10.2.0a0
+  - aws-c-cal >=0.9.13,<0.9.14.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 151340
+  timestamp: 1774282148690
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.4-h8b1a151_4.conda
+  sha256: 9d62c5029f6f8219368a8665f0a549da572dc777f52413b7d75609cacdbc02cc
+  md5: c7e3e08b7b1b285524ab9d74162ce40b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - aws-c-common >=0.12.6,<0.12.7.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 59383
+  timestamp: 1764610113765
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.10-h8b1a151_0.conda
+  sha256: 09472dd5fa4473cffd44741ee4c1112f2c76d7168d1343de53c2ad283dc1efa6
+  md5: f8e1bcc5c7d839c5882e94498791be08
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.12.6,<0.12.7.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 101435
+  timestamp: 1771063496927
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
   sha256: c30daba32ddebbb7ded490f0e371eae90f51e72db620554089103b4a6934b0d5
   md5: 51a19bba1b8ebfb60df25cde030b7ebc
@@ -1624,22 +1779,22 @@ packages:
   - pkg:pypi/cryptography?source=hash-mapping
   size: 1595763
   timestamp: 1770772744039
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
-  sha256: ee09ad7610c12c7008262d713416d0b58bf365bc38584dce48950025850bdf3f
-  md5: cae723309a49399d2949362f4ab5c9e4
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
+  sha256: 7684da83306bb69686c0506fb09aa7074e1a55ade50c3a879e4e5df6eebb1009
+  md5: af491aae930edc096b58466c51c4126c
   depends:
   - __glibc >=2.17,<3.0.a0
-  - krb5 >=1.21.3,<1.22.0a0
+  - krb5 >=1.22.2,<1.23.0a0
   - libgcc >=13
   - libntlm >=1.8,<2.0a0
   - libstdcxx >=13
   - libxcrypt >=4.4.36
-  - openssl >=3.5.0,<4.0a0
+  - openssl >=3.5.5,<4.0a0
   license: BSD-3-Clause-Attribution
   license_family: BSD
   purls: []
-  size: 209774
-  timestamp: 1750239039316
+  size: 210103
+  timestamp: 1771943128249
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cyrus-sasl-2.1.28-ha1cbb27_0.conda
   sha256: 7de03254fa5421e7ec2347c830a59530fb5356022ee0dc26ec1cef0be1de0911
   md5: 2867ea6551e97e53a81787fd967162b1
@@ -2147,123 +2302,123 @@ packages:
   name: farama-notifications
   version: 0.0.4
   sha256: 14de931035a41961f7c056361dc7f980762a143d05791ef5794a751a2caf05ae
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.0.1-gpl_h558b6b9_911.conda
-  sha256: 13010fc318e335f40142a542eb17ca466da5797c890d2014dfb5fdd7d77373f0
-  md5: fa4420e2929e93c62cf7e29189ab4ce1
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.0.1-gpl_hcddb375_914.conda
+  sha256: 0d465b145eb7166d6a3989f0befe790789624604945f53de767b169b1832c088
+  md5: f0e9f1452786e2b32907e8d9a6b3c752
   depends:
   - __glibc >=2.17,<3.0.a0
   - alsa-lib >=1.2.15.3,<1.3.0a0
   - aom >=3.9.1,<3.10.0a0
   - bzip2 >=1.0.8,<2.0a0
   - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.15.0,<3.0a0
+  - fontconfig >=2.17.1,<3.0a0
   - fonts-conda-ecosystem
   - gmp >=6.3.0,<7.0a0
   - harfbuzz >=12.3.2
   - lame >=3.100,<3.101.0a0
   - libass >=0.17.4,<0.17.5.0a0
-  - libexpat >=2.7.3,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
+  - libexpat >=2.7.4,<3.0a0
+  - libfreetype >=2.14.2
+  - libfreetype6 >=2.14.2
   - libgcc >=14
   - libiconv >=1.18,<2.0a0
   - libjxl >=0.11,<1.0a0
   - liblzma >=5.8.2,<6.0a0
-  - libopenvino >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-auto-batch-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-auto-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-hetero-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-intel-cpu-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-intel-gpu-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-intel-npu-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-ir-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-onnx-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-paddle-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-pytorch-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-tensorflow-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-tensorflow-lite-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopenvino >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-auto-batch-plugin >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-auto-plugin >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-hetero-plugin >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-intel-cpu-plugin >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-intel-gpu-plugin >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-intel-npu-plugin >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-ir-frontend >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-onnx-frontend >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-paddle-frontend >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-pytorch-frontend >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-tensorflow-frontend >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2026.0.0,<2026.0.1.0a0
   - libopus >=1.6.1,<2.0a0
-  - librsvg >=2.60.0,<3.0a0
+  - librsvg >=2.60.2,<3.0a0
   - libstdcxx >=14
   - libva >=2.23.0,<3.0a0
   - libvorbis >=1.3.7,<1.4.0a0
-  - libvpl >=2.15.0,<2.16.0a0
+  - libvpl >=2.16.0,<2.17.0a0
   - libvpx >=1.15.2,<1.16.0a0
-  - libvulkan-loader >=1.4.328.1,<2.0a0
+  - libvulkan-loader >=1.4.341.0,<2.0a0
   - libwebp-base >=1.6.0,<2.0a0
   - libxcb >=1.17.0,<2.0a0
   - libxml2
   - libxml2-16 >=2.14.6
   - libzlib >=1.3.1,<2.0a0
   - openh264 >=2.6.0,<2.6.1.0a0
-  - openssl >=3.5.4,<4.0a0
+  - openssl >=3.5.5,<4.0a0
   - pulseaudio-client >=17.0,<17.1.0a0
   - sdl2 >=2.32.56,<3.0a0
   - shaderc >=2025.5,<2025.6.0a0
-  - svt-av1 >=4.0.0,<4.0.1.0a0
+  - svt-av1 >=4.0.1,<4.0.2.0a0
   - x264 >=1!164.3095,<1!165
   - x265 >=3.5,<3.6.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libx11 >=1.8.13,<2.0a0
   constrains:
   - __cuda  >=12.8
   license: GPL-2.0-or-later
   license_family: GPL
   purls: []
-  size: 12496109
-  timestamp: 1769486435109
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-8.0.1-gpl_h751538b_111.conda
-  sha256: 2872ac2333366dfc065c33abd604a590e5755df0afac8d0c91882f1a1522f976
-  md5: 6e00484607e124f83f36dde59755799e
+  size: 12485347
+  timestamp: 1773008832077
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-8.0.1-gpl_ha5d8480_114.conda
+  sha256: 5ad931d8ae03ad6a76104dc79189ba0838eed15b814cb12ae94aed0f139e7e66
+  md5: c61afe756ee72cdb873b4a500a674975
   depends:
   - __osx >=11.0
   - aom >=3.9.1,<3.10.0a0
   - bzip2 >=1.0.8,<2.0a0
   - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.15.0,<3.0a0
+  - fontconfig >=2.17.1,<3.0a0
   - fonts-conda-ecosystem
   - gmp >=6.3.0,<7.0a0
   - harfbuzz >=12.3.2
   - lame >=3.100,<3.101.0a0
   - libass >=0.17.4,<0.17.5.0a0
   - libcxx >=19
-  - libexpat >=2.7.3,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
+  - libexpat >=2.7.4,<3.0a0
+  - libfreetype >=2.14.2
+  - libfreetype6 >=2.14.2
   - libiconv >=1.18,<2.0a0
   - libjxl >=0.11,<1.0a0
   - liblzma >=5.8.2,<6.0a0
-  - libopenvino >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-arm-cpu-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-auto-batch-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-auto-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-hetero-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-ir-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-onnx-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-paddle-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-pytorch-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-tensorflow-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-tensorflow-lite-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopenvino >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-arm-cpu-plugin >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-auto-batch-plugin >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-auto-plugin >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-hetero-plugin >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-ir-frontend >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-onnx-frontend >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-paddle-frontend >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-pytorch-frontend >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-tensorflow-frontend >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2026.0.0,<2026.0.1.0a0
   - libopus >=1.6.1,<2.0a0
   - librsvg >=2.60.0,<3.0a0
   - libvorbis >=1.3.7,<1.4.0a0
   - libvpx >=1.15.2,<1.16.0a0
-  - libvulkan-loader >=1.4.328.1,<2.0a0
+  - libvulkan-loader >=1.4.341.0,<2.0a0
   - libwebp-base >=1.6.0,<2.0a0
   - libxml2
   - libxml2-16 >=2.14.6
   - libzlib >=1.3.1,<2.0a0
   - openh264 >=2.6.0,<2.6.1.0a0
-  - openssl >=3.5.4,<4.0a0
+  - openssl >=3.5.5,<4.0a0
   - sdl2 >=2.32.56,<3.0a0
   - shaderc >=2025.5,<2025.6.0a0
-  - svt-av1 >=4.0.0,<4.0.1.0a0
+  - svt-av1 >=4.0.1,<4.0.2.0a0
   - x264 >=1!164.3095,<1!165
   - x265 >=3.5,<3.6.0a0
   license: GPL-2.0-or-later
   license_family: GPL
   purls: []
-  size: 9536272
-  timestamp: 1769486856693
+  size: 9562305
+  timestamp: 1773009604760
 - pypi: https://files.pythonhosted.org/packages/98/73/3a18f1e1276810e81477c431009b55eeccebbd7301d28a350b77aacf3c33/filelock-3.21.2-py3-none-any.whl
   name: filelock
   version: 3.21.2
@@ -2406,21 +2561,22 @@ packages:
   purls: []
   size: 1620504
   timestamp: 1727511233259
-- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
-  sha256: 7093aa19d6df5ccb6ca50329ef8510c6acb6b0d8001191909397368b65b02113
-  md5: 8f5b0b297b59e1ac160ad4beec99dbee
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.17.1-h27c8c51_0.conda
+  sha256: aa4a44dba97151221100a637c7f4bde619567afade9c0265f8e1c8eed8d7bd8c
+  md5: 867127763fbe935bab59815b6e0b7b5c
   depends:
   - __glibc >=2.17,<3.0.a0
-  - freetype >=2.12.1,<3.0a0
-  - libexpat >=2.6.3,<3.0a0
-  - libgcc >=13
-  - libuuid >=2.38.1,<3.0a0
+  - libexpat >=2.7.4,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libgcc >=14
+  - libuuid >=2.41.3,<3.0a0
   - libzlib >=1.3.1,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 265599
-  timestamp: 1730283881107
+  size: 270705
+  timestamp: 1771382710863
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.17.1-h2b252f5_0.conda
   sha256: 851e9c778bfc54645dcab7038c0383445cbebf16f6bb2d3f62ce422b1605385a
   md5: d06ae1a11b46cc4c74177ecd28de7c7a
@@ -2496,16 +2652,6 @@ packages:
   purls: []
   size: 144010
   timestamp: 1719014356708
-- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.1-ha770c72_0.conda
-  sha256: bf8e4dffe46f7d25dc06f31038cacb01672c47b9f45201f065b0f4d00ab0a83e
-  md5: 4afc585cd97ba8a23809406cd8a9eda8
-  depends:
-  - libfreetype 2.14.1 ha770c72_0
-  - libfreetype6 2.14.1 h73754d4_0
-  license: GPL-2.0-only OR FTL
-  purls: []
-  size: 173114
-  timestamp: 1757945422243
 - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
   sha256: 858283ff33d4c033f4971bf440cebff217d5552a5222ba994c49be990dacd40d
   md5: f9f81ea472684d75b9dd8d0b328cf655
@@ -2892,63 +3038,73 @@ packages:
   - dill>=0.3.7 ; extra == 'testing'
   - array-api-extra>=0.7.0 ; extra == 'testing'
   requires_python: '>=3.10'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.3.2-h6083320_0.conda
-  sha256: 92015faf283f9c0a8109e2761042cd47ae7a4505e24af42a53bc3767cb249912
-  md5: d170a70fc1d5c605fcebdf16851bd54a
+- pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
+  name: h11
+  version: 0.16.0
+  sha256: 63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
+  requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.1.0-h6083320_0.conda
+  sha256: 22c4f6df7eb4684a4b60e62de84211e7d80a0df2d7cfdbbd093a73650e3f2d45
+  md5: ca8a94b613db5d805c3d2498a7c30997
   depends:
   - __glibc >=2.17,<3.0.a0
   - cairo >=1.18.4,<2.0a0
   - graphite2 >=1.3.14,<2.0a0
-  - icu >=78.2,<79.0a0
-  - libexpat >=2.7.3,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
+  - icu >=78.3,<79.0a0
+  - libexpat >=2.7.5,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
   - libgcc >=14
-  - libglib >=2.86.3,<3.0a0
+  - libglib >=2.86.4,<3.0a0
   - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 2035859
-  timestamp: 1769445400168
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-12.3.2-h3103d1b_0.conda
-  sha256: f68c6704610396012124a3d86b087581174c2cf7968a46b6d95ba84cd87063c7
-  md5: d0af4858d81c0c7abddc6b71fd8c0340
+  size: 2338203
+  timestamp: 1775569314754
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.1.0-h3103d1b_0.conda
+  sha256: 9c8735a49def73d88ee823c50b11ae387a2d022c6b65ad3d7ea925c6ff5c406c
+  md5: 9b356f3fd7d224a2fd438e93d0e8696b
   depends:
   - __osx >=11.0
   - cairo >=1.18.4,<2.0a0
   - graphite2 >=1.3.14,<2.0a0
-  - icu >=78.2,<79.0a0
+  - icu >=78.3,<79.0a0
   - libcxx >=19
-  - libexpat >=2.7.3,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  - libglib >=2.86.3,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libexpat >=2.7.5,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libglib >=2.86.4,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
   license: MIT
-  license_family: MIT
   purls: []
-  size: 1441619
-  timestamp: 1769446246348
-- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_106.conda
-  sha256: 1fc50ce3b86710fba3ec9c5714f1612b5ffa4230d70bfe43e2a1436eacba1621
-  md5: c223ee1429ba538f3e48cfb4a0b97357
+  size: 1888785
+  timestamp: 1775570797512
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
+  sha256: c6ff674a4a5a237fcf748fed8f64e79df54b42189986e705f35ba64dc6603235
+  md5: 1d92558abd05cea0577f83a5eca38733
   depends:
   - __glibc >=2.17,<3.0.a0
+  - aws-c-auth >=0.10.1,<0.10.2.0a0
+  - aws-c-common >=0.12.6,<0.12.7.0a0
+  - aws-c-http >=0.10.12,<0.10.13.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-s3 >=0.11.5,<0.11.6.0a0
+  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
   - libaec >=1.1.5,<2.0a0
-  - libcurl >=8.18.0,<9.0a0
+  - libcurl >=8.19.0,<9.0a0
   - libgcc >=14
   - libgfortran
   - libgfortran5 >=14.3.0
   - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
   - openssl >=3.5.5,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 3708864
-  timestamp: 1770390337946
+  size: 4138489
+  timestamp: 1775243967708
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.6-nompi_had3affe_106.conda
   sha256: e91c2b8fe62d73bb56bdb9b5adcdcbedbd164ced288e0f361b8eb3f017ddcd7b
   md5: 2d1270d283403c542680e969bea70355
@@ -2966,142 +3122,82 @@ packages:
   purls: []
   size: 3299759
   timestamp: 1770390513189
-- pypi: https://files.pythonhosted.org/packages/41/ba/8d9fd9f1083525edfcb389c93738c802f3559cb749324090d7109c8bf4c2/hf_transfer-0.1.9-cp38-abi3-macosx_11_0_arm64.whl
-  name: hf-transfer
-  version: 0.1.9
-  sha256: 8669dbcc7a3e2e8d61d42cd24da9c50d57770bd74b445c65123291ca842a7e7a
-  requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/d6/d8/f87ea6f42456254b48915970ed98e993110521e9263472840174d32c880d/hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  name: hf-transfer
-  version: 0.1.9
-  sha256: cdca9bfb89e6f8f281890cc61a8aff2d3cecaff7e1a4d275574d96ca70098557
-  requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/9a/92/cf3ab0b652b082e66876d08da57fcc6fa2f0e6c70dfbbafbd470bb73eb47/hf_xet-1.2.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/0b/f8/7aacb8e5f4a7899d39c787b5984e912e6c18b11be136ef13947d7a66d265/hf_xet-1.4.3-cp37-abi3-macosx_11_0_arm64.whl
   name: hf-xet
-  version: 1.2.0
-  sha256: 3651fd5bfe0281951b988c0facbe726aa5e347b103a675f49a3fa8144c7968fd
+  version: 1.4.3
+  sha256: e23717ce4186b265f69afa66e6f0069fe7efbf331546f5c313d00e123dc84583
   requires_dist:
   - pytest ; extra == 'tests'
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/c0/e5/a2f3eaae09da57deceb16a96ebe9ae1f6f7b9b94145a9cd3c3f994e7782a/hf_xet-1.3.1-cp37-abi3-macosx_11_0_arm64.whl
+- pypi: https://files.pythonhosted.org/packages/df/9a/a24b26dc8a65f0ecc0fe5be981a19e61e7ca963b85e062c083f3a9100529/hf_xet-1.4.3-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
   name: hf-xet
-  version: 1.3.1
-  sha256: 329c80c86f2dda776bafd2e4813a46a3ee648dce3ac0c84625902c70d7a6ddba
+  version: 1.4.3
+  sha256: fc360b70c815bf340ed56c7b8c63aacf11762a4b099b2fe2c9bd6d6068668c08
   requires_dist:
   - pytest ; extra == 'tests'
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/31/a0/651f93d154cb72323358bf2bbae3e642bdb5d2f1bfc874d096f7cb159fa0/huggingface_hub-0.35.3-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
+  name: httpcore
+  version: 1.0.9
+  sha256: 2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55
+  requires_dist:
+  - certifi
+  - h11>=0.16
+  - anyio>=4.0,<5.0 ; extra == 'asyncio'
+  - h2>=3,<5 ; extra == 'http2'
+  - socksio==1.* ; extra == 'socks'
+  - trio>=0.22.0,<1.0 ; extra == 'trio'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
+  name: httpx
+  version: 0.28.1
+  sha256: d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
+  requires_dist:
+  - anyio
+  - certifi
+  - httpcore==1.*
+  - idna
+  - brotli ; platform_python_implementation == 'CPython' and extra == 'brotli'
+  - brotlicffi ; platform_python_implementation != 'CPython' and extra == 'brotli'
+  - click==8.* ; extra == 'cli'
+  - pygments==2.* ; extra == 'cli'
+  - rich>=10,<14 ; extra == 'cli'
+  - h2>=3,<5 ; extra == 'http2'
+  - socksio==1.* ; extra == 'socks'
+  - zstandard>=0.18.0 ; extra == 'zstd'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/3d/af/10a89c54937dccf6c10792770f362d96dd67aedfde108e6e1fd7a0836789/huggingface_hub-1.9.1-py3-none-any.whl
   name: huggingface-hub
-  version: 0.35.3
-  sha256: 0e3a01829c19d86d03793e4577816fe3bdfc1602ac62c7fb220d593d351224ba
+  version: 1.9.1
+  sha256: 8dae771b969b318203727a6c6c5209d25e661f6f0dd010fc09cc4a12cf81c657
   requires_dist:
-  - filelock
+  - filelock>=3.10.0
   - fsspec>=2023.5.0
+  - hf-xet>=1.4.3,<2.0.0 ; platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
+  - httpx>=0.23.0,<1
   - packaging>=20.9
   - pyyaml>=5.1
-  - requests
   - tqdm>=4.42.1
-  - typing-extensions>=3.7.4.3
-  - hf-xet>=1.1.3,<2.0.0 ; platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
-  - inquirerpy==0.3.4 ; extra == 'all'
-  - aiohttp ; extra == 'all'
-  - authlib>=1.3.2 ; extra == 'all'
-  - fastapi ; extra == 'all'
-  - httpx ; extra == 'all'
-  - itsdangerous ; extra == 'all'
-  - jedi ; extra == 'all'
-  - jinja2 ; extra == 'all'
-  - pytest>=8.1.1,<8.2.2 ; extra == 'all'
-  - pytest-cov ; extra == 'all'
-  - pytest-env ; extra == 'all'
-  - pytest-xdist ; extra == 'all'
-  - pytest-vcr ; extra == 'all'
-  - pytest-asyncio ; extra == 'all'
-  - pytest-rerunfailures<16.0 ; extra == 'all'
-  - pytest-mock ; extra == 'all'
-  - urllib3<2.0 ; extra == 'all'
-  - soundfile ; extra == 'all'
-  - pillow ; extra == 'all'
-  - gradio>=4.0.0 ; extra == 'all'
-  - numpy ; extra == 'all'
-  - ruff>=0.9.0 ; extra == 'all'
-  - libcst>=1.4.0 ; extra == 'all'
-  - ty ; extra == 'all'
-  - typing-extensions>=4.8.0 ; extra == 'all'
-  - types-pyyaml ; extra == 'all'
-  - types-requests ; extra == 'all'
-  - types-simplejson ; extra == 'all'
-  - types-toml ; extra == 'all'
-  - types-tqdm ; extra == 'all'
-  - types-urllib3 ; extra == 'all'
-  - mypy>=1.14.1,<1.15.0 ; python_full_version == '3.8.*' and extra == 'all'
-  - mypy==1.15.0 ; python_full_version >= '3.9' and extra == 'all'
-  - inquirerpy==0.3.4 ; extra == 'cli'
-  - inquirerpy==0.3.4 ; extra == 'dev'
-  - aiohttp ; extra == 'dev'
-  - authlib>=1.3.2 ; extra == 'dev'
-  - fastapi ; extra == 'dev'
-  - httpx ; extra == 'dev'
-  - itsdangerous ; extra == 'dev'
-  - jedi ; extra == 'dev'
-  - jinja2 ; extra == 'dev'
-  - pytest>=8.1.1,<8.2.2 ; extra == 'dev'
-  - pytest-cov ; extra == 'dev'
-  - pytest-env ; extra == 'dev'
-  - pytest-xdist ; extra == 'dev'
-  - pytest-vcr ; extra == 'dev'
-  - pytest-asyncio ; extra == 'dev'
-  - pytest-rerunfailures<16.0 ; extra == 'dev'
-  - pytest-mock ; extra == 'dev'
-  - urllib3<2.0 ; extra == 'dev'
-  - soundfile ; extra == 'dev'
-  - pillow ; extra == 'dev'
-  - gradio>=4.0.0 ; extra == 'dev'
-  - numpy ; extra == 'dev'
-  - ruff>=0.9.0 ; extra == 'dev'
-  - libcst>=1.4.0 ; extra == 'dev'
-  - ty ; extra == 'dev'
-  - typing-extensions>=4.8.0 ; extra == 'dev'
-  - types-pyyaml ; extra == 'dev'
-  - types-requests ; extra == 'dev'
-  - types-simplejson ; extra == 'dev'
-  - types-toml ; extra == 'dev'
-  - types-tqdm ; extra == 'dev'
-  - types-urllib3 ; extra == 'dev'
-  - mypy>=1.14.1,<1.15.0 ; python_full_version == '3.8.*' and extra == 'dev'
-  - mypy==1.15.0 ; python_full_version >= '3.9' and extra == 'dev'
-  - toml ; extra == 'fastai'
-  - fastai>=2.4 ; extra == 'fastai'
-  - fastcore>=1.3.27 ; extra == 'fastai'
-  - hf-transfer>=0.1.4 ; extra == 'hf-transfer'
-  - hf-xet>=1.1.2,<2.0.0 ; extra == 'hf-xet'
-  - aiohttp ; extra == 'inference'
-  - mcp>=1.8.0 ; extra == 'mcp'
-  - typer ; extra == 'mcp'
-  - aiohttp ; extra == 'mcp'
+  - typer
+  - typing-extensions>=4.1.0
   - authlib>=1.3.2 ; extra == 'oauth'
   - fastapi ; extra == 'oauth'
   - httpx ; extra == 'oauth'
   - itsdangerous ; extra == 'oauth'
-  - ruff>=0.9.0 ; extra == 'quality'
-  - libcst>=1.4.0 ; extra == 'quality'
-  - ty ; extra == 'quality'
-  - mypy>=1.14.1,<1.15.0 ; python_full_version == '3.8.*' and extra == 'quality'
-  - mypy==1.15.0 ; python_full_version >= '3.9' and extra == 'quality'
-  - tensorflow ; extra == 'tensorflow'
-  - pydot ; extra == 'tensorflow'
-  - graphviz ; extra == 'tensorflow'
-  - tensorflow ; extra == 'tensorflow-testing'
-  - keras<3.0 ; extra == 'tensorflow-testing'
-  - inquirerpy==0.3.4 ; extra == 'testing'
-  - aiohttp ; extra == 'testing'
+  - torch ; extra == 'torch'
+  - safetensors[torch] ; extra == 'torch'
+  - toml ; extra == 'fastai'
+  - fastai>=2.4 ; extra == 'fastai'
+  - fastcore>=1.3.27 ; extra == 'fastai'
+  - hf-xet>=1.4.3,<2.0.0 ; extra == 'hf-xet'
+  - mcp>=1.8.0 ; extra == 'mcp'
   - authlib>=1.3.2 ; extra == 'testing'
   - fastapi ; extra == 'testing'
   - httpx ; extra == 'testing'
   - itsdangerous ; extra == 'testing'
   - jedi ; extra == 'testing'
   - jinja2 ; extra == 'testing'
-  - pytest>=8.1.1,<8.2.2 ; extra == 'testing'
+  - pytest>=8.4.2 ; extra == 'testing'
   - pytest-cov ; extra == 'testing'
   - pytest-env ; extra == 'testing'
   - pytest-xdist ; extra == 'testing'
@@ -3112,21 +3208,85 @@ packages:
   - urllib3<2.0 ; extra == 'testing'
   - soundfile ; extra == 'testing'
   - pillow ; extra == 'testing'
-  - gradio>=4.0.0 ; extra == 'testing'
   - numpy ; extra == 'testing'
-  - torch ; extra == 'torch'
-  - safetensors[torch] ; extra == 'torch'
+  - duckdb ; extra == 'testing'
+  - fastapi ; extra == 'testing'
+  - gradio>=5.0.0 ; extra == 'gradio'
+  - requests ; extra == 'gradio'
   - typing-extensions>=4.8.0 ; extra == 'typing'
   - types-pyyaml ; extra == 'typing'
-  - types-requests ; extra == 'typing'
   - types-simplejson ; extra == 'typing'
   - types-toml ; extra == 'typing'
   - types-tqdm ; extra == 'typing'
   - types-urllib3 ; extra == 'typing'
-  requires_python: '>=3.8.0'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
-  sha256: 142a722072fa96cf16ff98eaaf641f54ab84744af81754c292cb81e0881c0329
-  md5: 186a18e3ba246eccfc7cff00cd19a870
+  - ruff>=0.9.0 ; extra == 'quality'
+  - mypy==1.15.0 ; extra == 'quality'
+  - libcst>=1.4.0 ; extra == 'quality'
+  - ty ; extra == 'quality'
+  - authlib>=1.3.2 ; extra == 'all'
+  - fastapi ; extra == 'all'
+  - httpx ; extra == 'all'
+  - itsdangerous ; extra == 'all'
+  - jedi ; extra == 'all'
+  - jinja2 ; extra == 'all'
+  - pytest>=8.4.2 ; extra == 'all'
+  - pytest-cov ; extra == 'all'
+  - pytest-env ; extra == 'all'
+  - pytest-xdist ; extra == 'all'
+  - pytest-vcr ; extra == 'all'
+  - pytest-asyncio ; extra == 'all'
+  - pytest-rerunfailures<16.0 ; extra == 'all'
+  - pytest-mock ; extra == 'all'
+  - urllib3<2.0 ; extra == 'all'
+  - soundfile ; extra == 'all'
+  - pillow ; extra == 'all'
+  - numpy ; extra == 'all'
+  - duckdb ; extra == 'all'
+  - fastapi ; extra == 'all'
+  - ruff>=0.9.0 ; extra == 'all'
+  - mypy==1.15.0 ; extra == 'all'
+  - libcst>=1.4.0 ; extra == 'all'
+  - ty ; extra == 'all'
+  - typing-extensions>=4.8.0 ; extra == 'all'
+  - types-pyyaml ; extra == 'all'
+  - types-simplejson ; extra == 'all'
+  - types-toml ; extra == 'all'
+  - types-tqdm ; extra == 'all'
+  - types-urllib3 ; extra == 'all'
+  - authlib>=1.3.2 ; extra == 'dev'
+  - fastapi ; extra == 'dev'
+  - httpx ; extra == 'dev'
+  - itsdangerous ; extra == 'dev'
+  - jedi ; extra == 'dev'
+  - jinja2 ; extra == 'dev'
+  - pytest>=8.4.2 ; extra == 'dev'
+  - pytest-cov ; extra == 'dev'
+  - pytest-env ; extra == 'dev'
+  - pytest-xdist ; extra == 'dev'
+  - pytest-vcr ; extra == 'dev'
+  - pytest-asyncio ; extra == 'dev'
+  - pytest-rerunfailures<16.0 ; extra == 'dev'
+  - pytest-mock ; extra == 'dev'
+  - urllib3<2.0 ; extra == 'dev'
+  - soundfile ; extra == 'dev'
+  - pillow ; extra == 'dev'
+  - numpy ; extra == 'dev'
+  - duckdb ; extra == 'dev'
+  - fastapi ; extra == 'dev'
+  - ruff>=0.9.0 ; extra == 'dev'
+  - mypy==1.15.0 ; extra == 'dev'
+  - libcst>=1.4.0 ; extra == 'dev'
+  - ty ; extra == 'dev'
+  - typing-extensions>=4.8.0 ; extra == 'dev'
+  - types-pyyaml ; extra == 'dev'
+  - types-simplejson ; extra == 'dev'
+  - types-toml ; extra == 'dev'
+  - types-tqdm ; extra == 'dev'
+  - types-urllib3 ; extra == 'dev'
+  requires_python: '>=3.10.0'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+  sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
+  md5: c80d8a3b84358cb967fa81e7075fbc8a
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -3134,18 +3294,18 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 12728445
-  timestamp: 1767969922681
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.2-h38cb7af_0.conda
-  sha256: d4cefbca587429d1192509edc52c88de52bc96c2447771ddc1f8bee928aed5ef
-  md5: 1e93aca311da0210e660d2247812fa02
+  size: 12723451
+  timestamp: 1773822285671
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
+  sha256: 3a7907a17e9937d3a46dfd41cffaf815abad59a569440d1e25177c15fd0684e5
+  md5: f1182c91c0de31a7abd40cedf6a5ebef
   depends:
   - __osx >=11.0
   license: MIT
   license_family: MIT
   purls: []
-  size: 12358010
-  timestamp: 1767970350308
+  size: 12361647
+  timestamp: 1773822915649
 - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
   name: idna
   version: '3.11'
@@ -3291,19 +3451,6 @@ packages:
   - pkg:pypi/iniconfig?source=compressed-mapping
   size: 13387
   timestamp: 1760831448842
-- pypi: https://files.pythonhosted.org/packages/ce/ff/3b59672c47c6284e8005b42e84ceba13864aa0f39f067c973d1af02f5d91/InquirerPy-0.3.4-py3-none-any.whl
-  name: inquirerpy
-  version: 0.3.4
-  sha256: c65fdfbac1fa00e3ee4fb10679f4d3ed7a012abf4833910e63c295827fe2a7d4
-  requires_dist:
-  - sphinx>=4.1.2,<5.0.0 ; extra == 'docs'
-  - furo>=2021.8.17b43,<2022.0.0 ; extra == 'docs'
-  - myst-parser>=0.15.1,<0.16.0 ; extra == 'docs'
-  - pfzy>=0.3.1,<0.4.0
-  - prompt-toolkit>=3.0.1,<4.0.0
-  - sphinx-autobuild>=2021.3.14,<2022.0.0 ; extra == 'docs'
-  - sphinx-copybutton>=0.4.0,<0.5.0 ; extra == 'docs'
-  requires_python: '>=3.7,<4.0'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/intel-gmmlib-22.9.0-hb700be7_0.conda
   sha256: edad668db79c6c4899d46e1cd4a331f5d008f9ed8f7d2e39e1dfe1a2d81acec0
   md5: 26311c5112b5c713f472bdfbb5ec5aa3
@@ -3316,20 +3463,20 @@ packages:
   purls: []
   size: 1009795
   timestamp: 1765886047465
-- conda: https://conda.anaconda.org/conda-forge/linux-64/intel-media-driver-25.3.4-hecca717_0.conda
-  sha256: 286679d4c175e8db2d047be766d1629f1ea5828bff9fe7e6aac2e6f0fad2b427
-  md5: 7ae2034a0e2e24eb07468f1a50cdf0bb
+- conda: https://conda.anaconda.org/conda-forge/linux-64/intel-media-driver-26.1.5-hecca717_0.conda
+  sha256: 11392c7e965a68548754f17b0e358f54590c233da6cbcdac1096c2a39ff0f6da
+  md5: 6124ffce32e909624a446aa5c419faec
   depends:
   - __glibc >=2.17,<3.0.a0
-  - intel-gmmlib >=22.8.1,<23.0a0
+  - intel-gmmlib >=22.9.0,<23.0a0
   - libgcc >=14
   - libstdcxx >=14
-  - libva >=2.22.0,<3.0a0
+  - libva >=2.23.0,<3.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 8424610
-  timestamp: 1757591682198
+  size: 8786646
+  timestamp: 1774266925285
 - conda: https://conda.anaconda.org/conda-forge/noarch/isort-5.13.2-pyhd8ed1ab_1.conda
   sha256: 6ebf6e83c2d449760ad5c5cc344711d6404f9e3cf6952811b8678aca5a4ab01f
   md5: ef7dc847f19fe4859d5aaa33385bf509
@@ -3342,30 +3489,32 @@ packages:
   - pkg:pypi/isort?source=hash-mapping
   size: 73545
   timestamp: 1733236278052
-- conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.8-he3c4edf_0.conda
-  sha256: 0e919ec86d980901d8cbb665e91f5e9bddb5ff662178f25aed6d63f999fd9afc
-  md5: a04073db11c2c86c555fb088acc8f8c1
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.9-h1588d4d_1.conda
+  sha256: a6a9858eadb4c794b56a1c954c1d4f4b57d96c9fb87092dd46f5bff9b0697b35
+  md5: 115ecf05370670f93bc81a8c4f7fd57f
   depends:
   - __glibc >=2.17,<3.0.a0
   - freeglut >=3.2.2,<4.0a0
+  - libexpat >=2.7.4,<3.0a0
   - libgcc >=14
+  - libgl >=1.7.0,<2.0a0
   - libglu >=9.0.3,<10.0a0
   - libglu >=9.0.3,<9.1.0a0
-  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libjpeg-turbo >=3.1.2,<4.0a0
   license: JasPer-2.0
   purls: []
-  size: 681643
-  timestamp: 1754514437930
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.8-hc0e5025_0.conda
-  sha256: 0d8a77e026a441c2c65616046a6ddcfffa42c5987bce1c51d352959653e2fb07
-  md5: 54d2328b8db98729ab21f60a4aba9f7c
+  size: 684185
+  timestamp: 1773677703432
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.9-h7543a42_1.conda
+  sha256: 58bfd15b7426f99ca2b1854535d4ede1ca2a35be4f8c43c5e34b6ffdcfd7a5c8
+  md5: e3f3a2a62fbaad99f327440dfd8a3ac3
   depends:
   - __osx >=11.0
-  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libjpeg-turbo >=3.1.2,<4.0a0
   license: JasPer-2.0
   purls: []
-  size: 585257
-  timestamp: 1754514688308
+  size: 584700
+  timestamp: 1773681839297
 - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
   name: jinja2
   version: 3.1.6
@@ -3402,21 +3551,22 @@ packages:
   purls: []
   size: 134088
   timestamp: 1754905959823
-- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
-  sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
-  md5: 3f43953b7d3fb3aaa1d0d0723d91e368
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
+  sha256: 3e307628ca3527448dd1cb14ad7bb9d04d1d28c7d4c5f97ba196ae984571dd25
+  md5: fb53fb07ce46a575c5d004bbc96032c2
   depends:
-  - keyutils >=1.6.1,<2.0a0
-  - libedit >=3.1.20191231,<3.2.0a0
-  - libedit >=3.1.20191231,<4.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - openssl >=3.3.1,<4.0a0
+  - __glibc >=2.17,<3.0.a0
+  - keyutils >=1.6.3,<2.0a0
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - openssl >=3.5.5,<4.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 1370023
-  timestamp: 1719463201255
+  size: 1386730
+  timestamp: 1769769569681
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
   sha256: 4442f957c3c77d69d9da3521268cad5d54c9033f1a73f99cde0a3658937b159b
   md5: c6dc8a0fdec13a0565936655c33069a1
@@ -3496,28 +3646,29 @@ packages:
   purls: []
   size: 188306
   timestamp: 1745264362794
-- pypi: https://files.pythonhosted.org/packages/d9/c9/c38f0bfe33527d1b139f67850d6a4c113d42d630cbf4846d02e3d6372d97/lerobot-0.4.3-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/60/8e/8e3763ad36ba0efb9ba0381ae06d328b54081587b45b0c1d049b26ed8d8c/lerobot-0.5.1-py3-none-any.whl
   name: lerobot
-  version: 0.4.3
-  sha256: b08c1c15b2356bd4e658122deabfb9dacd2d7447de4a4327720991723d4edf2c
+  version: 0.5.1
+  sha256: bbd11021023fde0947b6d1ff1c52fe91c86a28ab09a96359892f3ef7e8866862
   requires_dist:
-  - datasets>=4.0.0,<4.2.0
+  - datasets>=4.0.0,<5.0.0
   - diffusers>=0.27.2,<0.36.0
-  - huggingface-hub[cli,hf-transfer]>=0.34.2,<0.36.0
+  - huggingface-hub>=1.0.0,<2.0.0
   - accelerate>=1.10.0,<2.0.0
+  - numpy>=2.0.0,<2.3.0
   - setuptools>=71.0.0,<81.0.0
   - cmake>=3.29.0.1,<4.2.0
+  - packaging>=24.2,<26.0
+  - torch>=2.7,<2.11.0
+  - torchcodec>=0.3.0,<0.11.0 ; (platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l' and platform_machine != 'x86_64' and sys_platform != 'win32') or (platform_machine == 'aarch64' and sys_platform != 'linux' and sys_platform != 'win32') or (platform_machine == 'arm64' and sys_platform != 'linux' and sys_platform != 'win32') or (platform_machine == 'armv7l' and sys_platform != 'linux' and sys_platform != 'win32') or (platform_machine == 'x86_64' and sys_platform != 'darwin' and sys_platform != 'win32')
+  - torchvision>=0.22.0,<0.26.0
   - einops>=0.8.0,<0.9.0
-  - opencv-python-headless>=4.9.0,<4.13.0
+  - opencv-python-headless>=4.9.0,<4.14.0
   - av>=15.0.0,<16.0.0
   - jsonlines>=4.0.0,<5.0.0
-  - packaging>=24.2,<26.0
-  - pynput>=1.7.7,<1.9.0
+  - pynput>=1.7.8,<1.9.0
   - pyserial>=3.5,<4.0
   - wandb>=0.24.0,<0.25.0
-  - torch>=2.2.1,<2.8.0
-  - torchcodec>=0.2.1,<0.6.0 ; (platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l' and platform_machine != 'x86_64' and sys_platform != 'win32') or (platform_machine == 'aarch64' and sys_platform != 'linux' and sys_platform != 'win32') or (platform_machine == 'arm64' and sys_platform != 'linux' and sys_platform != 'win32') or (platform_machine == 'armv7l' and sys_platform != 'linux' and sys_platform != 'win32') or (platform_machine == 'x86_64' and sys_platform != 'darwin' and sys_platform != 'win32')
-  - torchvision>=0.21.0,<0.23.0
   - draccus==0.10.0
   - gymnasium>=1.1.1,<2.0.0
   - rerun-sdk>=0.24.0,<0.27.0
@@ -3525,12 +3676,21 @@ packages:
   - imageio[ffmpeg]>=2.34.0,<3.0.0
   - termcolor>=2.4.0,<4.0.0
   - pygame>=2.5.1,<2.7.0 ; extra == 'pygame-dep'
-  - placo>=0.9.6,<0.10.0 ; extra == 'placo-dep'
-  - transformers>=4.57.1,<5.0.0 ; extra == 'transformers-dep'
+  - placo>=0.9.6,<0.9.17 ; extra == 'placo-dep'
+  - transformers==5.3.0 ; extra == 'transformers-dep'
   - grpcio==1.73.1 ; extra == 'grpcio-dep'
   - protobuf>=6.31.1,<6.32.0 ; extra == 'grpcio-dep'
+  - python-can>=4.2.0,<5.0.0 ; extra == 'can-dep'
+  - peft>=0.18.0,<1.0.0 ; extra == 'peft-dep'
+  - scipy>=1.14.0,<2.0.0 ; extra == 'scipy-dep'
+  - qwen-vl-utils>=0.0.11,<0.1.0 ; extra == 'qwen-vl-utils-dep'
+  - matplotlib>=3.10.3,<4.0.0 ; extra == 'matplotlib-dep'
+  - contourpy>=1.3.0,<2.0.0 ; extra == 'matplotlib-dep'
   - feetech-servo-sdk>=1.0.0,<2.0.0 ; extra == 'feetech'
   - dynamixel-sdk>=3.7.31,<3.9.0 ; extra == 'dynamixel'
+  - lerobot[can-dep] ; extra == 'damiao'
+  - lerobot[can-dep] ; extra == 'robstride'
+  - lerobot[damiao] ; extra == 'openarms'
   - lerobot[pygame-dep] ; extra == 'gamepad'
   - hidapi>=0.14.0,<0.15.0 ; extra == 'gamepad'
   - lerobot[feetech] ; extra == 'hopejr'
@@ -3539,24 +3699,32 @@ packages:
   - pyzmq>=26.2.1,<28.0.0 ; extra == 'lekiwi'
   - pyzmq>=26.2.1,<28.0.0 ; extra == 'unitree-g1'
   - onnxruntime>=1.16.0,<2.0.0 ; extra == 'unitree-g1'
+  - onnx>=1.16.0,<2.0.0 ; extra == 'unitree-g1'
+  - meshcat>=0.3.0,<0.4.0 ; extra == 'unitree-g1'
+  - lerobot[matplotlib-dep] ; extra == 'unitree-g1'
+  - lerobot[pygame-dep] ; extra == 'unitree-g1'
   - reachy2-sdk>=1.0.15,<1.1.0 ; extra == 'reachy2'
   - lerobot[placo-dep] ; extra == 'kinematics'
   - pyrealsense2>=2.55.1.6486,<2.57.0 ; sys_platform != 'darwin' and extra == 'intelrealsense'
-  - pyrealsense2-macosx>=2.54,<2.55.0 ; sys_platform == 'darwin' and extra == 'intelrealsense'
+  - pyrealsense2-macosx>=2.54,<2.57.0 ; sys_platform == 'darwin' and extra == 'intelrealsense'
   - hebi-py>=2.8.0,<2.12.0 ; extra == 'phone'
   - teleop>=0.1.0,<0.2.0 ; extra == 'phone'
   - fastapi<1.0 ; extra == 'phone'
-  - transformers==4.49.0 ; extra == 'wallx'
-  - peft==0.17.1 ; extra == 'wallx'
-  - scipy==1.15.3 ; extra == 'wallx'
-  - torchdiffeq==0.2.5 ; extra == 'wallx'
-  - qwen-vl-utils==0.0.11 ; extra == 'wallx'
+  - lerobot[scipy-dep] ; extra == 'phone'
+  - lerobot[transformers-dep] ; extra == 'wallx'
+  - lerobot[peft] ; extra == 'wallx'
+  - lerobot[scipy-dep] ; extra == 'wallx'
+  - torchdiffeq>=0.2.4,<0.3.0 ; extra == 'wallx'
+  - lerobot[qwen-vl-utils-dep] ; extra == 'wallx'
+  - lerobot[transformers-dep] ; extra == 'pi'
+  - lerobot[scipy-dep] ; extra == 'pi'
   - lerobot[transformers-dep] ; extra == 'smolvla'
   - num2words>=0.5.14,<0.6.0 ; extra == 'smolvla'
   - accelerate>=1.7.0,<2.0.0 ; extra == 'smolvla'
   - safetensors>=0.4.3,<1.0.0 ; extra == 'smolvla'
+  - lerobot[transformers-dep] ; extra == 'multi-task-dit'
   - lerobot[transformers-dep] ; extra == 'groot'
-  - peft>=0.13.0,<1.0.0 ; extra == 'groot'
+  - lerobot[peft] ; extra == 'groot'
   - dm-tree>=0.1.8,<1.0.0 ; extra == 'groot'
   - timm>=1.0.0,<1.1.0 ; extra == 'groot'
   - safetensors>=0.4.3,<1.0.0 ; extra == 'groot'
@@ -3566,17 +3734,17 @@ packages:
   - flash-attn>=2.5.9,<3.0.0 ; sys_platform != 'darwin' and extra == 'groot'
   - lerobot[transformers-dep] ; extra == 'sarm'
   - faker>=33.0.0,<35.0.0 ; extra == 'sarm'
-  - matplotlib>=3.10.3,<4.0.0 ; extra == 'sarm'
-  - qwen-vl-utils>=0.0.14,<0.1.0 ; extra == 'sarm'
+  - lerobot[matplotlib-dep] ; extra == 'sarm'
+  - lerobot[qwen-vl-utils-dep] ; extra == 'sarm'
   - lerobot[transformers-dep] ; extra == 'xvla'
   - lerobot[transformers-dep] ; extra == 'hilserl'
   - gym-hil>=0.1.13,<0.2.0 ; extra == 'hilserl'
   - lerobot[grpcio-dep] ; extra == 'hilserl'
   - lerobot[placo-dep] ; extra == 'hilserl'
   - lerobot[grpcio-dep] ; extra == 'async'
-  - matplotlib>=3.10.3,<4.0.0 ; extra == 'async'
+  - lerobot[matplotlib-dep] ; extra == 'async'
   - lerobot[transformers-dep] ; extra == 'peft'
-  - peft>=0.18.0,<1.0.0 ; extra == 'peft'
+  - lerobot[peft-dep] ; extra == 'peft'
   - pre-commit>=3.7.0,<5.0.0 ; extra == 'dev'
   - debugpy>=1.8.1,<1.9.0 ; extra == 'dev'
   - lerobot[grpcio-dep] ; extra == 'dev'
@@ -3589,11 +3757,15 @@ packages:
   - scikit-image>=0.23.2,<0.26.0 ; extra == 'video-benchmark'
   - pandas>=2.2.2,<2.4.0 ; extra == 'video-benchmark'
   - gym-aloha>=0.1.2,<0.2.0 ; extra == 'aloha'
+  - lerobot[scipy-dep] ; extra == 'aloha'
   - gym-pusht>=0.1.5,<0.2.0 ; extra == 'pusht'
   - pymunk>=6.6.0,<7.0.0 ; extra == 'pusht'
   - lerobot[transformers-dep] ; extra == 'libero'
-  - hf-libero>=0.1.3,<0.2.0 ; extra == 'libero'
+  - hf-libero>=0.1.3,<0.2.0 ; sys_platform == 'linux' and extra == 'libero'
+  - lerobot[scipy-dep] ; extra == 'libero'
   - metaworld==3.0.0 ; extra == 'metaworld'
+  - lerobot[scipy-dep] ; extra == 'metaworld'
+  - scipy>=1.14.0,<2.0.0 ; extra == 'all'
   - lerobot[dynamixel] ; extra == 'all'
   - lerobot[gamepad] ; extra == 'all'
   - lerobot[hopejr] ; extra == 'all'
@@ -3601,6 +3773,8 @@ packages:
   - lerobot[reachy2] ; extra == 'all'
   - lerobot[kinematics] ; extra == 'all'
   - lerobot[intelrealsense] ; extra == 'all'
+  - lerobot[wallx] ; extra == 'all'
+  - lerobot[pi] ; extra == 'all'
   - lerobot[smolvla] ; extra == 'all'
   - lerobot[xvla] ; extra == 'all'
   - lerobot[hilserl] ; extra == 'all'
@@ -3611,16 +3785,16 @@ packages:
   - lerobot[aloha] ; extra == 'all'
   - lerobot[pusht] ; extra == 'all'
   - lerobot[phone] ; extra == 'all'
-  - lerobot[libero] ; extra == 'all'
+  - lerobot[libero] ; sys_platform == 'linux' and extra == 'all'
   - lerobot[metaworld] ; extra == 'all'
   - lerobot[sarm] ; extra == 'all'
   - lerobot[peft] ; extra == 'all'
-  requires_python: '>=3.10'
-- pypi: git+https://github.com/koonpeng/lerobot-ros?subdirectory=lerobot_robot_ros&rev=b4a635fc5264266bd1575f07d54be3d4bbd620e0#b4a635fc5264266bd1575f07d54be3d4bbd620e0
+  requires_python: '>=3.12'
+- pypi: git+https://github.com/koonpeng/lerobot-ros?subdirectory=lerobot_robot_ros&rev=87708d0ae14a724bca78f8ae9d55448332509a57#87708d0ae14a724bca78f8ae9d55448332509a57
   name: lerobot-robot-ros
   version: 0.1.0
   requires_dist:
-  - lerobot>=0.4.0,<0.5.0
+  - lerobot>=0.5.0,<0.6.0
   - rclpy
   - control-msgs
   - sensor-msgs
@@ -3628,16 +3802,16 @@ packages:
   - geometry-msgs
   - moveit-msgs
   requires_python: '>=3.10'
-- pypi: git+https://github.com/koonpeng/lerobot-ros?subdirectory=lerobot_teleoperator_devices&rev=b4a635fc5264266bd1575f07d54be3d4bbd620e0#b4a635fc5264266bd1575f07d54be3d4bbd620e0
+- pypi: git+https://github.com/koonpeng/lerobot-ros?subdirectory=lerobot_teleoperator_devices&rev=87708d0ae14a724bca78f8ae9d55448332509a57#87708d0ae14a724bca78f8ae9d55448332509a57
   name: lerobot-teleoperator-devices
   version: 0.1.0
   requires_dist:
-  - lerobot>=0.4.0,<0.5.0
+  - lerobot>=0.5.0,<0.6.0
   - pygame
   requires_python: '>=3.10'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/level-zero-1.28.0-hb700be7_0.conda
-  sha256: 863e1caf9d0086f93b66c43bf646481bb820fffdf037425c511cb0a54d18d1fc
-  md5: a4724e93a90434575b889adb4dc57b49
+- conda: https://conda.anaconda.org/conda-forge/linux-64/level-zero-1.28.2-hb700be7_0.conda
+  sha256: 5384380213daffbd7fe4d568b2cf2ab9f2476f7a5f228a3d70280e98333eaf0f
+  md5: 4323e07abff8366503b97a0f17924b76
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -3645,37 +3819,37 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 672752
-  timestamp: 1770189828697
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20250512.1-cxx17_hba17884_0.conda
-  sha256: dcd1429a1782864c452057a6c5bc1860f2b637dc20a2b7e6eacd57395bbceff8
-  md5: 83b160d4da3e1e847bf044997621ed63
+  size: 858387
+  timestamp: 1772045965844
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
+  sha256: a7a4481a4d217a3eadea0ec489826a69070fcc3153f00443aa491ed21527d239
+  md5: 6f7b4302263347698fd24565fbf11310
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
+  - libgcc >=14
+  - libstdcxx >=14
   constrains:
-  - libabseil-static =20250512.1=cxx17*
-  - abseil-cpp =20250512.1
+  - libabseil-static =20260107.1=cxx17*
+  - abseil-cpp =20260107.1
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 1310612
-  timestamp: 1750194198254
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20250512.1-cxx17_hd41c47c_0.conda
-  sha256: 7f0ee9ae7fa2cf7ac92b0acf8047c8bac965389e48be61bf1d463e057af2ea6a
-  md5: 360dbb413ee2c170a0a684a33c4fc6b8
+  size: 1384817
+  timestamp: 1770863194876
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20260107.1-cxx17_h2062a1b_0.conda
+  sha256: 756611fbb8d2957a5b4635d9772bd8432cb6ddac05580a6284cca6fdc9b07fca
+  md5: bb65152e0d7c7178c0f1ee25692c9fd1
   depends:
   - __osx >=11.0
-  - libcxx >=18
+  - libcxx >=19
   constrains:
-  - libabseil-static =20250512.1=cxx17*
-  - abseil-cpp =20250512.1
+  - abseil-cpp =20260107.1
+  - libabseil-static =20260107.1=cxx17*
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 1174081
-  timestamp: 1750194620012
+  size: 1229639
+  timestamp: 1770863511331
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libacl-2.3.2-h0f662aa_0.conda
   sha256: 1b704cf161c6f84658a7ac534555ef365ec982f23576b1c4ae4cac4baeb61685
   md5: ef8039969013acacf5b741092aef2ee7
@@ -3745,35 +3919,35 @@ packages:
   purls: []
   size: 138339
   timestamp: 1749328988096
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.3.0-h316e467_3.conda
-  sha256: f5ab201b8b4e1f776ced0340c59f87e441fd6763d3face527b5cf3f2280502c9
-  md5: 22d5cc5fb45aab8ed3c00cde2938b825
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.4.1-hcfa2d63_0.conda
+  sha256: e29d8ed0334305c6bafecb32f9a1967cfc0a081eac916e947a1f2f7c4bb41947
+  md5: f79415aee8862b3af85ea55dea37e46b
   depends:
   - __glibc >=2.17,<3.0.a0
   - aom >=3.9.1,<3.10.0a0
   - dav1d >=1.2.1,<1.2.2.0a0
   - libgcc >=14
-  - rav1e >=0.7.1,<0.8.0a0
-  - svt-av1 >=4.0.0,<4.0.1.0a0
+  - rav1e >=0.8.1,<0.9.0a0
+  - svt-av1 >=4.0.1,<4.0.2.0a0
   license: BSD-2-Clause
   license_family: BSD
   purls: []
-  size: 140323
-  timestamp: 1769476997956
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.3.0-hde9513d_3.conda
-  sha256: 92eb3f8134586972145378b21ac789a65ee232d7c1ef01ce5bfc9e850d0e0e60
-  md5: 6e9bcb90cfd20178a52f355030aba237
+  size: 148710
+  timestamp: 1774042709303
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.4.1-hfce71f6_0.conda
+  sha256: 09e31e51026a3b74d947ba4b30a68dd99013aeef2860bcb03565bf43cad18da6
+  md5: 2df04ee54a2ce2d34cf375eb02a63725
   depends:
   - __osx >=11.0
   - aom >=3.9.1,<3.10.0a0
   - dav1d >=1.2.1,<1.2.2.0a0
-  - rav1e >=0.7.1,<0.8.0a0
-  - svt-av1 >=4.0.0,<4.0.1.0a0
+  - rav1e >=0.8.1,<0.9.0a0
+  - svt-av1 >=4.0.1,<4.0.2.0a0
   license: BSD-2-Clause
   license_family: BSD
   purls: []
-  size: 111474
-  timestamp: 1769477399074
+  size: 118959
+  timestamp: 1774043016600
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-5_h4a7cf45_openblas.conda
   build_number: 5
   sha256: 18c72545080b86739352482ba14ba2c4815e19e26a7417ca21a95b76ec8da24c
@@ -3931,32 +4105,32 @@ packages:
   purls: []
   size: 14062741
   timestamp: 1767957389675
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp21.1-21.1.8-default_h99862b1_3.conda
-  sha256: de512ce246faec2d4f7766774769921a85b5aa053a74abd2f8c97ad50b393aac
-  md5: 24a2802074d26aecfdbc9b3f1d8168d1
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.0-default_h99862b1_0.conda
+  sha256: 914da94dbf829192b2bb360a7684b32e46f047a57de96a2f5ab39a011aeae6ea
+  md5: d966a23335e090a5410cc4f0dec8d00a
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libllvm21 >=21.1.8,<21.2.0a0
+  - libllvm22 >=22.1.0,<22.2.0a0
   - libstdcxx >=14
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 21066639
-  timestamp: 1770190428756
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-21.1.8-default_h746c552_3.conda
-  sha256: 8215f7553e2640461c1d9564147db4d0b31169cc31bb65c9db9fd38ccd73146e
-  md5: b4277f5a09d458a0306db3147bd0171c
+  size: 21661249
+  timestamp: 1772101075353
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.0-default_h746c552_0.conda
+  sha256: 4a9dd814492a129f2ff40cd4ab0b942232c9e3c6dbc0d0aaf861f1f65e99cc7d
+  md5: 140459a7413d8f6884eb68205ce39a0d
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libllvm21 >=21.1.8,<21.2.0a0
+  - libllvm22 >=22.1.0,<22.2.0a0
   - libstdcxx >=14
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 12349894
-  timestamp: 1770190719381
+  size: 12817500
+  timestamp: 1772101411287
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-21.1.8-default_h13b06bd_3.conda
   sha256: dc803069f4001aae4bdd6069af20140785a9c1a0c9abe6a3704e0ef87ad0f4c2
   md5: d111e982033ec02a55845e994a6db09a
@@ -3969,37 +4143,37 @@ packages:
   purls: []
   size: 8516482
   timestamp: 1771032974531
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-hb8b1518_5.conda
-  sha256: cb83980c57e311783ee831832eb2c20ecb41e7dee6e86e8b70b8cef0e43eab55
-  md5: d4a250da4737ee127fb1fa6452a9002e
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+  sha256: 205c4f19550f3647832ec44e35e6d93c8c206782bdd620c1d7cf66237580ff9c
+  md5: 49c553b47ff679a6a1e9fc80b9c5a2d4
   depends:
   - __glibc >=2.17,<3.0.a0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libgcc >=13
-  - libstdcxx >=13
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=14
+  - libstdcxx >=14
   - libzlib >=1.3.1,<2.0a0
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 4523621
-  timestamp: 1749905341688
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.18.0-h4e3cde8_0.conda
-  sha256: 5454709d9fb6e9c3dd6423bc284fa7835a7823bfa8323f6e8786cdd555101fab
-  md5: 0a5563efed19ca4461cf927419b6eb73
+  size: 4518030
+  timestamp: 1770902209173
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.19.0-hcf29cc6_0.conda
+  sha256: a0390fd0536ebcd2244e243f5f00ab8e76ab62ed9aa214cd54470fe7496620f4
+  md5: d50608c443a30c341c24277d28290f76
   depends:
   - __glibc >=2.17,<3.0.a0
-  - krb5 >=1.21.3,<1.22.0a0
+  - krb5 >=1.22.2,<1.23.0a0
   - libgcc >=14
   - libnghttp2 >=1.67.0,<2.0a0
   - libssh2 >=1.11.1,<2.0a0
   - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.4,<4.0a0
+  - openssl >=3.5.5,<4.0a0
   - zstd >=1.5.7,<1.6.0a0
   license: curl
   license_family: MIT
   purls: []
-  size: 462942
-  timestamp: 1767821743793
+  size: 466704
+  timestamp: 1773218522665
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.18.0-he38603e_0.conda
   sha256: 11c78b3e89bc332933386f0a11ac60d9200afb7a811b9e3bec98aef8d4a6389b
   md5: 36190179a799f3aee3c2d20a8a2b970d
@@ -4112,31 +4286,31 @@ packages:
   purls: []
   size: 107458
   timestamp: 1702146414478
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.3-hecca717_0.conda
-  sha256: 1e1b08f6211629cbc2efe7a5bca5953f8f6b3cae0eeb04ca4dacee1bd4e2db2f
-  md5: 8b09ae86839581147ef2e5c5e229d164
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.5-hecca717_0.conda
+  sha256: e8c2b57f6aacabdf2f1b0924bd4831ce5071ba080baa4a9e8c0d720588b6794c
+  md5: 49f570f3bc4c874a06ea69b7225753af
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   constrains:
-  - expat 2.7.3.*
+  - expat 2.7.5.*
   license: MIT
   license_family: MIT
   purls: []
-  size: 76643
-  timestamp: 1763549731408
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.4-hf6b4638_0.conda
-  sha256: 03887d8080d6a8fe02d75b80929271b39697ecca7628f0657d7afaea87761edf
-  md5: a92e310ae8dfc206ff449f362fc4217f
+  size: 76624
+  timestamp: 1774719175983
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.5-hf6b4638_0.conda
+  sha256: 06780dec91dd25770c8cf01e158e1062fbf7c576b1406427475ce69a8af75b7e
+  md5: a32123f93e168eaa4080d87b0fb5da8a
   depends:
   - __osx >=11.0
   constrains:
-  - expat 2.7.4.*
+  - expat 2.7.5.*
   license: MIT
   license_family: MIT
   purls: []
-  size: 68199
-  timestamp: 1771260020767
+  size: 68192
+  timestamp: 1774719211725
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
   sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
   md5: a360c33a5abe61c07959e449fa1453eb
@@ -4172,51 +4346,51 @@ packages:
   purls: []
   size: 424563
   timestamp: 1764526740626
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda
-  sha256: 4641d37faeb97cf8a121efafd6afd040904d4bca8c46798122f417c31d5dfbec
-  md5: f4084e4e6577797150f9b04a4560ceb0
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+  sha256: 38f014a7129e644636e46064ecd6b1945e729c2140e21d75bb476af39e692db2
+  md5: e289f3d17880e44b633ba911d57a321b
   depends:
-  - libfreetype6 >=2.14.1
+  - libfreetype6 >=2.14.3
   license: GPL-2.0-only OR FTL
   purls: []
-  size: 7664
-  timestamp: 1757945417134
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.1-hce30654_0.conda
-  sha256: 9de25a86066f078822d8dd95a83048d7dc2897d5d655c0e04a8a54fca13ef1ef
-  md5: f35fb38e89e2776994131fbf961fa44b
+  size: 8049
+  timestamp: 1774298163029
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_0.conda
+  sha256: a047a2f238362a37d484f9620e8cba29f513a933cd9eb68571ad4b270d6f8f3e
+  md5: f73b109d49568d5d1dda43bb147ae37f
   depends:
-  - libfreetype6 >=2.14.1
+  - libfreetype6 >=2.14.3
   license: GPL-2.0-only OR FTL
   purls: []
-  size: 7810
-  timestamp: 1757947168537
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.1-h73754d4_0.conda
-  sha256: 4a7af818a3179fafb6c91111752954e29d3a2a950259c14a2fc7ba40a8b03652
-  md5: 8e7251989bca326a28f4a5ffbd74557a
+  size: 8091
+  timestamp: 1774298691258
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
+  sha256: 16f020f96da79db1863fcdd8f2b8f4f7d52f177dd4c58601e38e9182e91adf1d
+  md5: fb16b4b69e3f1dcfe79d80db8fd0c55d
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libpng >=1.6.50,<1.7.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libpng >=1.6.55,<1.7.0a0
+  - libzlib >=1.3.2,<2.0a0
   constrains:
-  - freetype >=2.14.1
+  - freetype >=2.14.3
   license: GPL-2.0-only OR FTL
   purls: []
-  size: 386739
-  timestamp: 1757945416744
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.1-h6da58f4_0.conda
-  sha256: cc4aec4c490123c0f248c1acd1aeab592afb6a44b1536734e20937cda748f7cd
-  md5: 6d4ede03e2a8e20eb51f7f681d2a2550
+  size: 384575
+  timestamp: 1774298162622
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.3-hdfa99f5_0.conda
+  sha256: ff764608e1f2839e95e2cf9b243681475f8778c36af7a42b3f78f476fdbb1dd3
+  md5: e98ba7b5f09a5f450eca083d5a1c4649
   depends:
   - __osx >=11.0
-  - libpng >=1.6.50,<1.7.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libpng >=1.6.55,<1.7.0a0
+  - libzlib >=1.3.2,<2.0a0
   constrains:
-  - freetype >=2.14.1
+  - freetype >=2.14.3
   license: GPL-2.0-only OR FTL
   purls: []
-  size: 346703
-  timestamp: 1757947166116
+  size: 338085
+  timestamp: 1774298689297
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_17.conda
   sha256: 43860222cf3abf04ded0cf24541a105aa388e0e1d4d6ca46258e186d4e87ae3e
   md5: 3c281169ea25b987311400d7a7e28445
@@ -4314,9 +4488,9 @@ packages:
   purls: []
   size: 134712
   timestamp: 1731330998354
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.3-h6548e54_1.conda
-  sha256: cf44d4ae071b524b1e1bbd0eb9bc428715b41c735a6cdce97ec6f813160dcedc
-  md5: 5b5846bc2b23e07a1d61b89dcb67fcf0
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.4-h6548e54_1.conda
+  sha256: a27e44168a1240b15659888ce0d9b938ed4bdb49e9ea68a7c1ff27bcea8b55ce
+  md5: bb26456332b07f68bf3b7622ed71c0da
   depends:
   - __glibc >=2.17,<3.0.a0
   - libffi >=3.5.2,<3.6.0a0
@@ -4325,11 +4499,11 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   - pcre2 >=10.47,<10.48.0a0
   constrains:
-  - glib 2.86.3 *_1
+  - glib 2.86.4 *_1
   license: LGPL-2.1-or-later
   purls: []
-  size: 4368329
-  timestamp: 1770929706446
+  size: 4398701
+  timestamp: 1771863239578
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.86.4-he378b5c_1.conda
   sha256: a4254a241a96198e019ced2e0d2967e4c0ef64fac32077a45c065b32dc2b15d2
   md5: 673069f6725ed7b1073f9b96094294d1
@@ -4592,22 +4766,6 @@ packages:
   purls: []
   size: 26914852
   timestamp: 1757353228286
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm21-21.1.8-hf7376ad_0.conda
-  sha256: 91bb4f5be1601b40b4995911d785e29387970f0b3c80f33f7f9028f95335399f
-  md5: 1a2708a460884d6861425b7f9a7bef99
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libzlib >=1.3.1,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  purls: []
-  size: 44333366
-  timestamp: 1765959132513
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm21-21.1.8-h8e0c9ce_0.conda
   sha256: 3f4512155aca799a25937f9ee794490794fb33f8f90a5e6532d8be869e7d79a0
   md5: 8fc5b2387a7907cd58805668dad3b70f
@@ -4623,6 +4781,22 @@ packages:
   purls: []
   size: 29398498
   timestamp: 1765924904821
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.2-hf7376ad_0.conda
+  sha256: eda0013a9979d142f520747e3621749c493f5fbc8f9d13a52ac7a2b699338e7c
+  md5: 7147b0792a803cd5b9929ce5d48f7818
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 44217146
+  timestamp: 1774480335347
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
   sha256: 755c55ebab181d678c12e49cced893598f2bab22d582fbbf4d8b83c18be207eb
   md5: c7c83eecbb72d88b940c249af56c8b17
@@ -4646,39 +4820,39 @@ packages:
   purls: []
   size: 92242
   timestamp: 1768752982486
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
-  sha256: a4a7dab8db4dc81c736e9a9b42bdfd97b087816e029e221380511960ac46c690
-  md5: b499ce4b026493a13774bcf0f4c33849
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+  sha256: 663444d77a42f2265f54fb8b48c5450bfff4388d9c0f8253dd7855f0d993153f
+  md5: 2a45e7f8af083626f009645a6481f12d
   depends:
   - __glibc >=2.17,<3.0.a0
-  - c-ares >=1.34.5,<2.0a0
+  - c-ares >=1.34.6,<2.0a0
   - libev >=4.33,<4.34.0a0
   - libev >=4.33,<5.0a0
   - libgcc >=14
   - libstdcxx >=14
   - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.2,<4.0a0
+  - openssl >=3.5.5,<4.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 666600
-  timestamp: 1756834976695
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.67.0-hc438710_0.conda
-  sha256: a07cb53b5ffa2d5a18afc6fd5a526a5a53dd9523fbc022148bd2f9395697c46d
-  md5: a4b4dd73c67df470d091312ab87bf6ae
+  size: 663344
+  timestamp: 1773854035739
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h8f3e76b_0.conda
+  sha256: 2bc7bc3978066f2c274ebcbf711850cc9ab92e023e433b9631958a098d11e10a
+  md5: 6ea18834adbc3b33df9bd9fb45eaf95b
   depends:
   - __osx >=11.0
-  - c-ares >=1.34.5,<2.0a0
+  - c-ares >=1.34.6,<2.0a0
   - libcxx >=19
   - libev >=4.33,<4.34.0a0
   - libev >=4.33,<5.0a0
   - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.2,<4.0a0
+  - openssl >=3.5.5,<4.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 575454
-  timestamp: 1756835746393
+  size: 576526
+  timestamp: 1773854624224
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
   sha256: 927fe72b054277cde6cb82597d0fcf6baf127dcbce2e0a9d8925a68f1265eef5
   md5: d864d34357c3b65a4b731f78c0801dc4
@@ -4760,106 +4934,106 @@ packages:
   purls: []
   size: 4284132
   timestamp: 1768547079205
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.12.0-qt6_py312h52d6ec5_612.conda
-  sha256: 73b3c2f1bc8417d297bc71e895236c7a23ac6c3a6bffe617eada876b66fd3280
-  md5: 872b744a711e7948710f70a79926e207
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.13.0-qt6_py312h10ee65c_605.conda
+  sha256: 61478238a1e2ade5db06425067c605d226e55edd1706ab615cff61ae58a6b194
+  md5: 3b590bd5b15e5f15a0cee3bc538be9b1
   depends:
   - __glibc >=2.17,<3.0.a0
   - _openmp_mutex >=4.5
   - ffmpeg >=8.0.1,<9.0a0
-  - harfbuzz >=12.2.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - harfbuzz >=13.2.1
+  - hdf5 >=2.1.0,<3.0a0
   - imath >=3.2.2,<3.2.3.0a0
-  - jasper >=4.2.8,<5.0a0
-  - libavif16 >=1.3.0,<2.0a0
+  - jasper >=4.2.9,<5.0a0
+  - libavif16 >=1.4.1,<2.0a0
   - libcblas >=3.9.0,<4.0a0
   - libegl >=1.7.0,<2.0a0
-  - libexpat >=2.7.3,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
+  - libexpat >=2.7.5,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
   - libgcc >=14
   - libgl >=1.7.0,<2.0a0
   - libiconv >=1.18,<2.0a0
   - libjpeg-turbo >=3.1.2,<4.0a0
-  - libjxl >=0.11,<0.12.0a0
+  - libjxl >=0.11,<1.0a0
   - liblapack >=3.9.0,<4.0a0
   - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-auto-batch-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-auto-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-hetero-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-intel-cpu-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-intel-gpu-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-intel-npu-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-ir-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-onnx-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-paddle-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-pytorch-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-tensorflow-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-tensorflow-lite-frontend >=2025.4.1,<2025.4.2.0a0
-  - libpng >=1.6.53,<1.7.0a0
-  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libopenvino >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-auto-batch-plugin >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-auto-plugin >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-hetero-plugin >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-intel-cpu-plugin >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-intel-gpu-plugin >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-intel-npu-plugin >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-ir-frontend >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-onnx-frontend >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-paddle-frontend >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-pytorch-frontend >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-tensorflow-frontend >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2026.0.0,<2026.0.1.0a0
+  - libpng >=1.6.56,<1.7.0a0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
   - libstdcxx >=14
   - libtiff >=4.7.1,<4.8.0a0
   - libwebp-base >=1.6.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
   - numpy >=1.23,<3
-  - openexr >=3.4.4,<3.5.0a0
-  - qt6-main >=6.10.1,<6.11.0a0
+  - openexr >=3.4.8,<3.5.0a0
+  - qt6-main >=6.10.2,<6.11.0a0
   license: Apache-2.0
   license_family: Apache
   purls:
   - pkg:pypi/opencv-python?source=hash-mapping
   - pkg:pypi/opencv-python-headless?source=hash-mapping
-  size: 32672205
-  timestamp: 1766495315053
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.12.0-qt6_py312h74f5ed3_612.conda
-  sha256: a27a0fbec81fd4993bb146e22bf93f2a3f8a7d43365a2517e04b958d5a96547e
-  md5: 72cb8bc75dd263ca2575999d83548bfa
+  size: 33412356
+  timestamp: 1774790748050
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.13.0-qt6_py312hc9399c9_605.conda
+  sha256: e7b5aaf0a80bf37d085b9ecb3a2284c4ce9cb8c1ef9f8947b4515abe83988ef9
+  md5: 0b97bf5b07c356de2b3c2545c3528ade
   depends:
   - __osx >=11.0
   - ffmpeg >=8.0.1,<9.0a0
-  - harfbuzz >=12.2.0
+  - harfbuzz >=13.2.1
   - hdf5 >=1.14.6,<1.14.7.0a0
   - imath >=3.2.2,<3.2.3.0a0
-  - jasper >=4.2.8,<5.0a0
-  - libavif16 >=1.3.0,<2.0a0
+  - jasper >=4.2.9,<5.0a0
+  - libavif16 >=1.4.1,<2.0a0
   - libcblas >=3.9.0,<4.0a0
   - libcxx >=19
-  - libexpat >=2.7.3,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
+  - libexpat >=2.7.5,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
   - libiconv >=1.18,<2.0a0
   - libjpeg-turbo >=3.1.2,<4.0a0
-  - libjxl >=0.11,<0.12.0a0
+  - libjxl >=0.11,<1.0a0
   - liblapack >=3.9.0,<4.0a0
   - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-arm-cpu-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-auto-batch-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-auto-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-hetero-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-ir-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-onnx-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-paddle-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-pytorch-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-tensorflow-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-tensorflow-lite-frontend >=2025.4.1,<2025.4.2.0a0
-  - libpng >=1.6.53,<1.7.0a0
-  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libopenvino >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-arm-cpu-plugin >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-auto-batch-plugin >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-auto-plugin >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-hetero-plugin >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-ir-frontend >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-onnx-frontend >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-paddle-frontend >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-pytorch-frontend >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-tensorflow-frontend >=2026.0.0,<2026.0.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2026.0.0,<2026.0.1.0a0
+  - libpng >=1.6.56,<1.7.0a0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
   - libtiff >=4.7.1,<4.8.0a0
   - libwebp-base >=1.6.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
   - numpy >=1.23,<3
-  - openexr >=3.4.4,<3.5.0a0
-  - qt6-main >=6.10.1,<6.11.0a0
+  - openexr >=3.4.7,<3.5.0a0
+  - qt6-main >=6.10.2,<6.11.0a0
   license: Apache-2.0
   license_family: Apache
   purls:
   - pkg:pypi/opencv-python?source=hash-mapping
   - pkg:pypi/opencv-python-headless?source=hash-mapping
-  size: 17396503
-  timestamp: 1766496988356
+  size: 17974952
+  timestamp: 1774792303140
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
   sha256: 215086c108d80349e96051ad14131b751d17af3ed2cb5a34edd62fa89bfe8ead
   md5: 7df50d44d4a14d6c31a2c54f2cd92157
@@ -4870,299 +5044,347 @@ packages:
   purls: []
   size: 50757
   timestamp: 1731330993524
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2025.4.1-hb56ce9e_1.conda
-  sha256: d85e5e3b6dc56d6fdfe0c51a8af92407a7ef4fc5584d0e172d059033b8d6d3e0
-  md5: 9c4a59b80f7fc8da96bb807db95be69c
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2026.0.0-hb56ce9e_1.conda
+  sha256: a396a2d1aa267f21c98717ac097138b32e41e4c40ae501729bded3801476eeb5
+  md5: 9f0596e995efe372c470ff45c93131cb
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
   - pugixml >=1.15,<1.16.0a0
   - tbb >=2022.3.0
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 6504144
-  timestamp: 1769904250547
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2025.4.1-h3e6d54f_1.conda
-  sha256: 0589a3f7d44f151b9269cb87ac3373670a55591712e5be8229dc0871899af6c7
-  md5: f55a563a1ce81d56eccbcc4b441cf9d1
+  size: 6582302
+  timestamp: 1772727204779
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2026.0.0-h3e6d54f_1.conda
+  sha256: ffbd4a3c8540dfaddbdd68cf3073967a3c8faadd97d7df912f73734e53f9213e
+  md5: 8e140a6e2a1db294892a8da72c9afb0e
   depends:
   - __osx >=11.0
   - libcxx >=19
   - pugixml >=1.15,<1.16.0a0
   - tbb >=2022.3.0
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 4468925
-  timestamp: 1769897301943
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2025.4.1-h3e6d54f_1.conda
-  sha256: 5b0376624797a3766e8bcf084b1fdcdd59a2a8274945b5f19fa6d1c782e64e18
-  md5: f627ab701f81f8ddf1cdec094461cf9e
+  size: 4515660
+  timestamp: 1772716610278
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2026.0.0-h3e6d54f_1.conda
+  sha256: 352ebc24805cb756ef11afa5c9606b3e19da99e434afc35cddc356538b5ec49d
+  md5: 48f3117552be579619620f3b6768b52f
   depends:
   - __osx >=11.0
   - libcxx >=19
-  - libopenvino 2025.4.1 h3e6d54f_1
+  - libopenvino 2026.0.0 h3e6d54f_1
   - pugixml >=1.15,<1.16.0a0
   - tbb >=2022.3.0
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 8678582
-  timestamp: 1769897348300
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2025.4.1-hd85de46_1.conda
-  sha256: 7ec8faf6b4541f098b5c5c399b971075a1cca0a9bec19aa4ed4e70a88026496c
-  md5: 937020cf4502334abd149c0393d1f50e
+  size: 8759182
+  timestamp: 1772716648998
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2026.0.0-hd85de46_1.conda
+  sha256: 286de85805dc69ce0bd25367ae2a20c8096ddef35eb2483474eb246dacd5387e
+  md5: ee41df976413676f794af2785b291b0c
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libopenvino 2025.4.1 hb56ce9e_1
+  - libopenvino 2026.0.0 hb56ce9e_1
   - libstdcxx >=14
   - tbb >=2022.3.0
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 114792
-  timestamp: 1769904275716
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2025.4.1-h2406d2e_1.conda
-  sha256: ef97964a4c5ba8398eb6b8731279d844281864beb13f718f5f63beee3b598051
-  md5: 20cb6e2612e1a217cfc6e01175eb5d3b
+  size: 114431
+  timestamp: 1772727230331
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2026.0.0-h2406d2e_1.conda
+  sha256: 1cbbf43149334ccf793f782bd0924e08e5952c667578ac33a33076a4ab54ad47
+  md5: 6012967b53bf790c2ad9160c2779d7bc
   depends:
   - __osx >=11.0
   - libcxx >=19
-  - libopenvino 2025.4.1 h3e6d54f_1
+  - libopenvino 2026.0.0 h3e6d54f_1
   - tbb >=2022.3.0
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 105772
-  timestamp: 1769897414427
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2025.4.1-hd85de46_1.conda
-  sha256: aee3ae9d91a098263023fc2cb4b2d1e58a7111984c6503ae6e7c8e1169338f02
-  md5: d6e354f426f1a7a818a5ddcd930eec32
+  size: 105710
+  timestamp: 1772716704250
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2026.0.0-hd85de46_1.conda
+  sha256: 9988ed6339a5eb044ae8d079e2b22f5a310c41e49a0cf716057f30b21ef9cec2
+  md5: ca025fa5c42ba94453636a2ae333de6b
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libopenvino 2025.4.1 hb56ce9e_1
+  - libopenvino 2026.0.0 hb56ce9e_1
   - libstdcxx >=14
   - tbb >=2022.3.0
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 250114
-  timestamp: 1769904292210
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2025.4.1-h2406d2e_1.conda
-  sha256: 2dc43f0c05b2b94c4af692627db42adf1578ef46b07ae827b6cc9e9f1bc3f984
-  md5: 08e7fd889776ba8bbb1505d35711c33f
+  size: 249056
+  timestamp: 1772727247597
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2026.0.0-h2406d2e_1.conda
+  sha256: fa6c01a897ccc92998cae1e75ac65c68f311ad0834182801d5d3139ac307309f
+  md5: 52839e682c6bde645a9f4cdcdfc33639
   depends:
   - __osx >=11.0
   - libcxx >=19
-  - libopenvino 2025.4.1 h3e6d54f_1
+  - libopenvino 2026.0.0 h3e6d54f_1
   - tbb >=2022.3.0
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 217339
-  timestamp: 1769897484900
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2025.4.1-hd41364c_1.conda
-  sha256: bcf3d31a2bcc666b848506fb52b2979a28d7035e9942d39121d4ea64a27bfbfb
-  md5: 4fc70db8bc65b02ee9f0af2b76c7fa11
+  size: 213574
+  timestamp: 1772716732087
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2026.0.0-hd41364c_1.conda
+  sha256: c7db498aeda5b0f36b347f4211b93b66ba108faaf54157a08bae8fa3c3af5f81
+  md5: 07a23e96db38f63d9763f666b2db66aa
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libopenvino 2025.4.1 hb56ce9e_1
+  - libopenvino 2026.0.0 hb56ce9e_1
   - libstdcxx >=14
   - pugixml >=1.15,<1.16.0a0
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 212030
-  timestamp: 1769904308850
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2025.4.1-h85cbfa6_1.conda
-  sha256: 184941cb92e9a6bbb18fce85429759d7aa0c4ad1c09f408e976f4997198e2ff3
-  md5: 4e6ebb59f3d49bf1471a3bc02353f45d
+  size: 211582
+  timestamp: 1772727264950
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2026.0.0-h85cbfa6_1.conda
+  sha256: 18e6b6d061d27049e2a34fbd1a633209294eb700aa7eee7a3d2877ce4d45888b
+  md5: 77d314ff80fb262dbe061527dec60263
   depends:
   - __osx >=11.0
   - libcxx >=19
-  - libopenvino 2025.4.1 h3e6d54f_1
+  - libopenvino 2026.0.0 h3e6d54f_1
   - pugixml >=1.15,<1.16.0a0
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 185400
-  timestamp: 1769897516071
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2025.4.1-hb56ce9e_1.conda
-  sha256: 0ce2e257c87076aff0a19f4b9bb79a40fcfea04090e66b2f960cb341b9860c8e
-  md5: 2b9d3633dd182fa09a4ee935d841e0cb
+  size: 184975
+  timestamp: 1772716757394
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2026.0.0-hb56ce9e_1.conda
+  sha256: 01a28c0bd1f205b3800e7759e30bc8e8a75836e0d5a73a745b4da42837bbb174
+  md5: b43b96578573ddbcc8d084ae6e44c964
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libopenvino 2025.4.1 hb56ce9e_1
+  - libopenvino 2026.0.0 hb56ce9e_1
   - libstdcxx >=14
   - pugixml >=1.15,<1.16.0a0
   - tbb >=2022.3.0
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 12956806
-  timestamp: 1769904325853
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2025.4.1-hb56ce9e_1.conda
-  sha256: ca1981eb418551a6dbf0ab754a2b7297aae1131e36cde9001862ffdf23625f9d
-  md5: 1d2c0d22a6e2da0f7bcab32e9fe685d3
+  size: 13173323
+  timestamp: 1772727282718
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2026.0.0-hb56ce9e_1.conda
+  sha256: 720b87e1d5f1a10c577e040d4bf425072a978e925c6dfab8b1551bc848007c94
+  md5: 26e8e92c90d1a22af6eac8e9507d9b8f
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libopenvino 2025.4.1 hb56ce9e_1
+  - libopenvino 2026.0.0 hb56ce9e_1
   - libstdcxx >=14
   - ocl-icd >=2.3.3,<3.0a0
   - pugixml >=1.15,<1.16.0a0
   - tbb >=2022.3.0
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 11421657
-  timestamp: 1769904366195
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2025.4.1-hb56ce9e_1.conda
-  sha256: 0b3bb86bceb8f5f0d074c26f697e3dfc638f5886754d31252db3aff8a1608e82
-  md5: feb5d4c644bba35147fbcf375a4962ed
+  size: 11402462
+  timestamp: 1772727323957
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2026.0.0-hb56ce9e_1.conda
+  sha256: df7eb2b23a1af38f2cd2281353309f2e2a04da1374ecedc7c6745c2a67ba617c
+  md5: 01ba8b179ac45b2b37fe2d4225dddcc7
   depends:
   - __glibc >=2.17,<3.0.a0
-  - level-zero >=1.27.0,<2.0a0
+  - level-zero >=1.28.2,<2.0a0
   - libgcc >=14
-  - libopenvino 2025.4.1 hb56ce9e_1
+  - libopenvino 2026.0.0 hb56ce9e_1
   - libstdcxx >=14
   - pugixml >=1.15,<1.16.0a0
   - tbb >=2022.3.0
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 1743490
-  timestamp: 1769904403110
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2025.4.1-hd41364c_1.conda
-  sha256: 124df6a82752ac14b7d08a4345be7a5d7295183e7f76a7960af97e0b869d754d
-  md5: 07d4163e2859d645d065f2a627d5595a
+  size: 1994640
+  timestamp: 1772727360780
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2026.0.0-hd41364c_1.conda
+  sha256: 8e7356b0b80b3f180615e264694d6811d388b210155d419553ff64e42f78ffa0
+  md5: aa002c4d343b01cdcc458c95cd071d1b
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libopenvino 2025.4.1 hb56ce9e_1
+  - libopenvino 2026.0.0 hb56ce9e_1
   - libstdcxx >=14
   - pugixml >=1.15,<1.16.0a0
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 200411
-  timestamp: 1769904421156
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2025.4.1-h85cbfa6_1.conda
-  sha256: ed472f67904e621fe2f4b3c5247e1d7dc64539b1ccfef62ea8866500bef49b58
-  md5: f14c43137b800ad303f2d2bc6dacdd8c
+  size: 192778
+  timestamp: 1772727380069
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2026.0.0-h85cbfa6_1.conda
+  sha256: 166792875fe62f90a528a4931f29ea18cf74694469870e98c8772460f92fc653
+  md5: c7f37a124ab9a53444d213a3db5f9747
   depends:
   - __osx >=11.0
   - libcxx >=19
-  - libopenvino 2025.4.1 h3e6d54f_1
+  - libopenvino 2026.0.0 h3e6d54f_1
   - pugixml >=1.15,<1.16.0a0
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 177982
-  timestamp: 1769897546956
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2025.4.1-h1862bb8_1.conda
-  sha256: 22faa2b16c13558c3e245f12deffca6f89e22752dd0135c0826fbbeb43e90603
-  md5: 195f9d73c2ca55de60846d8bd274cf41
+  size: 172169
+  timestamp: 1772716782643
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2026.0.0-h7a07914_1.conda
+  sha256: 35a68214201e807bd9a31f94e618cb6a5385198e89eef46dde6c122cff77da58
+  md5: 218084544c2e7e78e4b8877ec37b8cdb
   depends:
   - __glibc >=2.17,<3.0.a0
   - libabseil * cxx17*
-  - libabseil >=20250512.1,<20250513.0a0
+  - libabseil >=20260107.1,<20260108.0a0
   - libgcc >=14
-  - libopenvino 2025.4.1 hb56ce9e_1
-  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libopenvino 2026.0.0 hb56ce9e_1
+  - libprotobuf >=6.33.5,<6.33.6.0a0
   - libstdcxx >=14
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 1902792
-  timestamp: 1769904438153
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2025.4.1-h7fb59aa_1.conda
-  sha256: 3c93097c46b54bc58d79523cd8fa9e1d4b41349eebea27511b06c6b2cfb36ed6
-  md5: aef846dbe6f1a1d03a621d791d520639
+  size: 1860687
+  timestamp: 1772727397981
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2026.0.0-h41365f2_1.conda
+  sha256: eb307ee1ad8eb47aa011d03d77995bfd1153b80893ab5880fd928093ad50cab4
+  md5: 8d32df9ac0c17ba2735e26be190399f6
   depends:
   - __osx >=11.0
   - libabseil * cxx17*
-  - libabseil >=20250512.1,<20250513.0a0
+  - libabseil >=20260107.1,<20260108.0a0
   - libcxx >=19
-  - libopenvino 2025.4.1 h3e6d54f_1
-  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libopenvino 2026.0.0 h3e6d54f_1
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 1410212
-  timestamp: 1769897576431
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2025.4.1-h1862bb8_1.conda
-  sha256: f03aba53f64b0e2dae1989f9ff680fdc955d087424e1e00c34f3436815c49f18
-  md5: 0ccbdeaf77b0dc8b09cbacd756c2250f
+  size: 1425474
+  timestamp: 1772716809587
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2026.0.0-h7a07914_1.conda
+  sha256: cb37b717480207a66443a93d4342cf88210a74c0820fc0edd70e4fc791a64779
+  md5: 74915e5e271ef76a89f711eff5959a75
   depends:
   - __glibc >=2.17,<3.0.a0
   - libabseil * cxx17*
-  - libabseil >=20250512.1,<20250513.0a0
+  - libabseil >=20260107.1,<20260108.0a0
   - libgcc >=14
-  - libopenvino 2025.4.1 hb56ce9e_1
-  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libopenvino 2026.0.0 hb56ce9e_1
+  - libprotobuf >=6.33.5,<6.33.6.0a0
   - libstdcxx >=14
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 745483
-  timestamp: 1769904456844
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2025.4.1-h7fb59aa_1.conda
-  sha256: 88daf2873ab4d8c61214379fc1eecd986c97f13e2a717c0d26d2ddeacc130eb7
-  md5: aa9e90952781f2313c875add9b586a8a
+  size: 684224
+  timestamp: 1772727417276
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2026.0.0-h41365f2_1.conda
+  sha256: e3ca93158beac502b65256ae78736889e8b40184b0dc938a1b8136ae2a0c3a4d
+  md5: 6c821b72c8e5b0467f3d39a33e357064
   depends:
   - __osx >=11.0
   - libabseil * cxx17*
-  - libabseil >=20250512.1,<20250513.0a0
+  - libabseil >=20260107.1,<20260108.0a0
   - libcxx >=19
-  - libopenvino 2025.4.1 h3e6d54f_1
-  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libopenvino 2026.0.0 h3e6d54f_1
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 451149
-  timestamp: 1769897609571
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2025.4.1-hecca717_1.conda
-  sha256: 5edd997be35bbdda6c8916de46a4ae7f321af6a6b07ba136228404cb713bcbe9
-  md5: 8d6450b5a6a5c33439a38b954511eb45
+  size: 434092
+  timestamp: 1772716839090
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2026.0.0-hecca717_1.conda
+  sha256: 086469e5cd8bfde48975fe8641a7d6924e3da00d75dd06c99e03a78df03a0568
+  md5: 559ef86008749861a53025f669004f18
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libopenvino 2025.4.1 hb56ce9e_1
+  - libopenvino 2026.0.0 hb56ce9e_1
   - libstdcxx >=14
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 1266512
-  timestamp: 1769904473901
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2025.4.1-hf6b4638_1.conda
-  sha256: 2144e28ad266fa1a2c0d0f6eb5da8602d104aa6c87a819d3fefbd781afbddfc6
-  md5: ffe333e6dd2aaaffef46c15a3440c393
+  size: 1185558
+  timestamp: 1772727435039
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2026.0.0-hf6b4638_1.conda
+  sha256: c694e5dc1bbb2ea876e65c8c33b148a24f56b5f7a60f8449ca62b159d9020709
+  md5: 7cd9c1d466e5be74f5cb32f545b1b887
   depends:
   - __osx >=11.0
   - libcxx >=19
-  - libopenvino 2025.4.1 h3e6d54f_1
+  - libopenvino 2026.0.0 h3e6d54f_1
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 835496
-  timestamp: 1769897637129
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2025.4.1-h0767aad_1.conda
-  sha256: 15aa71394abf35d3a25d2d8f68e419f9dbbc57a0849bc1f8ae34589b77f96aa7
-  md5: 9de5caa2cccb13b7bb765a915edb5aa8
+  size: 823766
+  timestamp: 1772716865028
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2026.0.0-h78e8023_1.conda
+  sha256: 3a9a404bc9fd39e7395d49f4bd8facb58a01a31aeceabe8723a9d4f8eb5cc381
+  md5: fb20f4234bc0e29af1baa13d35e36785
   depends:
   - __glibc >=2.17,<3.0.a0
   - libabseil * cxx17*
-  - libabseil >=20250512.1,<20250513.0a0
+  - libabseil >=20260107.1,<20260108.0a0
   - libgcc >=14
-  - libopenvino 2025.4.1 hb56ce9e_1
-  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libopenvino 2026.0.0 hb56ce9e_1
+  - libprotobuf >=6.33.5,<6.33.6.0a0
   - libstdcxx >=14
   - snappy >=1.2.2,<1.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 1324086
-  timestamp: 1769904491964
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2025.4.1-hf92d75f_1.conda
-  sha256: fac08e13fc4e132e9fbad351980fd9c6cde940ec87a579900caf56afd1f86fba
-  md5: f8d7d2f54ed7ddd512472c52afcef7f8
+  size: 1257870
+  timestamp: 1772727453738
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2026.0.0-hc295da0_1.conda
+  sha256: f680809aef09ca68d7446e3f1810ca3f3d9f744cbfe3a8d8ec9bd807f17d80fd
+  md5: 09d1d2b4e5648afd706e2252299087f4
   depends:
   - __osx >=11.0
   - libabseil * cxx17*
-  - libabseil >=20250512.1,<20250513.0a0
+  - libabseil >=20260107.1,<20260108.0a0
   - libcxx >=19
-  - libopenvino 2025.4.1 h3e6d54f_1
-  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libopenvino 2026.0.0 h3e6d54f_1
+  - libprotobuf >=6.33.5,<6.33.6.0a0
   - snappy >=1.2.2,<1.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 937402
-  timestamp: 1769897666625
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2025.4.1-hecca717_1.conda
-  sha256: 13d8f823cd137bcfa7830c13e114e43288b4d43f5d599c4bec3e8f9d07233a29
-  md5: 1a9afdd2b66ba2da54b31298d63e352e
+  size: 910147
+  timestamp: 1772716892527
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2026.0.0-hecca717_1.conda
+  sha256: e7cee37c92ed0b62c0458c13937b6ad66319f1879f236a31c3a67391a999f429
+  md5: 0f0281435478b981f672a44d0029018c
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libopenvino 2025.4.1 hb56ce9e_1
+  - libopenvino 2026.0.0 hb56ce9e_1
   - libstdcxx >=14
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 496261
-  timestamp: 1769904509651
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2025.4.1-hf6b4638_1.conda
-  sha256: 612729d6cebcd0a96f7026ad52997149ed415d799dd2c6c85de0d0bca68913ef
-  md5: 2e8dc14845f37fcda4b047c37f47d02d
+  size: 456585
+  timestamp: 1772727473378
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2026.0.0-hf6b4638_1.conda
+  sha256: 3079cdc940a7e0b84376845accefd084f9a01c37af5901083ae47cc02fd5723d
+  md5: 361b9eb57e71939cf3d35fa1145a6325
   depends:
   - __osx >=11.0
   - libcxx >=19
-  - libopenvino 2025.4.1 h3e6d54f_1
+  - libopenvino 2026.0.0 h3e6d54f_1
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 390176
-  timestamp: 1769897695807
+  size: 379126
+  timestamp: 1772716918802
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
   sha256: f1061a26213b9653bbb8372bfa3f291787ca091a9a3060a10df4d5297aad74fd
   md5: 2446ac1fe030c2aa6141386c1f5a6aed
@@ -5195,41 +5417,41 @@ packages:
   purls: []
   size: 28424
   timestamp: 1749901812541
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.55-h421ea60_0.conda
-  sha256: 36ade759122cdf0f16e2a2562a19746d96cf9c863ffaa812f2f5071ebbe9c03c
-  md5: 5f13ffc7d30ffec87864e678df9957b4
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.56-h421ea60_0.conda
+  sha256: 4f9fca3bc21e485ec0b3eb88db108b6cf9ab9a481cdf7d2ac6f9d30350b45ead
+  md5: 97169784f0775c85683c3d8badcea2c3
   depends:
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
   license: zlib-acknowledgement
   purls: []
-  size: 317669
-  timestamp: 1770691470744
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.55-h132b30e_0.conda
-  sha256: 7a4fd29a6ee2d7f7a6e610754dfdf7410ed08f40d8d8b488a27bc0f9981d5abb
-  md5: 871dc88b0192ac49b6a5509932c31377
+  size: 317540
+  timestamp: 1774513272700
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.56-h132b30e_0.conda
+  sha256: 3aac73e6c8b2d6dc38f8918c8de3354ed920db00fd9234c000b20fd66323c463
+  md5: ce25ae471d213f9dd5edb0fe8e0b102a
   depends:
   - __osx >=11.0
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
   license: zlib-acknowledgement
   purls: []
-  size: 288950
-  timestamp: 1770691485950
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.2-hb80d175_0.conda
-  sha256: 5f857281d53334f1a400afae7ae915161eb8f796ddadb11c082839a4c47de6da
-  md5: fa63c385ddb50957d93bdb394e355be8
+  size: 289288
+  timestamp: 1774513431937
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.3-h9abb657_0.conda
+  sha256: c7e61b86c273ec1ce92c0e087d1a0f3ed3b9485507c6cd35e03bc63de1b6b03f
+  md5: 405ec206d230d9d37ad7c2636114cbf4
   depends:
   - __glibc >=2.17,<3.0.a0
   - icu >=78.2,<79.0a0
-  - krb5 >=1.21.3,<1.22.0a0
+  - krb5 >=1.22.2,<1.23.0a0
   - libgcc >=14
   - openldap >=2.6.10,<2.7.0a0
   - openssl >=3.5.5,<4.0a0
   license: PostgreSQL
   purls: []
-  size: 2809023
-  timestamp: 1770915404394
+  size: 2865686
+  timestamp: 1772136328077
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-18.2-h6caddbb_0.conda
   sha256: c5df229177c964cce817739b4b59e1e1ceec315d4e6a30c70cb4994cf27390aa
   md5: 41ae8b0d426096e1d11bd83d8ca949f5
@@ -5243,52 +5465,55 @@ packages:
   purls: []
   size: 2643395
   timestamp: 1770916690384
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.31.1-h49aed37_4.conda
-  sha256: 0ef142ac31e6fd59b4af89ac800acb6deb3fbd9cc4ccf070c03cc2c784dc7296
-  md5: 07479fc04ba3ddd5d9f760ef1635cfa7
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.33.5-h2b00c02_0.conda
+  sha256: afbf195443269ae10a940372c1d37cda749355d2bd96ef9587a962abd87f2429
+  md5: 11ac478fa72cf12c214199b8a96523f4
   depends:
   - __glibc >=2.17,<3.0.a0
   - libabseil * cxx17*
-  - libabseil >=20250512.1,<20250513.0a0
+  - libabseil >=20260107.0,<20260108.0a0
   - libgcc >=14
   - libstdcxx >=14
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 4372578
-  timestamp: 1766316228461
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.31.1-h98f38fd_4.conda
-  sha256: 505d62fb2a487aff594a30f6c419f8e861fb3a47e25e407dae2779ac4a585b18
-  md5: 8a6b4281c176f1695ae0015f420e6aa9
+  size: 3638698
+  timestamp: 1769749419271
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-h4a5acfd_0.conda
+  sha256: 626852cd50690526c9eac216a9f467edd4cbb01060d0efe41b7def10b54bdb08
+  md5: b839e3295b66434f20969c8b940f056a
   depends:
   - __osx >=11.0
   - libabseil * cxx17*
-  - libabseil >=20250512.1,<20250513.0a0
+  - libabseil >=20260107.0,<20260108.0a0
   - libcxx >=19
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 3131502
-  timestamp: 1766315339805
-- conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.60.0-h61e6d4b_0.conda
-  sha256: 960b137673b2b8293e2a12d194add72967b3bf12fcdf691e7ad8bd5c8318cec3
-  md5: 91e6d4d684e237fba31b9815c4b40edf
+  size: 2713660
+  timestamp: 1769748299578
+- conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.1-h4c96295_0.conda
+  sha256: dc4698b32b2ca3fc0715d7d307476a71622bee0f2f708f9dadec8af21e1047c8
+  md5: a4b87f1fbcdbb8ad32e99c2611120f2e
   depends:
   - __glibc >=2.17,<3.0.a0
   - cairo >=1.18.4,<2.0a0
-  - gdk-pixbuf >=2.44.3,<3.0a0
+  - fontconfig >=2.17.1,<3.0a0
+  - fonts-conda-ecosystem
+  - gdk-pixbuf >=2.44.5,<3.0a0
+  - harfbuzz >=13.1.1
   - libgcc >=14
-  - libglib >=2.86.0,<3.0a0
+  - libglib >=2.86.4,<3.0a0
   - libxml2-16 >=2.14.6
   - pango >=1.56.4,<2.0a0
   constrains:
   - __glibc >=2.17
   license: LGPL-2.1-or-later
   purls: []
-  size: 3421977
-  timestamp: 1759327942156
+  size: 3474421
+  timestamp: 1773814909137
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.60.0-h9001022_1.conda
   sha256: 9ba1531b46c75313736e2ef8ba1a4d3ef7d3ffd22efe8d593bfa99da7143a1cb
   md5: b6c81d5b3324b9ff9fe8f39d25d8be66
@@ -5323,9 +5548,9 @@ packages:
   purls: []
   size: 355619
   timestamp: 1765181778282
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.2-hf4e2dac_0.conda
-  sha256: 04596fcee262a870e4b7c9807224680ff48d4d0cc0dac076a602503d3dc6d217
-  md5: da5be73701eecd0e8454423fd6ffcf30
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
+  sha256: d716847b7deca293d2e49ed1c8ab9e4b9e04b9d780aea49a97c26925b28a7993
+  md5: fd893f6a3002a635b5e50ceb9dd2c0f4
   depends:
   - __glibc >=2.17,<3.0.a0
   - icu >=78.2,<79.0a0
@@ -5333,19 +5558,19 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: blessing
   purls: []
-  size: 942808
-  timestamp: 1768147973361
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.51.2-h1ae2325_0.conda
-  sha256: 6e9b9f269732cbc4698c7984aa5b9682c168e2a8d1e0406e1ff10091ca046167
-  md5: 4b0bf313c53c3e89692f020fb55d5f2c
+  size: 951405
+  timestamp: 1772818874251
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.52.0-h1ae2325_0.conda
+  sha256: beb0fd5594d6d7c7cd42c992b6bb4d66cbb39d6c94a8234f15956da99a04306c
+  md5: f6233a3fddc35a2ec9f617f79d6f3d71
   depends:
   - __osx >=11.0
   - icu >=78.2,<79.0a0
   - libzlib >=1.3.1,<2.0a0
   license: blessing
   purls: []
-  size: 909777
-  timestamp: 1768148320535
+  size: 918420
+  timestamp: 1772819478684
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
   sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
   md5: eecce068c7e4eddeb169591baac20ac4
@@ -5585,21 +5810,20 @@ packages:
   purls: []
   size: 259122
   timestamp: 1753879389702
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libvpl-2.15.0-h54a6638_1.conda
-  sha256: bf0010d93f5b154c59bd9d3cc32168698c1d24f2904729f4693917cce5b27a9f
-  md5: a41a299c157cc6d0eff05e5fc298cc45
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvpl-2.16.0-h54a6638_0.conda
+  sha256: 38850657dd6835613ef16b34895a54bea98bc7639db6a649c886b331635714fc
+  md5: 9f6b0090c3902b2c763a16f7dace7b6e
   depends:
-  - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - intel-media-driver >=25.3.3,<25.4.0a0
-  - libva >=2.22.0,<3.0a0
+  - libstdcxx >=14
+  - intel-media-driver >=26.1.2,<26.2.0a0
+  - libva >=2.23.0,<3.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 287944
-  timestamp: 1757278954789
+  size: 287992
+  timestamp: 1772980546550
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.15.2-hecca717_0.conda
   sha256: 8e1119977f235b488ab32d540c018d3fd1eccefc3dd3859921a0ff555d8c10d2
   md5: 10f5008f1c89a40b09711b5a9cdbd229
@@ -5833,31 +6057,30 @@ packages:
   purls: []
   size: 3998313
   timestamp: 1767985241142
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
-  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
-  md5: edb0dca6bc32e4f4789199455a1dbeb8
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+  sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
+  md5: d87ff7921124eccd67248aa483c23fec
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
   constrains:
-  - zlib 1.3.1 *_2
+  - zlib 1.3.2 *_2
   license: Zlib
   license_family: Other
   purls: []
-  size: 60963
-  timestamp: 1727963148474
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
-  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
-  md5: 369964e85dc26bfe78f41399b366c435
+  size: 63629
+  timestamp: 1774072609062
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+  sha256: 361415a698514b19a852f5d1123c5da746d4642139904156ddfca7c922d23a05
+  md5: bc5a5721b6439f2f62a84f2548136082
   depends:
   - __osx >=11.0
   constrains:
-  - zlib 1.3.1 *_2
+  - zlib 1.3.2 *_2
   license: Zlib
   license_family: Other
   purls: []
-  size: 46438
-  timestamp: 1727963202283
+  size: 47759
+  timestamp: 1774072956767
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.0-hc7d1edf_0.conda
   sha256: 0daeedb3872ad0fdd6f0d7e7165c63488e8a315d7057907434145fba0c1e7b3d
   md5: ff0820b5588b20be3b858552ecf8ffae
@@ -5916,6 +6139,39 @@ packages:
   - pkg:pypi/lxml?source=hash-mapping
   size: 1364873
   timestamp: 1762506910901
+- pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
+  name: markdown-it-py
+  version: 4.0.0
+  sha256: 87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147
+  requires_dist:
+  - mdurl~=0.1
+  - psutil ; extra == 'benchmarking'
+  - pytest ; extra == 'benchmarking'
+  - pytest-benchmark ; extra == 'benchmarking'
+  - commonmark~=0.9 ; extra == 'compare'
+  - markdown~=3.4 ; extra == 'compare'
+  - mistletoe~=1.0 ; extra == 'compare'
+  - mistune~=3.0 ; extra == 'compare'
+  - panflute~=2.3 ; extra == 'compare'
+  - markdown-it-pyrs ; extra == 'compare'
+  - linkify-it-py>=1,<3 ; extra == 'linkify'
+  - mdit-py-plugins>=0.5.0 ; extra == 'plugins'
+  - gprof2dot ; extra == 'profiling'
+  - mdit-py-plugins>=0.5.0 ; extra == 'rtd'
+  - myst-parser ; extra == 'rtd'
+  - pyyaml ; extra == 'rtd'
+  - sphinx ; extra == 'rtd'
+  - sphinx-copybutton ; extra == 'rtd'
+  - sphinx-design ; extra == 'rtd'
+  - sphinx-book-theme~=1.0 ; extra == 'rtd'
+  - jupyter-sphinx ; extra == 'rtd'
+  - ipykernel ; extra == 'rtd'
+  - coverage ; extra == 'testing'
+  - pytest ; extra == 'testing'
+  - pytest-cov ; extra == 'testing'
+  - pytest-regressions ; extra == 'testing'
+  - requests ; extra == 'testing'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: markupsafe
   version: 3.0.3
@@ -5937,6 +6193,11 @@ packages:
   - pkg:pypi/mccabe?source=hash-mapping
   size: 12934
   timestamp: 1733216573915
+- pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+  name: mdurl
+  version: 0.1.2
+  sha256: 84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8
+  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl
   name: mergedeep
   version: 1.3.4
@@ -6113,95 +6374,95 @@ packages:
   - pkg:pypi/nodeenv?source=hash-mapping
   size: 40866
   timestamp: 1766261270149
-- conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-25.2.1-h728ac57_2.conda
-  sha256: 553164f7b041eb3e4cb22c1e4e6f3da532632416d3a7fa4fa97fa48e64f1eb85
-  md5: 4c05dc4998537fabe4b545d9ef9d0a13
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-25.8.2-he4ff34a_0.conda
+  sha256: d1a673d1418d9e956b6e4e46c23e72a511c5c1d45dc5519c947457427036d5e2
+  md5: baffb1570b3918c784d4490babc52fbf
   depends:
-  - libstdcxx >=14
   - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.28,<3.0.a0
-  - icu >=78.2,<79.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libnghttp2 >=1.68.1,<2.0a0
   - libuv >=1.51.0,<2.0a0
-  - libnghttp2 >=1.67.0,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
   - c-ares >=1.34.6,<2.0a0
-  - libsqlite >=3.51.2,<4.0a0
+  - openssl >=3.5.5,<4.0a0
+  - libsqlite >=3.52.0,<4.0a0
+  - icu >=78.3,<79.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libabseil >=20260107.1,<20260108.0a0
+  - libabseil * cxx17*
+  - zstd >=1.5.7,<1.6.0a0
   - libbrotlicommon >=1.2.0,<1.3.0a0
   - libbrotlienc >=1.2.0,<1.3.0a0
   - libbrotlidec >=1.2.0,<1.3.0a0
-  - openssl >=3.5.4,<4.0a0
-  - libabseil >=20250512.1,<20250513.0a0
-  - libabseil * cxx17*
   license: MIT
   license_family: MIT
   purls: []
-  size: 17243215
-  timestamp: 1769159690239
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-25.2.1-he11bded_2.conda
-  sha256: b470110a3392411f99814599ca99d07e8f98232d0a56609743decd0968695b87
-  md5: 1906bf55d4785219ec5c0e276e380b28
+  size: 18829340
+  timestamp: 1774514313036
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-25.8.2-h7039424_0.conda
+  sha256: 4782b172b3b8a557b60bf5f591821cf100e2092ba7a5494ce047dfa41626de26
+  md5: ca8277c52fdface8bb8ebff7cd9a6f56
   depends:
-  - __osx >=11.0
   - libcxx >=19
-  - libuv >=1.51.0,<2.0a0
-  - libabseil >=20250512.1,<20250513.0a0
-  - libabseil * cxx17*
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.4,<4.0a0
-  - c-ares >=1.34.6,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - __osx >=11.0
+  - icu >=78.3,<79.0a0
   - libbrotlicommon >=1.2.0,<1.3.0a0
   - libbrotlienc >=1.2.0,<1.3.0a0
   - libbrotlidec >=1.2.0,<1.3.0a0
-  - libsqlite >=3.51.2,<4.0a0
-  - libnghttp2 >=1.67.0,<2.0a0
-  - icu >=78.2,<79.0a0
+  - libnghttp2 >=1.68.1,<2.0a0
+  - libuv >=1.51.0,<2.0a0
+  - libsqlite >=3.52.0,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.5,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - c-ares >=1.34.6,<2.0a0
+  - libabseil >=20260107.1,<20260108.0a0
+  - libabseil * cxx17*
   license: MIT
   license_family: MIT
   purls: []
-  size: 16193816
-  timestamp: 1769159676661
-- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.2-py312h33ff503_1.conda
-  sha256: fec4d37e1a7c677ddc07bb968255df74902733398b77acc1d05f9dc599e879df
-  md5: 3569a8fca2dd3202e4ab08f42499f6d3
+  size: 17101803
+  timestamp: 1774517834028
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.2.6-py312h72c5963_0.conda
+  sha256: c3b3ff686c86ed3ec7a2cc38053fd6234260b64286c2bd573e436156f39d14a7
+  md5: 17fac9db62daa5c810091c2882b28f45
   depends:
-  - python
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - liblapack >=3.9.0,<4.0a0
-  - python_abi 3.12.* *_cp312
-  - libcblas >=3.9.0,<4.0a0
   - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   constrains:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/numpy?source=hash-mapping
-  size: 8757566
-  timestamp: 1770098484112
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.2-py312he281c53_1.conda
-  sha256: 7fd2f1a33b244129dcc2163304d103a7062fc38f01fe13945c9ea95cef12b954
-  md5: 4afbe6ffff0335d25f3c5cc78b1350a4
+  size: 8490501
+  timestamp: 1747545073507
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.2.6-py312h7c1f314_0.conda
+  sha256: f5d69838c10a6c34a6de8b643b1795bf6fa9b22642ede5fc296d5673eabc344e
+  md5: fff7ab22b4f5c7036d3c2e1f92632fa4
   depends:
-  - python
-  - libcxx >=19
   - __osx >=11.0
-  - python 3.12.* *_cpython
   - libblas >=3.9.0,<4.0a0
-  - python_abi 3.12.* *_cp312
-  - liblapack >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
   constrains:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/numpy?source=hash-mapping
-  size: 6840961
-  timestamp: 1770098400654
+  size: 6437085
+  timestamp: 1747545094808
 - pypi: https://files.pythonhosted.org/packages/af/eb/ff4b8c503fa1f1796679dce648854d58751982426e4e4b37d6fce49d259c/nvidia_cublas_cu12-12.6.4.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
   name: nvidia-cublas-cu12
   version: 12.6.4.1
@@ -6305,63 +6566,37 @@ packages:
   purls: []
   size: 55357
   timestamp: 1749853464518
-- conda: https://conda.anaconda.org/conda-forge/linux-64/opencv-4.12.0-qt6_py312h7bb6282_612.conda
-  sha256: c4532ba519a1b072398de54669c5c783991eb332aaa2a076cc27dd4a6379ccc3
-  md5: 3c22d365c8d69933d2ad9fb4bad1bc24
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.4.9-h40f6f1d_0.conda
+  sha256: 930187c0fa5df54ac504d078f6aac64dfe6b101ca8952cae88d0d3825490d67c
+  md5: c702e499f1a80315ac41df8dd5c785bf
   depends:
-  - libopencv 4.12.0 qt6_py312h52d6ec5_612
-  - libprotobuf >=6.31.1,<6.31.2.0a0
-  - py-opencv 4.12.0 qt6_py312h598be00_612
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 28422
-  timestamp: 1766495425558
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/opencv-4.12.0-qt6_py312h5b798a3_612.conda
-  sha256: 5f7db074febac65e5d9bdd3ba877b8c644fc217fafd487da0938d585c8d3a6eb
-  md5: 8f67158fd4d352807f9a6be5f3c1ae7f
-  depends:
-  - libopencv 4.12.0 qt6_py312h74f5ed3_612
-  - libprotobuf >=6.31.1,<6.31.2.0a0
-  - py-opencv 4.12.0 qt6_py312he92a2c1_612
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 27909
-  timestamp: 1766497165754
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.4.4-h40f6f1d_1.conda
-  sha256: 97881c7f2fb05b24c8481b6b2c311b7106b9c165c47a2d37242927ff5d14f0e0
-  md5: c87d9f26932f2e000d3767fc8893e51a
-  depends:
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - libdeflate >=1.25,<1.26.0a0
-  - openjph >=0.26.0,<0.27.0a0
+  - __glibc >=2.17,<3.0.a0
+  - openjph >=0.26.3,<0.27.0a0
   - imath >=3.2.2,<3.2.3.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 1218225
-  timestamp: 1766606762619
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openexr-3.4.5-he0ec429_0.conda
-  sha256: 0167c3165028991d866a5487ed359bad5837bb9860ea2c0a9acb0d62c7b85036
-  md5: 3d8e72e0f8c0a0b4e6f720306f28cbd5
+  size: 1217847
+  timestamp: 1775504236214
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openexr-3.4.9-he0ec429_0.conda
+  sha256: 97f9ca1510454da24228be47492c88d6d24b08a0b804f31c584cfe902f33db56
+  md5: f6f182dea89ee15d7044123341ee1b72
   depends:
-  - __osx >=11.0
   - libcxx >=19
+  - __osx >=11.0
+  - libzlib >=1.3.2,<2.0a0
   - libdeflate >=1.25,<1.26.0a0
   - imath >=3.2.2,<3.2.3.0a0
-  - libzlib >=1.3.1,<2.0a0
   - openjph >=0.26.3,<0.27.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 981972
-  timestamp: 1771861876764
+  size: 980989
+  timestamp: 1775504556830
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
   sha256: 3f231f2747a37a58471c82a9a8a80d92b7fece9f3fce10901a5ac888ce00b747
   md5: b28cf020fd2dead0ca6d113608683842
@@ -6385,19 +6620,19 @@ packages:
   purls: []
   size: 601538
   timestamp: 1739400923874
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.26.0-h8d634f6_0.conda
-  sha256: 5f8e3ad6e707c3ffee81c3c2cbc1ac8f66eb10bbe0fe2edbe1cdad0972e006c8
-  md5: 65900b71509b2fd6c0a34a5dc1bd893a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.26.3-h8d634f6_0.conda
+  sha256: 4587e7762f27cad93619de77fa0573e2e17a899892d4bed3010196093e343533
+  md5: 792d5b6e99677177f5527a758a02bc07
   depends:
-  - libgcc >=14
-  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
   - libtiff >=4.7.1,<4.8.0a0
   license: BSD-2-Clause
   license_family: BSD
   purls: []
-  size: 279868
-  timestamp: 1766578366964
+  size: 279846
+  timestamp: 1771349499024
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjph-0.26.3-h2a4d681_0.conda
   sha256: 8da463f8e61ce53ab8e577a7a039d8af84aa431058004b6b7d76606470933e78
   md5: a41bb9b11d64287b789c267f715efe75
@@ -6410,21 +6645,21 @@ packages:
   purls: []
   size: 182293
   timestamp: 1771349598209
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
-  sha256: cb0b07db15e303e6f0a19646807715d28f1264c6350309a559702f4f34f37892
-  md5: 2e5bf4f1da39c0b32778561c3c4e5878
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-hbde042b_1.conda
+  sha256: 2e185a3dc2bdc4525dd68559efa3f24fa9159a76c40473e320732b35115163b2
+  md5: 3c40a106eadf7c14c6236ceddb267893
   depends:
   - __glibc >=2.17,<3.0.a0
-  - cyrus-sasl >=2.1.27,<3.0a0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - openssl >=3.5.0,<4.0a0
+  - cyrus-sasl >=2.1.28,<3.0a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - openssl >=3.5.5,<4.0a0
   license: OLDAP-2.8
   license_family: BSD
   purls: []
-  size: 780253
-  timestamp: 1748010165522
+  size: 785570
+  timestamp: 1771970256722
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openldap-2.6.10-hbe55e7a_0.conda
   sha256: 08d859836b81296c16f74336c3a9a455b23d57ce1d7c2b0b3e1b7a07f984c677
   md5: 6fd5d73c63b5d37d9196efb4f044af76
@@ -6757,17 +6992,6 @@ packages:
   purls: []
   size: 850231
   timestamp: 1763655726735
-- pypi: https://files.pythonhosted.org/packages/8c/d7/8ff98376b1acc4503253b685ea09981697385ce344d4e3935c2af49e044d/pfzy-0.3.4-py3-none-any.whl
-  name: pfzy
-  version: 0.3.4
-  sha256: 5f50d5b2b3207fa72e7ec0ef08372ef652685470974a107d0d4999fc5a903a96
-  requires_dist:
-  - sphinx>=4.1.2,<5.0.0 ; extra == 'docs'
-  - furo>=2021.8.17b43,<2022.0.0 ; extra == 'docs'
-  - myst-parser>=0.15.1,<0.16.0 ; extra == 'docs'
-  - sphinx-autobuild>=2021.3.14,<2022.0.0 ; extra == 'docs'
-  - sphinx-copybutton>=0.4.0,<0.5.0 ; extra == 'docs'
-  requires_python: '>=3.7,<4.0'
 - pypi: https://files.pythonhosted.org/packages/d6/71/5026395b290ff404b836e636f51d7297e6c83beceaa87c592718747e670f/pillow-12.1.1-cp312-cp312-macosx_11_0_arm64.whl
   name: pillow
   version: 12.1.1
@@ -6901,13 +7125,6 @@ packages:
   - pkg:pypi/pluggy?source=compressed-mapping
   size: 25877
   timestamp: 1764896838868
-- pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
-  name: prompt-toolkit
-  version: 3.0.52
-  sha256: 9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955
-  requires_dist:
-  - wcwidth
-  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/0a/b6/5c9a0e42df4d00bfb4a3cbbe5cf9f54260300c88a0e9af1f47ca5ce17ac0/propcache-0.4.1-cp312-cp312-macosx_11_0_arm64.whl
   name: propcache
   version: 0.4.1
@@ -7009,34 +7226,34 @@ packages:
   purls: []
   size: 750785
   timestamp: 1763148198088
-- conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.12.0-qt6_py312h598be00_612.conda
-  sha256: 625f42acd5e3b4591c69be2e718ecebc3bd2ed4a00bea7ebd472b607e0197cfb
-  md5: 9fefe5550f3e8d5555efe24dfc94805c
+- conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.13.0-qt6_py312h3a6da57_605.conda
+  sha256: 6c681feb1f0cb8b68e1cf04fc25d195a6be778884cd79d44b7cb549bfd406b13
+  md5: c4256c5bec0075a4f2ffec87aa291769
   depends:
-  - libopencv 4.12.0 qt6_py312h52d6ec5_612
-  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libopencv 4.13.0 qt6_py312h10ee65c_605
+  - libprotobuf >=6.33.5,<6.33.6.0a0
   - numpy >=1.23,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 1154634
-  timestamp: 1766495407579
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/py-opencv-4.12.0-qt6_py312he92a2c1_612.conda
-  sha256: 46a833a937e6658c8f55d348290fed27620845c5aa7ad61a80ad886b73fd6c4f
-  md5: 1d96583062af08a9c5d072ae1d26dfd5
+  size: 1154629
+  timestamp: 1774790878017
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/py-opencv-4.13.0-qt6_py312hf453e02_605.conda
+  sha256: 3f31996dedbff203f0cc0232dd48aba5173bf3deb8a3a82d655b2ae3823e8f72
+  md5: a49392159945958a507fcfd983c4dbbc
   depends:
-  - libopencv 4.12.0 qt6_py312h74f5ed3_612
-  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libopencv 4.13.0 qt6_py312hc9399c9_605
+  - libprotobuf >=6.33.5,<6.33.6.0a0
   - numpy >=1.23,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 1154844
-  timestamp: 1766497121627
+  size: 1155042
+  timestamp: 1774792391129
 - pypi: https://files.pythonhosted.org/packages/c6/6f/8f9eb40c2328d66e8b097777ddcf38494115ff9f1b5bc9754ba46991191e/pyarrow-23.0.0-cp312-cp312-manylinux_2_28_x86_64.whl
   name: pyarrow
   version: 23.0.0
@@ -7407,70 +7624,80 @@ packages:
   - pyyaml>=6.0,<7.0
   - toml ; python_full_version < '3.12' and extra == 'toml'
   requires_python: '>=3.6'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.10.2-hb82b983_4.conda
-  sha256: 82393e8fc34c07cbd7fbba5ef7ce672165ff657492ad1790bb5fad63d607cccd
-  md5: 9861c7820fdb45bc50a2ea60f4ff7952
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.10.2-pl5321h16c4a6b_6.conda
+  sha256: dd2fdde2cfecd29d4acd2bacbb341f00500d8b3b1c0583a8d92e07fc1e4b1106
+  md5: 3a00bff44c15ee37bfd5eb435e1b2a51
   depends:
+  - libxcb
+  - xcb-util
+  - xcb-util-wm
+  - xcb-util-keysyms
+  - xcb-util-image
+  - xcb-util-renderutil
+  - xcb-util-cursor
   - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.15.3,<1.3.0a0
-  - dbus >=1.16.2,<2.0a0
-  - double-conversion >=3.4.0,<3.5.0a0
-  - fontconfig >=2.15.0,<3.0a0
-  - fonts-conda-ecosystem
-  - harfbuzz >=12.3.2
-  - icu >=78.2,<79.0a0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libclang-cpp21.1 >=21.1.8,<21.2.0a0
-  - libclang13 >=21.1.8
-  - libcups >=2.3.3,<2.4.0a0
-  - libdrm >=2.4.125,<2.5.0a0
-  - libegl >=1.7.0,<2.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
   - libgcc >=14
-  - libgl >=1.7.0,<2.0a0
-  - libglib >=2.86.3,<3.0a0
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  - libllvm21 >=21.1.8,<21.2.0a0
-  - libpng >=1.6.54,<1.7.0a0
-  - libpq >=18.1,<19.0a0
-  - libsqlite >=3.51.2,<4.0a0
   - libstdcxx >=14
-  - libtiff >=4.7.1,<4.8.0a0
-  - libvulkan-loader >=1.4.328.1,<2.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - libxkbcommon >=1.13.1,<2.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - icu >=78.3,<79.0a0
+  - libllvm22 >=22.1.0,<22.2.0a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - xorg-libxtst >=1.2.5,<2.0a0
+  - libfreetype >=2.14.2
+  - libfreetype6 >=2.14.2
   - libxml2
   - libxml2-16 >=2.14.6
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.5,<4.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - wayland >=1.24.0,<2.0a0
-  - xcb-util >=0.4.1,<0.5.0a0
-  - xcb-util-cursor >=0.1.6,<0.2.0a0
-  - xcb-util-image >=0.4.0,<0.5.0a0
-  - xcb-util-keysyms >=0.4.1,<0.5.0a0
-  - xcb-util-renderutil >=0.3.10,<0.4.0a0
-  - xcb-util-wm >=0.4.2,<0.5.0a0
-  - xorg-libice >=1.1.2,<2.0a0
-  - xorg-libsm >=1.2.6,<2.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxcomposite >=0.4.6,<1.0a0
-  - xorg-libxcursor >=1.2.3,<2.0a0
-  - xorg-libxdamage >=1.1.6,<2.0a0
-  - xorg-libxext >=1.3.7,<2.0a0
-  - xorg-libxrandr >=1.5.5,<2.0a0
-  - xorg-libxtst >=1.2.5,<2.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  - libegl >=1.7.0,<2.0a0
   - xorg-libxxf86vm >=1.1.7,<2.0a0
+  - libdrm >=2.4.125,<2.5.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libvulkan-loader >=1.4.341.0,<2.0a0
+  - libclang-cpp22.1 >=22.1.0,<22.2.0a0
+  - double-conversion >=3.4.0,<3.5.0a0
+  - dbus >=1.16.2,<2.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - alsa-lib >=1.2.15.3,<1.3.0a0
+  - wayland >=1.24.0,<2.0a0
+  - xcb-util-cursor >=0.1.6,<0.2.0a0
+  - libpng >=1.6.55,<1.7.0a0
+  - libclang13 >=22.1.0
+  - libwebp-base >=1.6.0,<2.0a0
   - zstd >=1.5.7,<1.6.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - xorg-libxrandr >=1.5.5,<2.0a0
+  - libcups >=2.3.3,<2.4.0a0
+  - libpq >=18.3,<19.0a0
+  - libjpeg-turbo >=3.1.2,<4.0a0
+  - xorg-libxcomposite >=0.4.7,<1.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - harfbuzz >=13.1.1
+  - openssl >=3.5.5,<4.0a0
+  - fontconfig >=2.17.1,<3.0a0
+  - fonts-conda-ecosystem
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - libsqlite >=3.52.0,<4.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - libglib >=2.86.4,<3.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - libxkbcommon >=1.13.1,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
   constrains:
-  - qt 6.10.2
+  - qt ==6.10.2
   license: LGPL-3.0-only
   license_family: LGPL
   purls: []
-  size: 57423827
-  timestamp: 1769655891299
+  size: 58118322
+  timestamp: 1773865930316
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qt6-main-6.10.2-h9aec236_4.conda
   sha256: b2bca718b31eb0f3a16a9254ef8d6eaae030cf0173e90cf0cfb80e08e7114a29
   md5: 4c78221e73a7ec9c5eebe695a6542714
@@ -7502,22 +7729,22 @@ packages:
   purls: []
   size: 45674676
   timestamp: 1769686625551
-- conda: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.7.1-h8fae777_3.conda
-  sha256: 6e5e704c1c21f820d760e56082b276deaf2b53cf9b751772761c3088a365f6f4
-  md5: 2c42649888aac645608191ffdc80d13a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.8.1-h1fbca29_0.conda
+  sha256: cf550bbc8e5ebedb6dba9ccaead3e07bd1cb86b183644a4c853e06e4b3ad5ac7
+  md5: d83958768626b3c8471ce032e28afcd3
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc >=14
   constrains:
   - __glibc >=2.17
   license: BSD-2-Clause
   license_family: BSD
   purls: []
-  size: 5176669
-  timestamp: 1746622023242
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rav1e-0.7.1-h0716509_3.conda
-  sha256: 65f862b2b31ef2b557990a82015cbd41e5a66041c2f79b4451dd14b4595d4c04
-  md5: 7b37f30516100b86ea522350c8cab44c
+  size: 5595970
+  timestamp: 1772540833621
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rav1e-0.8.1-h8246384_0.conda
+  sha256: 925e35b71fe513e0380ecd2fe137e3f4f248bf7ce4bad96946c7c704b7a50d26
+  md5: 4706a8a71474c692482c3f86c2175454
   depends:
   - __osx >=11.0
   constrains:
@@ -7525,8 +7752,8 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls: []
-  size: 856271
-  timestamp: 1746622200646
+  size: 886953
+  timestamp: 1772541394570
 - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
   sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
   md5: d7d95fc8287ea7bf33e0e7116d2b95ec
@@ -7625,9 +7852,18 @@ packages:
   purls: []
   size: 185448
   timestamp: 1748645057503
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-action-msgs-2.3.0-np2py312h2ed9cc7_15.conda
-  sha256: f60c23a74a393283f780b86828f84184838c8d86dc08c96f19cae7f1d1d1899f
-  md5: cd250d5728c4d32013f105b534630961
+- pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
+  name: rich
+  version: 14.3.3
+  sha256: 793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d
+  requires_dist:
+  - ipywidgets>=7.5.1,<9 ; extra == 'jupyter'
+  - markdown-it-py>=2.2.0
+  - pygments>=2.13.0,<3.0.0
+  requires_python: '>=3.8.0'
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-action-msgs-2.3.1-np2py312h2ed9cc7_17.conda
+  sha256: 33926ef352c7d1f0e78376b3edf1c7f0b813c97726a7c7b2bd6a62e990f11f4e
+  md5: c9e754c954d2658bd531419e9a6d3639
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -7635,20 +7871,19 @@ packages:
   - ros-kilted-rosidl-core-runtime
   - ros-kilted-service-msgs
   - ros-kilted-unique-identifier-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 150396
-  timestamp: 1769483028288
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-action-msgs-2.3.0-np2py312h50b1e4c_15.conda
-  sha256: 5b8b8a309727b9043af130d136eeafff391413ee2324d4a4f3ba66dfd5723e64
-  md5: c24ca7abcd6b4973aa0c930beab12cd2
+  size: 153676
+  timestamp: 1775549238659
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-action-msgs-2.3.1-np2py312h50b1e4c_17.conda
+  sha256: 087205c6d3733dee5eb314f569a965e514d7098ef1534840d489628526c4bd7d
+  md5: 6c3474b72bd04a4c9fc6c6cd10ec7bad
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -7656,53 +7891,52 @@ packages:
   - ros-kilted-rosidl-core-runtime
   - ros-kilted-service-msgs
   - ros-kilted-unique-identifier-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - numpy >=1.23,<3
+  - __osx >=11.0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 138092
-  timestamp: 1769490829212
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-actionlib-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: 8c048b3f8d0bbf2eaf972181dbd1fad7af495c936aa1187153d8ee20fb80251d
-  md5: 85215a31f763c8e1f53cb8a2e94d4758
+  size: 141510
+  timestamp: 1775550787111
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-actionlib-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: 2b8ebe61b96614f2e1cc35ef60a61f0c2f5e70512e1e09a971e7bc616cf4d2d2
+  md5: 11d5a26861d86ebf0661e61604aedafd
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 110953
-  timestamp: 1769483406077
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-actionlib-msgs-5.5.1-np2py312h50b1e4c_15.conda
-  sha256: 494bda96109182cdafe686a3807da5c78c300a76844efbd346d8cbf8fadc3c78
-  md5: 426352e669e955d2e8e774b470704a88
+  size: 113695
+  timestamp: 1775549582461
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-actionlib-msgs-5.5.2-np2py312h50b1e4c_17.conda
+  sha256: f99e296a3d9e02cd38e18175747b65dddaf69d41e2e2ce75c12009cc699ac46e
+  md5: ed3015e41bff5b0be8bd9ee017f990bb
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 103300
-  timestamp: 1769491689568
+  size: 106066
+  timestamp: 1775551583848
 - conda: aic_interfaces/aic_control_interfaces
   name: ros-kilted-aic-control-interfaces
   version: 0.0.1
@@ -7717,7 +7951,7 @@ packages:
   - ros-kilted-std-msgs
   - ros-kilted-trajectory-msgs
   - ros2-distro-mutex
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - libcxx >=22
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
@@ -7736,7 +7970,7 @@ packages:
   - ros-kilted-std-msgs
   - ros-kilted-trajectory-msgs
   - ros2-distro-mutex
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - libgcc >=15
   - libgcc >=15
   - libstdcxx >=15
@@ -7763,7 +7997,7 @@ packages:
   - ros-kilted-std-srvs
   - ros-kilted-trajectory-msgs
   - ros2-distro-mutex
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - libcxx >=22
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
@@ -7788,7 +8022,7 @@ packages:
   - ros-kilted-std-srvs
   - ros-kilted-trajectory-msgs
   - ros2-distro-mutex
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - libgcc >=15
   - libgcc >=15
   - libstdcxx >=15
@@ -7807,7 +8041,6 @@ packages:
   - ros-kilted-aic-model-interfaces
   - ros-kilted-aic-task-interfaces
   - ros-kilted-geometry-msgs
-  - ros-kilted-lifecycle
   - ros-kilted-lifecycle-msgs
   - ros-kilted-rclpy
   - ros-kilted-sensor-msgs
@@ -7815,7 +8048,7 @@ packages:
   - ros-kilted-tf2-ros
   - ros-kilted-trajectory-msgs
   - ros2-distro-mutex
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - libcxx >=22
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
@@ -7832,7 +8065,6 @@ packages:
   - ros-kilted-aic-model-interfaces
   - ros-kilted-aic-task-interfaces
   - ros-kilted-geometry-msgs
-  - ros-kilted-lifecycle
   - ros-kilted-lifecycle-msgs
   - ros-kilted-rclpy
   - ros-kilted-sensor-msgs
@@ -7840,7 +8072,7 @@ packages:
   - ros-kilted-tf2-ros
   - ros-kilted-trajectory-msgs
   - ros2-distro-mutex
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - libgcc >=15
   - libgcc >=15
   - libstdcxx >=15
@@ -7863,7 +8095,7 @@ packages:
   - ros-kilted-std-msgs
   - ros-kilted-trajectory-msgs
   - ros2-distro-mutex
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - libcxx >=22
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
@@ -7884,7 +8116,7 @@ packages:
   - ros-kilted-std-msgs
   - ros-kilted-trajectory-msgs
   - ros2-distro-mutex
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - libgcc >=15
   - libgcc >=15
   - libstdcxx >=15
@@ -7901,7 +8133,7 @@ packages:
   depends:
   - ros-kilted-rosidl-default-runtime
   - ros2-distro-mutex
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - libcxx >=22
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
@@ -7916,7 +8148,7 @@ packages:
   depends:
   - ros-kilted-rosidl-default-runtime
   - ros2-distro-mutex
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - libgcc >=15
   - libgcc >=15
   - libstdcxx >=15
@@ -7935,7 +8167,7 @@ packages:
   - ros-kilted-geometry-msgs
   - ros-kilted-rclpy
   - ros2-distro-mutex
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - libcxx >=22
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
@@ -7952,16 +8184,16 @@ packages:
   - ros-kilted-geometry-msgs
   - ros-kilted-rclpy
   - ros2-distro-mutex
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - libgcc >=15
   - libgcc >=15
   - libstdcxx >=15
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: LicenseRef-Apache-2.0
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 04d2c3366ffca89ad11ea4c2ace80875007da2558bff58116c9e94efb44bf752
-  md5: 46da3fd3ab5893835d82f97182386e03
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: 5d00da6dfcac81ff634b3be1dd9753107a0c0e1d5171698b1e65a8e6831706f0
+  md5: 21fc4d9b28df527df4537168a6a992aa
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -7979,21 +8211,20 @@ packages:
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-cmake-version
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - cmake
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 23311
-  timestamp: 1769481102393
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-2.7.4-np2py312h50b1e4c_15.conda
-  sha256: 7222fa72762ec6fc4383ce1c7b726b37abca3ac10bbf86b4b90e89aace829762
-  md5: eb805cf826eef844f963206766df75f9
+  size: 23273
+  timestamp: 1775547332725
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-2.7.5-np2py312h50b1e4c_17.conda
+  sha256: 6eac22369e25cf8067e93cdd0cf1b1b053229d9032998751270b6cbd6c7561fb
+  md5: 1e6ab273933189d3e4deb0f6ff2fb5ab
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -8011,1163 +8242,1137 @@ packages:
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-cmake-version
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - cmake
-  - __osx >=11.0
   - libcxx >=18
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __osx >=11.0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 23891
-  timestamp: 1769481773107
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-auto-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 66b0601e3cb0a89c8ff4cf9139dfef1f53811e6b4ad86107ee2a2570593cbc01
-  md5: c443427db41b72ac18a26ae09791aecf
+  size: 24149
+  timestamp: 1775547934536
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-auto-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: 6d4097441e1b2f0f623c65b0fe5848aa335da969e7c8c08f84f291f0cbbbe61a
+  md5: dc0ed6adaf5aa169c937b407ef36de8f
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-ament-cmake-gmock
   - ros-kilted-ament-cmake-gtest
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 28345
-  timestamp: 1769481188917
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-auto-2.7.4-np2py312h50b1e4c_15.conda
-  sha256: ad41e0abd23509ed3cd0ada5431f0dd3ecbb0eb9d257a001cb245b9cc7e363b9
-  md5: 39ead6e73801ba4077321fd6c83d52d7
+  size: 28268
+  timestamp: 1775547411327
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-auto-2.7.5-np2py312h50b1e4c_17.conda
+  sha256: e7669e3a81604b9105308b9feb0c369858489d36a98fc1dc622b672fda3b0680
+  md5: b38a8dca4704475d1a3cde427c7f30ed
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-ament-cmake-gmock
   - ros-kilted-ament-cmake-gtest
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 28925
-  timestamp: 1769482052924
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-copyright-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: 80d447ca5bd394174d3520cea91c923b6d13c5d7a58f3e824f3dda18cd468fd8
-  md5: a2baaa8ad0c19b6b90cd23ebee54f4b0
+  size: 29169
+  timestamp: 1775548122356
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-copyright-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: 7eed979756b5dbad9fd34d65ea4b468f2e322b09017af4c56247a9de44ce9c7a
+  md5: a1b044f826d92146c00b8786c463c6b9
   depends:
   - python
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-copyright
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 22771
-  timestamp: 1769481463900
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-copyright-0.19.2-np2py312h50b1e4c_15.conda
-  sha256: 7399c7128752dd68274e2c55dfa014b48ed712549591c3fe7995f071c4e7de00
-  md5: e31d47e1ffac814f5b066a40018d57f8
+  size: 22676
+  timestamp: 1775547771228
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-copyright-0.19.2-np2py312h50b1e4c_17.conda
+  sha256: 42b68637a5b68c9f7fad37adb983c50708529771d393b20ceac4777508d03e14
+  md5: 44734104b9ba50bd6b9d6ea8b82039c7
   depends:
   - python
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-copyright
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 23384
-  timestamp: 1769487605776
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-core-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 8f36dc1eb0162087fb01366234a6c048c64e81203f97e302f98113e3a0f9c7a0
-  md5: 85e9b5fc898f9cf6addc71dfa36e8b10
+  size: 23577
+  timestamp: 1775548363160
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-core-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: b75fae043a4026f3d2c2fc91094960860f4c536795cafca5defd33fe5875caff
+  md5: d919b96959c620a2a8113b8fafb95e50
   depends:
   - catkin_pkg
   - python
   - ros-kilted-ament-package
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - cmake
-  - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 45111
-  timestamp: 1769480651203
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-core-2.7.4-np2py312h50b1e4c_15.conda
-  sha256: c7df63c697b23fc7a864cf23bc67b89348cbfa47a3024ade973f825d0ba73de6
-  md5: 30a186da57ca04222977bd20f22d6513
+  size: 45038
+  timestamp: 1775546826225
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-core-2.7.5-np2py312h50b1e4c_17.conda
+  sha256: 52225fcc40deb72e5b09ef5b99f25cb4c89bb416c622eb1b800179753bfa1ba9
+  md5: f8276be70f23f1cd326104a98b2c4b74
   depends:
   - catkin_pkg
   - python
   - ros-kilted-ament-package
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - cmake
-  - __osx >=11.0
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - __osx >=11.0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 45812
-  timestamp: 1769480826017
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-cppcheck-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: 6540cdb6a1c18f79c864b02fa687cce8053122daa85baf19b6fefa9ab7df5f10
-  md5: 5f3c8b6a753e01f897da794dba844362
+  size: 46017
+  timestamp: 1775546973752
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-cppcheck-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: f3eaf026a91077ff49dd2ca957f2b4e2e4a7a304ea268cc4d8999330a3e44842
+  md5: 7320748b0b10a6adae8863e9bbf77960
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-cppcheck
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 24428
-  timestamp: 1769481507391
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-cppcheck-0.19.2-np2py312h50b1e4c_15.conda
-  sha256: df83e1793b73b5e606e24cbc5296140bb57b0dd90ac97fd9ebdbd9dd6fb382e1
-  md5: 92a9ad1843af52d831b9023fa99b8804
+  size: 24460
+  timestamp: 1775547811988
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-cppcheck-0.19.2-np2py312h50b1e4c_17.conda
+  sha256: 5feff93b6ad9809316109b87e43e172019885eb8d821fdb752d5616e56cacffd
+  md5: 4b1f891dffb1f7ea3431a2ba70633048
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-cppcheck
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 25028
-  timestamp: 1769487704232
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-cpplint-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: 7aec389707a2b0d3c1b59fd0e65536fa088cd85cc6564fd9d2b59a7d75597df9
-  md5: 93d99db9574a3a125f607ac9da1fe19a
+  size: 25195
+  timestamp: 1775548443261
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-cpplint-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: 2dde3a49053fce0a15d5bcdfa207fae005a9c0e41c481516a81b8d140a562538
+  md5: 1801ddc6f5a1f0a640cf0e1f98cab792
   depends:
   - python
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-cpplint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 23392
-  timestamp: 1769481537257
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-cpplint-0.19.2-np2py312h50b1e4c_15.conda
-  sha256: e111feb1809a96ddbd3984ce879e99243e80b74f7c8ee8d0c58c6b44f29fd121
-  md5: 5ec93fce85068799b9a5ac9cae43f9b4
+  size: 23302
+  timestamp: 1775547844307
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-cpplint-0.19.2-np2py312h50b1e4c_17.conda
+  sha256: d9b39f594108f8a5358d30c1ce5026739ed99954daf08e5da687102254ec26bf
+  md5: 7fc825b8256ce617a2e0b09e819fe23a
   depends:
   - python
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-cpplint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 23988
-  timestamp: 1769487750924
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-definitions-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: a9b69457a535c895399087943eae06309326386c5524d58ceed801973c0ad2a7
-  md5: d089091beccce78e25b1651a4e8e2649
+  size: 24203
+  timestamp: 1775548478780
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-definitions-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: 3a71ae5ba7232538d8cc0b7b6db0b371c50104c91b3abc99b295c2413b6a9463
+  md5: 638edba69790d39d6eb7297a0f2d1d82
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 22114
-  timestamp: 1769480737763
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-definitions-2.7.4-np2py312h50b1e4c_15.conda
-  sha256: f0c7c65d0bcbd56aa0c887cd1d9398f9468b3c6313f89d0e267f8e42135177bf
-  md5: 250d1a4e90d90de3060fb7de577e49e9
+  size: 21999
+  timestamp: 1775546915500
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-definitions-2.7.5-np2py312h50b1e4c_17.conda
+  sha256: 9e025899bd92f4e8acb7d12a165f21cc47aa5e195e7f05dc0ba8d90175443d27
+  md5: 1db91f0cc7c833e041fda3885d758216
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 22693
-  timestamp: 1769481051747
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-dependencies-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 2dce8aadb63053a32e9cde54649fd708a1de1ca8b37c25e102483d2e476676f1
-  md5: 8ac9eb866af22a19224ac3ece94c680d
+  size: 22906
+  timestamp: 1775547262875
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-dependencies-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: a23be926b6ba9c0a0fc3553d5564f81c4bd7478a42e8d5a7ab99742abeede9d0
+  md5: 1e112901d7cc66c314f2ff43d54588ae
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ament-cmake-libraries
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 23028
-  timestamp: 1769480813067
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-dependencies-2.7.4-np2py312h50b1e4c_15.conda
-  sha256: f6edf403c6794401f57cfa71b1cafbe2ef664fe0d2cecb90ff3d1b3908065026
-  md5: 06f2f7e9b695c8487991114223776d0b
+  size: 22944
+  timestamp: 1775546989653
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-dependencies-2.7.5-np2py312h50b1e4c_17.conda
+  sha256: 75ab553d70522729fda172ccf40ca8dc90c845611ece63ad4f89a7ab9f8bf1d5
+  md5: bf40a518b24981c6cb7512cc7eb11464
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ament-cmake-libraries
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
+  - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 23604
-  timestamp: 1769481284902
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-include-directories-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 3146b32550989fd8f902c09ae3c980bed3fa4b804819122e23296a7dd4f34df2
-  md5: 399e9034be1db231768bbc88042300ad
+  size: 23829
+  timestamp: 1775547522926
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-include-directories-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: b044fd47490d6bb63eda6486e4596c9172a7e3af0c133d6b2de95dc26de02a46
+  md5: 730bc10c6df375ace3f9532d225f7f58
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 22435
+  timestamp: 1775546911345
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-include-directories-2.7.5-np2py312h50b1e4c_17.conda
+  sha256: 5e033695c1048d4136a3dc9f5bc17eec7e622a8c7eef3e5c5f99a9428f27d11a
+  md5: 6451abf6736709caedcfe4f887f6c48b
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __osx >=11.0
+  - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 23347
+  timestamp: 1775547255572
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-interfaces-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: 49bc3ed68e16f3a6ce1c7d81d526cd487c5dc7eae26f29e7f44578950256a207
+  md5: e0d6189736bff3a3f08c3e5ef94e5ca4
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-cmake-export-libraries
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 22644
+  timestamp: 1775546963050
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-interfaces-2.7.5-np2py312h50b1e4c_17.conda
+  sha256: 894e1726cb0b476c2ed9cb330cbdee485e603380fd8673cd2f2546d632bf51bf
+  md5: 2ba5e7ecb87b721bda3702969b89b4c1
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-cmake-export-libraries
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libcxx >=18
+  - __osx >=11.0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 23533
+  timestamp: 1775547492126
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-libraries-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: 43065ef921bb436a2ee7781dfb31bb90bf8530ecd7b336f663bd79e6476e542b
+  md5: 2097b645102b1d63757b1b4ed30c1a6c
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 22522
-  timestamp: 1769480735309
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-include-directories-2.7.4-np2py312h50b1e4c_15.conda
-  sha256: 3ff065e54e5c8f1454529ad1512331b071c9bbd81f10325cd44f6e41e95575e5
-  md5: e7d6db193fc0d20ab74827ee68df0a80
+  size: 23956
+  timestamp: 1775546891063
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-libraries-2.7.5-np2py312h50b1e4c_17.conda
+  sha256: c9742682bcde18a373ea06ce1be0b72dc798f26dde9878f9466621972d6f1e3e
+  md5: b68673a4f9f7da5c9ea6841b6ca74471
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 24882
+  timestamp: 1775547219142
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-link-flags-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: 0dedd4cf45a73d279f85f284b42a2d9b508861026b2e1fb00fccffed219d97d3
+  md5: af61c4bae2c975c4b6b714f21c2c34fd
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 21962
+  timestamp: 1775546907187
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-link-flags-2.7.5-np2py312h50b1e4c_17.conda
+  sha256: d13f8332d9672db3bcc36b540e97dc8e99ff411fb54bd315730f7e6b3b6f1155
+  md5: cecd21b48c87d29dd7c311aa3c626815
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libcxx >=18
+  - __osx >=11.0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 22887
+  timestamp: 1775547247502
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-targets-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: 35ce95acc60b229e8614b82e0e8494c0708f86987f90aff64770083c9d4ed7f9
+  md5: 2e9e76938e608bd2863eb1b37dbab16b
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-cmake-export-libraries
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 22796
+  timestamp: 1775546999584
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-targets-2.7.5-np2py312h50b1e4c_17.conda
+  sha256: 0bea358a73ac16f4c70abe66e6570b79329da7c62071bcf3875525e2fcb792a1
+  md5: d78207bfe489f29d7fed5c76cc011edb
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-cmake-export-libraries
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libcxx >=18
+  - __osx >=11.0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  license: Apache-2.0
+  size: 23669
+  timestamp: 1775547538086
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-flake8-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: aceeadf46266513c0253c7449c6ed12df9411be79488cea86d6602052fb3dd25
+  md5: 9523157b81f4e2f1864ac79a362aed56
+  depends:
+  - python
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ament-flake8
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 24300
+  timestamp: 1775547839333
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-flake8-0.19.2-np2py312h50b1e4c_17.conda
+  sha256: a70cec88e54462001cd5778d67d598ea86d4c740a8153ed132464a0c691e3d89
+  md5: 75f79f7ed721aa9fcfe71624eab62e73
+  depends:
+  - python
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ament-flake8
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libcxx >=18
+  - __osx >=11.0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 25216
+  timestamp: 1775548472744
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-gen-version-h-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: acc2405f656e89597f4afce49b563d99f5e1d3eeb0f95c8caaae411b7f0305d2
+  md5: 80072ff4b56dccb2fce2578b5366a73f
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 24741
+  timestamp: 1775547207574
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-gen-version-h-2.7.5-np2py312h50b1e4c_17.conda
+  sha256: bf9eaa2be85c0e1e21ceae62e64002082afc917c2b12282c2336209f8db42dce
+  md5: c39753f0a795fac9b8f5d3fe8c326592
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __osx >=11.0
+  - libcxx >=18
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 25667
+  timestamp: 1775547791702
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-gmock-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: be92c1a428b7d88a3b5309de8313afc448fe839f3c5ef7dfe3a94abc2a3cb284
+  md5: 0e789de3cdcc8cd0378fa39813f4aa9d
+  depends:
+  - gmock
+  - python
+  - ros-kilted-ament-cmake-gtest
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-gmock-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  license: Apache-2.0
+  size: 24916
+  timestamp: 1775547221018
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-gmock-2.7.5-np2py312h50b1e4c_17.conda
+  sha256: dbe112f199805e99e1a6094dad6e398082e4881de9f7f41b77251855f4375a7b
+  md5: 3ecfb4ff914397f289fca2af777afd33
+  depends:
+  - gmock
+  - python
+  - ros-kilted-ament-cmake-gtest
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-gmock-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __osx >=11.0
+  - libcxx >=18
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 25775
+  timestamp: 1775547808604
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-gtest-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: 769ce5f530f840682fd976516ecca720769b2a0c1bbe82cede70bb9dda27cc9f
+  md5: e281945fab528fa1852d27e59b86892e
+  depends:
+  - gtest
+  - python
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-gtest-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - gtest >=1.17.0,<1.17.1.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  license: Apache-2.0
+  size: 24638
+  timestamp: 1775547078388
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-gtest-2.7.5-np2py312h50b1e4c_17.conda
+  sha256: 1ab29f30a6d957916ae7cb668e079c451238113093a103185b193a0987aed9be
+  md5: e631fce5cb8021fd2a02a4f41082386f
+  depends:
+  - gtest
+  - python
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-gtest-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __osx >=11.0
+  - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - gtest >=1.17.0,<1.17.1.0a0
+  license: Apache-2.0
+  size: 25523
+  timestamp: 1775547670521
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-include-directories-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: ab7ff425c7a49b4e1317e8875e73d4611a2e726cce5087a56fdfabab8040de87
+  md5: 35059b446952f248a747b12968d733a2
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 21871
+  timestamp: 1775546918522
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-include-directories-2.7.5-np2py312h50b1e4c_17.conda
+  sha256: 7ba8d7eee5d5fc49d9c4268313f874522bcc4b4ce556314abbf1558663e3aab0
+  md5: 2355810a8a40043184aa1f43f26cd3c1
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __osx >=11.0
+  - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 22793
+  timestamp: 1775547370200
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-libraries-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: d583899909dbf018fa87181f1a9b1511b04737f078b73d2a6992920e65a64456
+  md5: 4016fdfd9d2542dc053788da8409adf5
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 21567
+  timestamp: 1775546914327
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-libraries-2.7.5-np2py312h50b1e4c_17.conda
+  sha256: a75a21ea089a43b8d71ca94066d231b90e8070c83092047cd3b5f270b9c0f841
+  md5: a5bdddf198ff142cc6daa8c265bbe62d
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __osx >=11.0
+  - libcxx >=18
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 22489
+  timestamp: 1775547360160
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-lint-cmake-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: fa45a1f5487c5ce70ebb6fe3aadd2bab834ebc5cdba03521a422d4cdfce9c366
+  md5: 3b098af2a935e2a506167cf30240ffaf
+  depends:
+  - python
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ament-lint-cmake
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 22320
+  timestamp: 1775547573322
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-lint-cmake-0.19.2-np2py312h50b1e4c_17.conda
+  sha256: cb0ca7c90b4f210e476202e86c6a4a3df2ba6add2509f7113aa98c4ec3437d3f
+  md5: 87bcc066bde67537073fadb56c71bea7
+  depends:
+  - python
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ament-lint-cmake
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __osx >=11.0
+  - libcxx >=18
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 23244
+  timestamp: 1775548235953
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-pep257-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: 19bcac83bd5099ea9c2cba71ba6e0434834db12f1717236ac69728debe39a2df
+  md5: da51ebb254b53e4da9a79e5bc73793e4
+  depends:
+  - python
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ament-pep257
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 23127
+  timestamp: 1775547834487
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-pep257-0.19.2-np2py312h50b1e4c_17.conda
+  sha256: d8079781a04ff0dc490cf56ec71e0236cae609e58384e003527c09933c65fd28
+  md5: 6ba461aa612b702812fe23379a685694
+  depends:
+  - python
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ament-pep257
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __osx >=11.0
+  - libcxx >=18
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 23961
+  timestamp: 1775548466849
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-pytest-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: c96a78e6e18786301836386d8ad4a46380a2730f01252e0468730d8b6b279a07
+  md5: 8b1b563f8f96b821bd9f1011b2cff3ec
+  depends:
+  - pytest
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 24879
+  timestamp: 1775547095042
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-pytest-2.7.5-np2py312h50b1e4c_17.conda
+  sha256: 0cec87bb8484dc3c0c8ccb5b322446665e66d2c1408c4f71cb7707f60e599157
+  md5: 031d5c9adb70c7945eb43c361d176222
+  depends:
+  - pytest
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __osx >=11.0
+  - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 25759
+  timestamp: 1775547695761
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-python-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: 773b02bef57e16ee0f97ec1c507929c2b76d168ef79d5a10bf56ee80b37a8f87
+  md5: 2932843f2dadd2ceb84222e9536ab852
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 24116
+  timestamp: 1775546903019
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-python-2.7.5-np2py312h50b1e4c_17.conda
+  sha256: 0dafd0c49d1811dd6fc14968a14e3b9fa0c5a3e0f8288ec8d32edef3105868d8
+  md5: e5dc20802bf78710e20e6b1bfce81101
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __osx >=11.0
+  - libcxx >=18
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  license: Apache-2.0
+  size: 25046
+  timestamp: 1775547333153
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-ros-0.14.7-np2py312h2ed9cc7_17.conda
+  sha256: 227801e80779eaa81a7f2af2c2282e8c85ba7184236a868165530a8a807d31a9
+  md5: 79d96d4ae3ab11dad2657d819d35e258
+  depends:
+  - python
+  - ros-kilted-ament-cmake
+  - ros-kilted-ament-cmake-gmock
+  - ros-kilted-ament-cmake-gtest
+  - ros-kilted-ament-cmake-pytest
+  - ros-kilted-ament-cmake-ros-core
+  - ros-kilted-rmw-test-fixture-implementation
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 31528
+  timestamp: 1775550474145
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-ros-0.14.7-np2py312h50b1e4c_17.conda
+  sha256: 09a9c5c08fc8acd004efdd20dbdc59a74a7ed8e8fd34db73d755464502ce5b64
+  md5: 2e45ac77dd28eccefe339a7997b76684
+  depends:
+  - python
+  - ros-kilted-ament-cmake
+  - ros-kilted-ament-cmake-gmock
+  - ros-kilted-ament-cmake-gtest
+  - ros-kilted-ament-cmake-pytest
+  - ros-kilted-ament-cmake-ros-core
+  - ros-kilted-rmw-test-fixture-implementation
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __osx >=11.0
+  - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 32023
+  timestamp: 1775553207204
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-ros-core-0.14.7-np2py312h2ed9cc7_17.conda
+  sha256: 8d3b4a40844d9792b636220e6269309be03539763ec1b78526f1869f78a9cb04
+  md5: f31bc898c6fa860e878f886b17b239c6
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-cmake-libraries
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 27027
+  timestamp: 1775548192666
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-ros-core-0.14.7-np2py312h50b1e4c_17.conda
+  sha256: 512b187c75dc6803b5047dd83326465a7b52a18ee45eebfeec40fec5a1a383d0
+  md5: 8a0964f99530ef5be6c6c9507385f464
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-cmake-libraries
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __osx >=11.0
+  - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 27457
+  timestamp: 1775549190813
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-target-dependencies-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: c28bf7f3343ab0af8ff573f110fad6f02871c741dd2d1426384e643bfea5f508
+  md5: f6fd85bcdae11c1691408ed13a70be85
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-cmake-include-directories
+  - ros-kilted-ament-cmake-libraries
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 23847
+  timestamp: 1775546994581
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-target-dependencies-2.7.5-np2py312h50b1e4c_17.conda
+  sha256: 2ed7632cc3938a2abcdac24da0082cc2a0dc5e55b920975d98cbfae8d026117a
+  md5: 21650ab91a707ebf954cf134788a11fc
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-cmake-include-directories
+  - ros-kilted-ament-cmake-libraries
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __osx >=11.0
+  - libcxx >=18
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 24738
+  timestamp: 1775547531612
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-test-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: 091fc3fa4dd74c35712a021e84fb23e74ddfe0ce04c071c60b951232b9d40d36
+  md5: 83490826e62b7bffbb03665a99eb3632
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  license: Apache-2.0
+  size: 36013
+  timestamp: 1775546979031
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-test-2.7.5-np2py312h50b1e4c_17.conda
+  sha256: f9cb862bd05697778f6a7f634ea7e2b7e06fd6018595f33043effb22892299c0
+  md5: bbaeb8af7c8cdc937139eb279652581a
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __osx >=11.0
+  - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 37000
+  timestamp: 1775547507451
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-uncrustify-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: 6502415382293742485580397cde9a9cab9f133433a4a301da92b80b4ff59bf1
+  md5: a5d1a9f59731460718c2a0d90d6e2262
+  depends:
+  - python
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ament-uncrustify
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 23670
+  timestamp: 1775547828596
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-uncrustify-0.19.2-np2py312h50b1e4c_17.conda
+  sha256: ad32e38030067d6af088d00f1f3cb3ba96430695e53671db235e51e910594e27
+  md5: a8803c64e0774d2359a8b11e3983a3f4
+  depends:
+  - python
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ament-uncrustify
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libcxx >=18
+  - __osx >=11.0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 24552
+  timestamp: 1775548460350
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-version-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: 524023fa68f02ef3c2a0f8498eafed79b5113709f69b4711164d10bf9effa5f8
+  md5: 06cc56e859ed55e54b1dc6e75742a29c
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  license: Apache-2.0
+  size: 21746
+  timestamp: 1775546902592
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-version-2.7.5-np2py312h50b1e4c_17.conda
+  sha256: 84ed15c30c60179415133038b5526563419df390ee7ed7d5c143fabd887e87e3
+  md5: 158ce7033ea79da70984ddc0699e61f4
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __osx >=11.0
+  - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 22631
+  timestamp: 1775547238208
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-xmllint-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: db4d020e444fc0d4d0cd43b69b8047a35bd95da22e9c2e54601b1c7a7e27cb40
+  md5: 2bd3c75df8f994f09ce8eac421daadd6
+  depends:
+  - python
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ament-xmllint
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
   size: 23121
-  timestamp: 1769481046236
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-interfaces-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 9f344aea3c6c3189e1837d3e49f9cbb2f58f15ef894c0e363d5799c3093d1b9f
-  md5: 2c37d7ef87df5ffb736909a569b5677f
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ament-cmake-export-libraries
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  license: Apache-2.0
-  size: 22711
-  timestamp: 1769480789655
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-interfaces-2.7.4-np2py312h50b1e4c_15.conda
-  sha256: 2fc545296098da35fc670d5b675b3055c70fdb540ed71d8963d71a80ee2f5e69
-  md5: e9184b0c16cd634d3d443e2fcb2f37ad
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ament-cmake-export-libraries
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
-  - __osx >=11.0
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 23349
-  timestamp: 1769481201844
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-libraries-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 74b890cb42fe3782240732c412335417f70efebf8f6f95951ffb2f0b89116758
-  md5: 003f824386ad0df5e28685886c935a54
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  size: 24064
-  timestamp: 1769480717067
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-libraries-2.7.4-np2py312h50b1e4c_15.conda
-  sha256: f0cea3a498e3445c6682f87b275165c760d65c1325c2cce2e7da7a009911f431
-  md5: d8c010f0a5b42810db2cad313f424d97
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
-  - libcxx >=18
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  size: 24666
-  timestamp: 1769481007806
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-link-flags-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 467316e076be16bbcb06634bb4f95f0d79c05927b895202748247cc71ae40e1d
-  md5: 00b9c414a1ee9b08ede82a212e525559
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  license: Apache-2.0
-  size: 22072
-  timestamp: 1769480732895
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-link-flags-2.7.4-np2py312h50b1e4c_15.conda
-  sha256: 6a934371b5bbe0d1bac4f3f4012032e809a8458aadbfb5e9cb42e101a74d53c6
-  md5: 02290e0762a7464d902c4fd1bab4685c
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
-  - libcxx >=18
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  size: 22700
-  timestamp: 1769481039998
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-targets-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: b9d9575853ae818e67a0a23b08bb5984afa3b1eb65ca36b73737e5af24b5ecf8
-  md5: fd5a17abd307705dcd3bdb2898dc50a7
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ament-cmake-export-libraries
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  license: Apache-2.0
-  size: 22842
-  timestamp: 1769480820688
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-export-targets-2.7.4-np2py312h50b1e4c_15.conda
-  sha256: e5ae69b0d755e91471ff37a3fdf9077ad16fb328ef1b10dc6067294e5173c6a6
-  md5: 980415acba55bce546ea3a65fe244c11
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ament-cmake-export-libraries
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
-  - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  size: 23486
-  timestamp: 1769481299570
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-flake8-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: 2e598c5947b41a801132cec18f653f1ca1a8d144a5abf0984b2e92d9ca16f87b
-  md5: 72f532de20c5842c9155851f34e1a9ce
-  depends:
-  - python
-  - ros-kilted-ament-cmake-test
-  - ros-kilted-ament-flake8
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  size: 24401
-  timestamp: 1769481533987
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-flake8-0.19.2-np2py312h50b1e4c_15.conda
-  sha256: 78ff0f5fb408af25730cc2df64caaa80823d1d8f38843699c6d59f4bdf4eda1b
-  md5: 2100bc65efcad60aeb73371d23bc7081
-  depends:
-  - python
-  - ros-kilted-ament-cmake-test
-  - ros-kilted-ament-flake8
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
-  - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  size: 25038
-  timestamp: 1769487743692
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-gen-version-h-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 26b18d2167ddf9142c0e23ad2830cbad7c483d2cf6922eeebd680cf85482ecc2
-  md5: 881401cd2f5543c7014b9b8ce9f58839
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 24858
-  timestamp: 1769481007827
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-gen-version-h-2.7.4-np2py312h50b1e4c_15.conda
-  sha256: 195747e035ac8801fabf4aeb850471b2aec8774a42a9684e8d241325ef47d6f0
-  md5: dd34dc5a8a33fd0ee046da2391ae827a
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
-  - __osx >=11.0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 25449
-  timestamp: 1769481612613
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-gmock-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 884697d38dd5d9f732a9a7298db85a8ad59c61c95c7859e09638fcb20ac81596
-  md5: 8b2c84b624599159f5fd52e8f53ffdf4
-  depends:
-  - gmock
-  - python
-  - ros-kilted-ament-cmake-gtest
-  - ros-kilted-ament-cmake-test
-  - ros-kilted-gmock-vendor
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 24969
-  timestamp: 1769481015135
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-gmock-2.7.4-np2py312h50b1e4c_15.conda
-  sha256: 9a6a0a58ec2f9f309ec9f3adc6e7fb9e2e9b7e29ffacafbd7fd7e81ee8b088bf
-  md5: ae2fd0a0fabd34303dd4d8be6e3514a5
-  depends:
-  - gmock
-  - python
-  - ros-kilted-ament-cmake-gtest
-  - ros-kilted-ament-cmake-test
-  - ros-kilted-gmock-vendor
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
-  - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  size: 25541
-  timestamp: 1769481628562
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-gtest-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 2a93fe86af764b3d0f146cd504f2fbd58b79a84b81c9f7624b7907e2e02779dd
-  md5: 5e01157c6eeaca03a52c4433f144ee71
-  depends:
-  - gtest
-  - python
-  - ros-kilted-ament-cmake-test
-  - ros-kilted-gtest-vendor
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  - gtest >=1.17.0,<1.17.1.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  size: 24727
-  timestamp: 1769480902483
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-gtest-2.7.4-np2py312h50b1e4c_15.conda
-  sha256: 757abf8da0b1148939e884a190b410cf2cb2c93b6f26433717e08c2fbcb27b21
-  md5: b0794694ec1145e29b84372c0e7c5c5e
-  depends:
-  - gtest
-  - python
-  - ros-kilted-ament-cmake-test
-  - ros-kilted-gtest-vendor
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
-  - libcxx >=18
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  - gtest >=1.17.0,<1.17.1.0a0
-  license: Apache-2.0
-  size: 25312
-  timestamp: 1769481378917
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-include-directories-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 5f0f8e99de8873f83a86b0e270e0db8cd52b5a56509ec9d749bdb260b551c354
-  md5: f7ca94da299f30afddac7a57287e7254
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 21983
-  timestamp: 1769480743262
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-include-directories-2.7.4-np2py312h50b1e4c_15.conda
-  sha256: d6608f505d36ada8c64436ddd71580d08aa0299bc450cb7a34e2bef2664acbf1
-  md5: 099f9a13b6722a89bf85106c7feeea69
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
-  - libcxx >=18
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  license: Apache-2.0
-  size: 22647
-  timestamp: 1769481003628
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-libraries-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 5c8829b5b649319911651dea098321d130d6df60d19c86bc4ef93cd4e3663eaa
-  md5: 8bfdcb115448d744bdce81e32968786d
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  license: Apache-2.0
-  size: 21677
-  timestamp: 1769480740419
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-libraries-2.7.4-np2py312h50b1e4c_15.conda
-  sha256: 4a0b686f9e955a5b21e1d3ee5ed15c9c99a26e66967bbb9608b99f8a992f83e6
-  md5: 33d27c1656ec0580c859ca10510af51a
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
-  - __osx >=11.0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  size: 22307
-  timestamp: 1769480993265
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-lint-cmake-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: 35b8649e41fccf6b3d8d1bfc247ac3aaf5b48bc7cc4ebb249cb8540a0e1e078a
-  md5: 95553d5e0b7febbdd97efacc95ce613f
-  depends:
-  - python
-  - ros-kilted-ament-cmake-test
-  - ros-kilted-ament-lint-cmake
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  license: Apache-2.0
-  size: 22466
-  timestamp: 1769481317856
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-lint-cmake-0.19.2-np2py312h50b1e4c_15.conda
-  sha256: b30bec5bf33034e325cd892200c5bc021b4d763066c52b68c3b8f32664b16c07
-  md5: d96c2e2488009acd7c62044ffc479f6b
-  depends:
-  - python
-  - ros-kilted-ament-cmake-test
-  - ros-kilted-ament-lint-cmake
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
-  - libcxx >=18
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 23056
-  timestamp: 1769487384801
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-pep257-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: 0887f0c8752693120e2a6223fb8d79587bc3b2885114af9007afb5830334ae25
-  md5: 9a52a42e2ec48222ed221b6e2f53af74
-  depends:
-  - python
-  - ros-kilted-ament-cmake-test
-  - ros-kilted-ament-pep257
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  size: 23131
-  timestamp: 1769481530853
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-pep257-0.19.2-np2py312h50b1e4c_15.conda
-  sha256: bf95f49e561b4647b3810cc4e720a2573828bc73d5bf11d0405670c53c321d9d
-  md5: b93cd8bceb8772cd1f30dc0f0dbcde10
-  depends:
-  - python
-  - ros-kilted-ament-cmake-test
-  - ros-kilted-ament-pep257
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
-  - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  license: Apache-2.0
-  size: 23797
-  timestamp: 1769487734891
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-pytest-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 3619d742f876b2d70029ce84382faeb5ab20c714154a830761a9d01ee3da6912
-  md5: 8e96b311d0505cb58d9eee8b51ab44b3
-  depends:
-  - pytest
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ament-cmake-test
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  license: Apache-2.0
-  size: 24915
-  timestamp: 1769480918140
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-pytest-2.7.4-np2py312h50b1e4c_15.conda
-  sha256: eb2657032de7b0c1d88f7e0a9bc6ce0fb7827284b56752de932fba466903bc8f
-  md5: c3818f90087459f6e17c4910ace53121
-  depends:
-  - pytest
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ament-cmake-test
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
-  - libcxx >=18
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 25481
-  timestamp: 1769481400070
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-python-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 6c026590141a204404ef1d29048a0b3dd942b8336e2b6321f493659ada980791
-  md5: 92fe94f74cc22d28c2c7499a16207597
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  size: 24233
-  timestamp: 1769480730766
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-python-2.7.4-np2py312h50b1e4c_15.conda
-  sha256: 90e5e49433a41fba30c437b0b0c11fe497bd2b0594d1cd3eb017bd0caa05ccd1
-  md5: 42671c550639d4902c5f927dc72c79ce
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
-  - __osx >=11.0
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 24819
-  timestamp: 1769480967304
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-ros-0.14.7-np2py312h2ed9cc7_15.conda
-  sha256: 68cbacba669307e3e4d6779d25a48e3204ba51965f4098a6dc26d8aed16607cc
-  md5: ffb557307b62a1afa4ba895ac1744383
-  depends:
-  - python
-  - ros-kilted-ament-cmake
-  - ros-kilted-ament-cmake-gmock
-  - ros-kilted-ament-cmake-gtest
-  - ros-kilted-ament-cmake-pytest
-  - ros-kilted-ament-cmake-ros-core
-  - ros-kilted-rmw-test-fixture-implementation
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 31437
-  timestamp: 1769484283079
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-ros-0.14.7-np2py312h50b1e4c_15.conda
-  sha256: ce0dc439f62a09080dee4a1f41eeab8c1c5bc7f93cb73a944717d093bf35c923
-  md5: eae96a2087c52f0bc868478bda4fe64c
-  depends:
-  - python
-  - ros-kilted-ament-cmake
-  - ros-kilted-ament-cmake-gmock
-  - ros-kilted-ament-cmake-gtest
-  - ros-kilted-ament-cmake-pytest
-  - ros-kilted-ament-cmake-ros-core
-  - ros-kilted-rmw-test-fixture-implementation
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
-  - __osx >=11.0
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 31764
-  timestamp: 1769493855630
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-ros-core-0.14.7-np2py312h2ed9cc7_15.conda
-  sha256: 9365320bc946d43aeafee521d188299fdebdfabca0918b2e8ce9e461138ebd26
-  md5: 7c52656bd8d4222e34f38df6391b469b
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ament-cmake-libraries
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  license: Apache-2.0
-  size: 26949
-  timestamp: 1769481907394
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-ros-core-0.14.7-np2py312h50b1e4c_15.conda
-  sha256: 08c38b887ea94a6cd10df19d22e5721ef8aebaeb9e46d153708cd2cedf11c9e6
-  md5: 4c841375fd02d75d5340bb76db8b4995
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ament-cmake-libraries
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
-  - __osx >=11.0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 27259
-  timestamp: 1769488307648
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-target-dependencies-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 82515e1e547fe97d8a2bc828384f32423f6c0dc5b061ad5d8aab5740437df286
-  md5: 89f796d6e2f2749f814b35c0f0668287
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ament-cmake-include-directories
-  - ros-kilted-ament-cmake-libraries
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 23932
-  timestamp: 1769480816925
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-target-dependencies-2.7.4-np2py312h50b1e4c_15.conda
-  sha256: bf1f79c40c33a06c0f8b69a74b2e2e8bfeebe97f72353cb0ba2a06d1174e44d9
-  md5: 9e679bc6376ac26669a0e3b33fe1a3c5
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ament-cmake-include-directories
-  - ros-kilted-ament-cmake-libraries
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
-  - libcxx >=18
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 24565
-  timestamp: 1769481292174
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-test-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 5a3b6c9413ec8763f1d99438cf3e53ffb54a26ca4334952f836195006b9a4583
-  md5: 37278ec25dd247b4ce3d9d3a0f07407c
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  size: 36128
-  timestamp: 1769480803209
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-test-2.7.4-np2py312h50b1e4c_15.conda
-  sha256: 63e51ddf8048fb933751415daa46bb38171c4d7b7f19ea3c2af54e1220c001a5
-  md5: 5f1ab1b6085c31be72848838894667d3
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
-  - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  license: Apache-2.0
-  size: 36817
-  timestamp: 1769481261863
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-uncrustify-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: d66b90aeae700f4789c6d4e7e058694b8f34f21bfe24a73a61e229e197588755
-  md5: 1ce82ab15d9f893241772b41d4d13b28
-  depends:
-  - python
-  - ros-kilted-ament-cmake-test
-  - ros-kilted-ament-uncrustify
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  license: Apache-2.0
-  size: 23696
-  timestamp: 1769481527634
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-uncrustify-0.19.2-np2py312h50b1e4c_15.conda
-  sha256: 120a87bc7079403a25a6adb4db35d5d656ad42208b169986378a0918b1ae9d36
-  md5: c74002539af300e7b26fdc06f70b40bd
-  depends:
-  - python
-  - ros-kilted-ament-cmake-test
-  - ros-kilted-ament-uncrustify
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
-  - __osx >=11.0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 24363
-  timestamp: 1769487726625
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-version-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 8dba01c60fdbf70d91eeeac51e838eb206ab384f8284003d4708e86c74e420a0
-  md5: e743c926d8767a3477132e2a9734aa95
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  license: Apache-2.0
-  size: 21841
-  timestamp: 1769480730458
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-version-2.7.4-np2py312h50b1e4c_15.conda
-  sha256: 3d924e89d38c02bcff9dec6eac5f1130eb8d9c1bd07b94b31336e3ac32111c8f
-  md5: 735a8a0b5d51cf6f1693296ea9ace05e
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
-  - libcxx >=18
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  size: 22483
-  timestamp: 1769481032149
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-xmllint-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: 9c6f6d5ecef33ea31d3e3205ff2ffd14011e359214934cb066eff80c4a057d6a
-  md5: 6b77831d9bf6b347bcaf8b2a61c43572
+  timestamp: 1775547814591
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-xmllint-0.19.2-np2py312h50b1e4c_17.conda
+  sha256: 5fa9cc4cc78001c09db7b8627878fe8068a36a985f78396c99c0893661f940d8
+  md5: 42ec02ebebf38b504161119a697f8a70
   depends:
   - python
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-xmllint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 23145
-  timestamp: 1769481508877
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cmake-xmllint-0.19.2-np2py312h50b1e4c_15.conda
-  sha256: ae767bad537393d6162e633a4434dabf32efbcf3300b79be5abf58d947874c85
-  md5: 4a43ddc0cc93aecf134d0705477599a0
-  depends:
-  - python
-  - ros-kilted-ament-cmake-test
-  - ros-kilted-ament-xmllint
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
+  - libcxx >=18
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 23558
-  timestamp: 1769487701638
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-copyright-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: 6aa31473a87dae773d64ce2f539c31a7d58c7d4f0a6b5fd25aab5d8bb82d2343
-  md5: 9b784da5ac4e74a0a5e5da2d01b0c14a
+  size: 23732
+  timestamp: 1775548443505
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-copyright-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: 6be8a9e348235ff3db82b875f9c1af84f5a90f8a2fdc89cab76c0568b86472b3
+  md5: c879dd54d1c623e068838d1fcf0edf29
   depends:
   - importlib-metadata
   - python
   - ros-kilted-ament-lint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 66724
-  timestamp: 1769480992745
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-copyright-0.19.2-np2py312h50b1e4c_15.conda
-  sha256: 4e3d3249438e936189543168d4409ec2a255becdfe6c179cfe593b9604a120af
-  md5: 453e264a25d1727f07c3d6142cf8b72b
+  size: 66487
+  timestamp: 1775547176258
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-copyright-0.19.2-np2py312h50b1e4c_17.conda
+  sha256: 556ed97e8a2746606a951d140b38f0c96dc3a0b78d43cdc71ff55a964f06e6e1
+  md5: 584b2ff173f7b261b4b7c1476c1e9599
   depends:
   - importlib-metadata
   - python
   - ros-kilted-ament-lint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
+  - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 67226
-  timestamp: 1769481584474
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cppcheck-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: d0a3ed65f89d81bb9380be164f9192755bf31ef20baca9a21edd00a47aef50bc
-  md5: adf590ff0763679a66e1990e4af26e49
+  size: 67230
+  timestamp: 1775547771843
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cppcheck-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: 2b4a2c9b7228b791bbf9d457e5b78694ae621b01866da7d390a0411a67b9005f
+  md5: 30afffcee4dae3d3841f57d64f9b9638
   depends:
   - cppcheck
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 30333
-  timestamp: 1769481347590
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cppcheck-0.19.2-np2py312h50b1e4c_15.conda
-  sha256: 5f4730c5e1f9eb85fdd1c49ef6da3395f68340f4f9085f72caa9068834d45c9a
-  md5: 64430f5be599b238bd13c9ff0915b6d4
+  size: 30042
+  timestamp: 1775547606835
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cppcheck-0.19.2-np2py312h50b1e4c_17.conda
+  sha256: 5d50da47c96b344d7863b5518a308ec9437442e77cf022422364df807a6d1e5d
+  md5: 68d4c2db9d855202706c40de7f2a875b
   depends:
   - cppcheck
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
-  - python_abi 3.12.* *_cp312
+  - libcxx >=18
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 30654
-  timestamp: 1769487438667
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cpplint-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: 26784f92d828c4f12fc7864b2a9fefd61bf8a20e451e2f26a09ae2d7df8ae9e1
-  md5: f63e2c7f509af8911e0c127c9b5fbcf4
+  size: 30621
+  timestamp: 1775548267575
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cpplint-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: ef17a6393abd54a6766981e84cabc97c772c4c8d3d68a041e89d9f24bd9a1623
+  md5: 172668d4570336154c26c6eac0a3e30b
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0 OR BSD-3-Clause
-  size: 169476
-  timestamp: 1769481219523
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cpplint-0.19.2-np2py312h50b1e4c_15.conda
-  sha256: 9086fbcbc64cc4dde97221c25821511541509c6f99a36fa9a79a81ae8c83af9b
-  md5: 5d7bd3f87623c5a2cdb85420b70e7036
+  size: 169222
+  timestamp: 1775547490817
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-cpplint-0.19.2-np2py312h50b1e4c_17.conda
+  sha256: 5fa9c0528b8a0c20a2f9502cfea8be359961855c5263a1b03519f73372ddf559
+  md5: 0cd9daebcaae11ec5f35e011f953864a
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __osx >=11.0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0 OR BSD-3-Clause
-  size: 169789
-  timestamp: 1769481982239
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-flake8-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: c34f8ba11875bb03bbcdc95271b8889cf0914d43d5b1f1e3910b35ec6fedaa55
-  md5: 1c8b4dff520b9d84f1624f103ce1c494
+  size: 169749
+  timestamp: 1775548083825
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-flake8-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: 31e3af40a3db2a246e0dfa349b55371b3b1a2fed0c0ad9a8b7d0690b12013f22
+  md5: 06bb8ec21556f91b76da9c6dac4ce3f1
   depends:
   - flake8
   - flake8-builtins
@@ -9178,20 +9383,19 @@ packages:
   - python
   - ros-kilted-ament-lint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 28444
-  timestamp: 1769480790211
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-flake8-0.19.2-np2py312h50b1e4c_15.conda
-  sha256: bab5c58fbd62d82b4f4e03c318aa480606313bd505c78a28fc0f5d4f5a014bc6
-  md5: 18bd2cb1a6f9d5796bf393cb27979a6f
+  size: 28208
+  timestamp: 1775546964948
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-flake8-0.19.2-np2py312h50b1e4c_17.conda
+  sha256: 1374ed18b9dc08cd9e88013934c319571c4a98794bed1fbeade36eef5e1cf002
+  md5: 8d5f3effd80fa19c825aeecf0bd1a898
   depends:
   - flake8
   - flake8-builtins
@@ -9202,181 +9406,177 @@ packages:
   - python
   - ros-kilted-ament-lint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
+  - libcxx >=18
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 29034
-  timestamp: 1769481238698
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-index-cpp-1.11.2-np2py312h2ed9cc7_15.conda
-  sha256: 8214ed7ae705dbfb85e556b327e5e7f9ab05cd742fc842656d101d3e5222c64c
-  md5: 13c6c302922f1aa14cd9d683bb7dc851
+  size: 29017
+  timestamp: 1775547490607
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-index-cpp-1.11.3-np2py312h2ed9cc7_17.conda
+  sha256: c8ced08dfa7caccbcd2468a173c4c326003ffcb7c178771ae882f4e9d7542ef9
+  md5: 53b094689fbead2a33c6c47a16cd9b17
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 47318
-  timestamp: 1769482249098
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-index-cpp-1.11.2-np2py312h50b1e4c_15.conda
-  sha256: 2db374e0d0ac2e872f090d35d8deb1c185efc5943e30e56ac27bb1bbdea579db
-  md5: a4aef21245b3cb6483cb67c0567ef997
+  size: 52338
+  timestamp: 1775548543053
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-index-cpp-1.11.3-np2py312h50b1e4c_17.conda
+  sha256: c43ef700ec25ca85e0892dc4a8f872e2e0bbe320e2707ce7142036a3eaf89f10
+  md5: fa78075bebe16ec740e916383eb5fc52
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 47855
-  timestamp: 1769488709751
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-index-python-1.11.2-np2py312h2ed9cc7_15.conda
-  sha256: f22dcb480a960217c725d72535312cfea3c9ec62a23b720fcbe882bd91d13e90
-  md5: 2701b3d22fe007869f2175d981684992
+  size: 50607
+  timestamp: 1775549465743
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-index-python-1.11.3-np2py312h2ed9cc7_17.conda
+  sha256: 35de5c6172510ad551a2bfcf06c7ff383c490db24c54c7bf06208494b1fe4846
+  md5: 268e9a1947ab9a19b88e2831b988e0ef
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 30782
-  timestamp: 1769481335293
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-index-python-1.11.2-np2py312h50b1e4c_15.conda
-  sha256: 52a42ce13b1b827e1a12b87a2190da7b97e19405428ef52a116e591d934f4ff0
-  md5: 0a54fe08666e03570624f71954dd2961
-  depends:
-  - python
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
-  - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  license: Apache-2.0
-  size: 31102
-  timestamp: 1769487417679
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-lint-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: 5be09a96a230b4ab934049c347b6b631f2e124576ce131fbc9385f24d3aca378
-  md5: 24fbc34aafec03038079daae6bbb73a3
-  depends:
-  - python
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 17707
-  timestamp: 1769480717597
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-lint-0.19.2-np2py312h50b1e4c_15.conda
-  sha256: caa8b4d79035f870ac2b4ba73223302de19fb0ffe20a8c8e78a411b4b0b4628e
-  md5: 30a7c189798b8b4d679c91762b557e2a
+  size: 30502
+  timestamp: 1775547588121
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-index-python-1.11.3-np2py312h50b1e4c_17.conda
+  sha256: 3cb2119359368d74af2e2930fac71cdba81860a1100394af1c0411d2fe1623db
+  md5: 46c5c6df044ea6e0ae6dab26e474fc27
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 18272
-  timestamp: 1769480933127
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-lint-auto-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: d34a706b4158bf666742b623cc1b298ccc3e850e1e0136aca002fb1c710f9b5c
-  md5: 3fb4801466c1988de38f04e2de7fb6c3
+  size: 31082
+  timestamp: 1775548251894
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-lint-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: 73cfcf49b46619773eed9a439d8263efcc16595f9deaba304e9227fa3dee074f
+  md5: 47593ea1b76419873cb9969967f11a8b
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  license: Apache-2.0
+  size: 17450
+  timestamp: 1775546890246
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-lint-0.19.2-np2py312h50b1e4c_17.conda
+  sha256: 6f06efbd7f780975c4f5a9893150f748680427f5ab0498e0833cb4b3e0e76808
+  md5: f362e561d02f6a116b71aa4edb654e94
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libcxx >=18
+  - __osx >=11.0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  license: Apache-2.0
+  size: 18276
+  timestamp: 1775547299862
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-lint-auto-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: cb2a6e8dcd4c8476fae8ea97106cbde9a410857ff1633164ee3f774a2c1e1736
+  md5: a9eab95a94e7080cf158107d985f92d3
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ament-cmake-test
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 22063
-  timestamp: 1769480914604
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-lint-auto-0.19.2-np2py312h50b1e4c_15.conda
-  sha256: 465405d473243953a512e714ed997ecaaa5e59f0703ca9445ebee97d752c8600
-  md5: 38b08dc677bf7d7ae3379e600280c62c
+  size: 21989
+  timestamp: 1775547090680
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-lint-auto-0.19.2-np2py312h50b1e4c_17.conda
+  sha256: 1409e1fe1d62a0440edd85f2a13bdd26ee37a12c8b4a1028fb9547077542b559
+  md5: a30247706c0718a601dec2f3a6e1147f
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ament-cmake-test
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 22706
-  timestamp: 1769481395102
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-lint-cmake-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: b21aed41fcb1024bfa29102cb3e5df70a364a31bdf9d2a0e7292949ce68527b7
-  md5: 7d6e6de3c4a18b3ec840ca232a0216dd
+  size: 22882
+  timestamp: 1775547689239
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-lint-cmake-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: a8bab22294f560aafc499fbd556440499b27a05690c507dba99215d9e010b7fe
+  md5: 7dc9e9e1b85536dbd9bcc2cb4f0269cc
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 39882
-  timestamp: 1769481189235
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-lint-cmake-0.19.2-np2py312h50b1e4c_15.conda
-  sha256: 88a176ed95de63178c9a3e5bd5d2c2e3b31f0079cf64242d8e238afe7073aa05
-  md5: a49c056b32c1c37831b540aee4c6e559
+  size: 39643
+  timestamp: 1775547417198
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-lint-cmake-0.19.2-np2py312h50b1e4c_17.conda
+  sha256: 302ac8530e9760c6b596b461260edb24a47e147a5b33348c5dbfb5db59772dee
+  md5: 5fb056afe7eae4a22d2dd6f288fb5039
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
+  - libcxx >=18
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 40199
-  timestamp: 1769481928214
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-lint-common-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: eedce33897daded79f153386167e2763474f461e06e85602b37a6502a5fba6ce
-  md5: 4dd9f0a045be6382ad31521ab231c62e
+  size: 40196
+  timestamp: 1775548037373
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-lint-common-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: d617f5f510f0697c29e51f1404686067356b7bc43a580bd44615468f865c8f93
+  md5: 7f9e9dbe5d97482a8e25d69dc64d309a
   depends:
   - python
   - ros-kilted-ament-cmake-copyright
@@ -9389,20 +9589,19 @@ packages:
   - ros-kilted-ament-cmake-uncrustify
   - ros-kilted-ament-cmake-xmllint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 22365
-  timestamp: 1769481566436
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-lint-common-0.19.2-np2py312h50b1e4c_15.conda
-  sha256: d63bb0befd1a9584c17ee4cad1803c6720c6b0f25ddebc8728ad92f80e8e0394
-  md5: fcf58fea8cd166e7c95f7d45d5483b91
+  size: 22309
+  timestamp: 1775547879574
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-lint-common-0.19.2-np2py312h50b1e4c_17.conda
+  sha256: 6d26b8c2a823f16d497951f190d025d3546cda3be28d671093b7a22b6e3d1b15
+  md5: 0564ea02f308469d42822f82d275897b
   depends:
   - python
   - ros-kilted-ament-cmake-copyright
@@ -9415,230 +9614,228 @@ packages:
   - ros-kilted-ament-cmake-uncrustify
   - ros-kilted-ament-cmake-xmllint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - __osx >=11.0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 22992
-  timestamp: 1769487812967
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-package-0.17.2-np2py312h2ed9cc7_15.conda
-  sha256: 291b9dffcdf7d046dc5795c10818f44fa25eafd47b3cd8c7cc56a4669ce36dfb
-  md5: de16418e1ed797ebf75f6f241d610a65
+  size: 23197
+  timestamp: 1775548805102
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-package-0.17.2-np2py312h2ed9cc7_17.conda
+  sha256: b029632cc4dcb017e9bd8d703e5940a5ecd99e13158ebd10550c175841f9cc85
+  md5: 1f69c3912d148bd88796a514f5d6d20c
   depends:
   - importlib-metadata
   - importlib_resources
   - python
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - setuptools
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 43016
-  timestamp: 1769480640155
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-package-0.17.2-np2py312h50b1e4c_15.conda
-  sha256: a612131f1cda1b9278fbb720574c3ccb4adb72456b154e6604ab896ebdc1028f
-  md5: 232e96d14292148c111897f7ed819b0c
+  size: 42836
+  timestamp: 1775546815797
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-package-0.17.2-np2py312h50b1e4c_17.conda
+  sha256: b45765f2995ea152ef3a2a5c5670b190a60a621b75cd269b168a8f3de3eaa205
+  md5: d1f491e6d880ea8e98e4d79ecb1a127b
   depends:
   - importlib-metadata
   - importlib_resources
   - python
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - setuptools
   - libcxx >=18
   - __osx >=11.0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 43604
-  timestamp: 1769480805595
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-pep257-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: fa4e7940159bd4d2ac094a9835f78d3a3678829c305032600afc3a97f0334ad9
-  md5: 6d421e449affa3f6635e389940526c79
+  size: 43623
+  timestamp: 1775546957554
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-pep257-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: a2c45dbc197d8d8a51874eddc0e77a125fb1a2d0ed2383392e7af09af73a2964
+  md5: 4242fa902fde572cceb9611964098b8a
   depends:
   - pydocstyle
   - python
   - ros-kilted-ament-lint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0 OR MIT
-  size: 27110
-  timestamp: 1769480887391
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-pep257-0.19.2-np2py312h50b1e4c_15.conda
-  sha256: 0842d60b0d115fde1d2890e782348696d8267bd2db4a47404bfbb2499657cb88
-  md5: 25a93622e8d67738064128cd0f699252
+  size: 26851
+  timestamp: 1775547063829
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-pep257-0.19.2-np2py312h50b1e4c_17.conda
+  sha256: 5df86223403b1e4a4d0ec3027709f4dde584ec396785a76bc3111009c2be8eeb
+  md5: 774f40c598cb41ceb9960c57ee7a74c1
   depends:
   - pydocstyle
   - python
   - ros-kilted-ament-lint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
-  - numpy >=1.23,<3
+  - libcxx >=18
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0 OR MIT
-  size: 27662
-  timestamp: 1769481360356
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-uncrustify-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: 3dcbbd0614e17959ce1ad3a23201ccbc21620000f53d0cf0055a5e143d4cc2ab
-  md5: bae1ca96a3fd4c9807d220fd18098533
+  size: 27676
+  timestamp: 1775547654735
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-uncrustify-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: e486f97892f4d24fc8b20019a619da91c6ae5b2aa00175a711a7321c509fce4a
+  md5: 1de29a953846b07315a3a21f20f1e6fc
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-uncrustify-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 68547
-  timestamp: 1769481342533
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-uncrustify-0.19.2-np2py312h50b1e4c_15.conda
-  sha256: 4bfd5ffc118bb04738994f3b0a589c52db0e69ff5d643608daec25424293d640
-  md5: 0376c6b59884895b4b7a58c73b20347c
+  size: 68343
+  timestamp: 1775547596599
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-uncrustify-0.19.2-np2py312h50b1e4c_17.conda
+  sha256: 85411f4c9a36a54507a3f0bbd1a15f78d7ccbec0d645fb85d0425c8d4ec5cc42
+  md5: 2afea82bac97a7bac39769f753bca0dd
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-uncrustify-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 68887
-  timestamp: 1769487429600
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-xmllint-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: b99e3734c6aa2805a18e680c2b9c45cd92c24086fdb736f507a1d8d7d18c5358
-  md5: 296f4f1296d72f5b1c66ee54a297ed30
+  size: 68875
+  timestamp: 1775548261193
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-xmllint-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: 4b1ecf3874ccedfba66c7c7122c7e8759c3b9ab21daa612eb94a7a616a8692d9
+  md5: b84f7ed7b7c5081fba854c6213ef2c4d
   depends:
   - libxml2
   - python
   - ros-kilted-ament-lint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 28160
-  timestamp: 1769481086986
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-xmllint-0.19.2-np2py312h50b1e4c_15.conda
-  sha256: cd3a3fef685004ff6e72a4fcb5a8647fe080b91c147f326964bcbe20c8ee357e
-  md5: b6eed6436df1fe471d1bde693285b291
+  size: 27933
+  timestamp: 1775547316530
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ament-xmllint-0.19.2-np2py312h50b1e4c_17.conda
+  sha256: 177e2765a9a6371121a635fa34e21e6c36d97c2434e572595223b35c0efc1ff0
+  md5: dca1606c2ae68f5100fc985eeabc77d0
   depends:
   - libxml2
   - python
   - ros-kilted-ament-lint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 28732
-  timestamp: 1769481750694
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-builtin-interfaces-2.3.0-np2py312h2ed9cc7_15.conda
-  sha256: 2893e4a553c73351b790ec5934f6005e0b140c40c002c620afcc8b774f03b13f
-  md5: effaba6a72597d712d64c30f257418b8
+  size: 28716
+  timestamp: 1775547910289
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-builtin-interfaces-2.3.1-np2py312h2ed9cc7_17.conda
+  sha256: d981b1b6eaff61c9d7f65e42554f38849681ebbf2e308f573a06a040278800f9
+  md5: 8992399be2191fa178ebeaa69b5e3857
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 78376
-  timestamp: 1769482959329
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-builtin-interfaces-2.3.0-np2py312h50b1e4c_15.conda
-  sha256: 55642602603602bf3d38589fcf7800064b46166adf138e82c4b798a21bd8005b
-  md5: d76e2efcfd420d6b5d55e2f87810b1b9
+  size: 80442
+  timestamp: 1775549166535
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-builtin-interfaces-2.3.1-np2py312h50b1e4c_17.conda
+  sha256: 50a650d4c05179cca25c6e72b000d45a12aa5824cca19a6d294399322065fd1d
+  md5: 609d1016ff08c73401fc9b7aedee66dc
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 74568
-  timestamp: 1769490640345
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-class-loader-2.8.1-np2py312h2ed9cc7_15.conda
-  sha256: f964517a49f200e28eff5a8519703c36493d79c0655608ced57b83b169cb90c6
-  md5: e76de5f7262b15e1585e75c2bf8f6611
+  size: 76696
+  timestamp: 1775550630357
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-class-loader-2.8.1-np2py312h2ed9cc7_17.conda
+  sha256: 7a798f855659b0050152b405fa8c6d246e11995598e63a6e48aafb693dffa32a
+  md5: a5cf7fe5ae40e3f361952cb44ca77972
   depends:
   - console_bridge
   - python
   - ros-kilted-console-bridge-vendor
   - ros-kilted-rcpputils
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - console_bridge >=1.0.2,<1.1.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - console_bridge >=1.0.2,<1.1.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 74996
-  timestamp: 1769484350402
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-class-loader-2.8.1-np2py312h50b1e4c_15.conda
-  sha256: b1e9449bbded5d2cf6c24f89bdc2f0a5897f3caa8b4de59587c1a9b6874fedd1
-  md5: 88acef4973de996ef0a257c153c3d16f
+  size: 75039
+  timestamp: 1775550536242
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-class-loader-2.8.1-np2py312h50b1e4c_17.conda
+  sha256: 4be216ff3a1fef583b61bc7adf78ea64b79f34153bedf3c3ee4884e6095f0601
+  md5: 930b52d77c76e4833dd4b63a7e17dad7
   depends:
   - console_bridge
   - python
   - ros-kilted-console-bridge-vendor
   - ros-kilted-rcpputils
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
+  - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - console_bridge >=1.0.2,<1.1.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 68746
-  timestamp: 1769493991962
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-common-interfaces-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: ce9736083f5f7f3071771574dd0ef91302ef7ea56620778d0921864bd9726e71
-  md5: e37d071e458e1a4b70b1058d2aa1040f
+  size: 68949
+  timestamp: 1775553334170
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-common-interfaces-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: 5c3b766b1ef9427ae995195d5aa355b1b2e6ad41f954f2ed81d5cd5d3b4b1e08
+  md5: d7b7d4aeb87f4227fe590092ed7eddca
   depends:
   - python
   - ros-kilted-actionlib-msgs
@@ -9654,20 +9851,19 @@ packages:
   - ros-kilted-stereo-msgs
   - ros-kilted-trajectory-msgs
   - ros-kilted-visualization-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 26736
-  timestamp: 1769484184350
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-common-interfaces-5.5.1-np2py312h50b1e4c_15.conda
-  sha256: 98af7aa12e3474052341e9ee7bccf8a0427ed1990c6d7a239aec02881e8ad4f2
-  md5: b1d07fdc969f9c476ead493274d0e318
+  size: 26863
+  timestamp: 1775550386515
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-common-interfaces-5.5.2-np2py312h50b1e4c_17.conda
+  sha256: 04b74d39dca7c7b83a7d0d8a9c10333fcf533d9511687dec4413a2633177615c
+  md5: cf3f70134aa1b9c946dbd4f16ace6bf3
   depends:
   - python
   - ros-kilted-actionlib-msgs
@@ -9683,89 +9879,88 @@ packages:
   - ros-kilted-stereo-msgs
   - ros-kilted-trajectory-msgs
   - ros-kilted-visualization-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
+  - libcxx >=18
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 27084
-  timestamp: 1769493611650
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-composition-interfaces-2.3.0-np2py312h2ed9cc7_15.conda
-  sha256: 084236f8ccd20c061818e907af5e1d2e08e0101124ec6d715a1966fba7071bdb
-  md5: 5f59e671702d5f717fafefb12c2ac857
+  size: 27310
+  timestamp: 1775553024172
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-composition-interfaces-2.3.1-np2py312h2ed9cc7_17.conda
+  sha256: 6e6eca5e8568eac94dee89cc825e01ace62fc02e82a00468e60bcac31cbf8834
+  md5: 8440bc2ca424bee4bb9aa5aca768c1bb
   depends:
   - python
   - ros-kilted-rcl-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 224241
-  timestamp: 1769483409226
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-composition-interfaces-2.3.0-np2py312h50b1e4c_15.conda
-  sha256: dc08b78863eda3221542612e644f052d90f186e06f232fa4a89c558028ca5869
-  md5: b7c1d674f45558a8bead882b457a2c9b
+  size: 227468
+  timestamp: 1775549583148
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-composition-interfaces-2.3.1-np2py312h50b1e4c_17.conda
+  sha256: 0f3e42cfd3ade4df104cf55ab3e0ec073ae121d362d91d10c6affebe651164fa
+  md5: 601801c9775275d96020a07f1f1fb497
   depends:
   - python
   - ros-kilted-rcl-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
+  - __osx >=11.0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 191876
-  timestamp: 1769491838085
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-console-bridge-vendor-1.8.0-np2py312h2ed9cc7_15.conda
-  sha256: a3ac7fc473e86bf0bc60e0a7800c08ed24253f091692d842ab4d239d145b3f99
-  md5: 03e0f3f9baf49a76546419538cff2ef2
+  size: 195241
+  timestamp: 1775551663120
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-console-bridge-vendor-1.8.0-np2py312h2ed9cc7_17.conda
+  sha256: 8439ef0bcd0dd46541af67edd1dac97fb70b3217574a711ac394efa693270356
+  md5: 68658a292a3ce8d7850af77895e693f2
   depends:
   - console_bridge
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - console_bridge >=1.0.2,<1.1.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0 OR BSD-3-Clause
-  size: 27851
-  timestamp: 1769482324658
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-console-bridge-vendor-1.8.0-np2py312h50b1e4c_15.conda
-  sha256: 862f91376540f65d3e1a9bc0c1ac360c637a1347f10d40946dcffacde88fd36f
-  md5: 10f00caa948b3e86bf911bdfaad484dd
+  size: 27870
+  timestamp: 1775548606197
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-console-bridge-vendor-1.8.0-np2py312h50b1e4c_17.conda
+  sha256: 25c061ffd66dde0903834c7026150cb30783b6e37cd7845dd35a5e29d8c9494e
+  md5: 16d788ebf49603794380d6b57531145a
   depends:
   - console_bridge
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - python_abi 3.12.* *_cp312
+  - __osx >=11.0
   - console_bridge >=1.0.2,<1.1.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0 OR BSD-3-Clause
-  size: 28182
-  timestamp: 1769489124807
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-control-msgs-6.7.0-np2py312h2ed9cc7_15.conda
-  sha256: 49ea5350ffb1888978fc2686283480b8f7d9598dea965294c50c8a615f019edf
-  md5: bcec99fc72a7fcb5997b0835f36082d0
+  size: 28379
+  timestamp: 1775549602143
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-control-msgs-6.8.0-np2py312h2ed9cc7_17.conda
+  sha256: e528cb981b23906d7786f0e1ac048704ea7bc20ea1b56c5ccf76c03c7c9c7fec
+  md5: d308ea713b309eab0d8345c01359b6b1
   depends:
   - python
   - ros-kilted-action-msgs
@@ -9777,22 +9972,21 @@ packages:
   - ros-kilted-sensor-msgs
   - ros-kilted-std-msgs
   - ros-kilted-trajectory-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
   purls:
   - pkg:pypi/control_msgs?source=project-defined-mapping
-  size: 1539952
-  timestamp: 1769483771340
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-control-msgs-6.7.0-np2py312h50b1e4c_15.conda
-  sha256: c81443ef8186070372521591b83f9ee9c410c6830129379f9dfc4debc5a7f324
-  md5: cc492d6ced540f8e7ff909dfa1d4d7d9
+  size: 1604561
+  timestamp: 1775549932462
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-control-msgs-6.8.0-np2py312h50b1e4c_17.conda
+  sha256: aa81c116b234a24f043a9d0ac9d99014299678519385162853318c0d655b93f6
+  md5: 06d73d40a1853c21b27f1b995adae9d5
   depends:
   - python
   - ros-kilted-action-msgs
@@ -9804,20 +9998,20 @@ packages:
   - ros-kilted-sensor-msgs
   - ros-kilted-std-msgs
   - ros-kilted-trajectory-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
   purls:
   - pkg:pypi/control_msgs?source=project-defined-mapping
-  size: 1254330
-  timestamp: 1769492808021
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-cyclonedds-0.10.5-np2py312h2ed9cc7_15.conda
-  sha256: bf6529b3a78493f3b034ba54fda08a3a99962be45706bec4fa04a0ea326f8940
-  md5: 8876184e5c17a515fd29f828a5fa6205
+  size: 1308114
+  timestamp: 1775552391989
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-cyclonedds-0.10.5-np2py312h2ed9cc7_17.conda
+  sha256: 6361bc98d6dc314c715637a61f7357c6a8af3ce2f4e1c8b9c68e39f3368191e5
+  md5: d07e8e7e1e81062eedfd722ca3d892e3
   depends:
   - openssl
   - python
@@ -9825,20 +10019,20 @@ packages:
   - ros-kilted-iceoryx-hoofs
   - ros-kilted-iceoryx-posh
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - openssl >=3.6.0,<4.0a0
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - openssl >=3.6.1,<4.0a0
   license: EPL-2.0 OR BSD-3-Clause
-  size: 1198745
-  timestamp: 1769481018679
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-cyclonedds-0.10.5-np2py312h50b1e4c_15.conda
-  sha256: f2b81644ad57750b532defdaa066acb9d7c3c9096642c07e01ca2c07738bdf22
-  md5: 8c6f56377a13c525b06e1e95d4378858
+  size: 1198633
+  timestamp: 1775547228076
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-cyclonedds-0.10.5-np2py312h50b1e4c_17.conda
+  sha256: 32a0f3f30e3232086c20452df553c33ca780169a9bc6eb40974b0931bd20b97b
+  md5: daf99a5705eb76240833f0e4e7aea92f
   depends:
   - openssl
   - python
@@ -9846,19 +10040,19 @@ packages:
   - ros-kilted-iceoryx-hoofs
   - ros-kilted-iceoryx-posh
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - openssl >=3.6.1,<4.0a0
   - python_abi 3.12.* *_cp312
-  - openssl >=3.6.0,<4.0a0
   license: EPL-2.0 OR BSD-3-Clause
-  size: 1054272
-  timestamp: 1769481638389
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-diagnostic-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: c0c59bd84116eb45371262b67a60b9f9d556295321a942622a55e7ad9acf3e6e
-  md5: f06410148f6797ebb284297157dea6cf
+  size: 1054302
+  timestamp: 1775547816882
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-diagnostic-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: 774368d747e2b6c6bb8fb8d53edcc078041f501dbb13c87afc4acf3584798592
+  md5: 8628f2e9f515f209de0eb36f3a583732
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -9866,20 +10060,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 208495
-  timestamp: 1769483495945
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-diagnostic-msgs-5.5.1-np2py312h50b1e4c_15.conda
-  sha256: 9a1b58cfd6b763a3fb8ad0de4515c18ef445f5a76fbb7b44547f99087e632252
-  md5: 6ed5b54cd11c23a0a3ec94adcc34e8ac
+  size: 212290
+  timestamp: 1775549669603
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-diagnostic-msgs-5.5.2-np2py312h50b1e4c_17.conda
+  sha256: b601e9d081a991ed25dcdede6c2851327fd8277b54797890ffcdbe18a8c18500
+  md5: 388493e0617213071e8734c9da0097a2
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -9887,335 +10080,329 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 181451
-  timestamp: 1769492140351
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-fastcdr-2.3.3-np2py312h2ed9cc7_15.conda
-  sha256: f2ac2aa71ac7fcd45c22c805488745626defd9315f1446196eb788e1f873599b
-  md5: 8c47ecf373bd16953e7429b203bf0bf3
+  size: 185243
+  timestamp: 1775551889821
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-fastcdr-2.3.5-np2py312h2ed9cc7_17.conda
+  sha256: 07cb8eb1a61140e12b295668670b3079ea017be518d9c5c70385ff512bf4d412
+  md5: 30eb82f50f361d1cb06900301cf29325
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 89685
-  timestamp: 1769481202273
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-fastcdr-2.3.3-np2py312h50b1e4c_15.conda
-  sha256: 58ce8ff19bfddf7922a0a5c753b7e1f818b11b0108e65423071d59308b2ecd5b
-  md5: a75b8c74e73e3a164b145203377e47c3
+  size: 89534
+  timestamp: 1775547413501
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-fastcdr-2.3.5-np2py312h50b1e4c_17.conda
+  sha256: fc88a8b11eb5ebba64fbe4633cd7c5d912b024a6fbc7f9859b5be7021fdaeaf9
+  md5: 9ad18460f6981fc52dd4a86a0dace2b8
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - __osx >=11.0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 81928
-  timestamp: 1769481911615
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-fastdds-3.2.3-np2py312h2ed9cc7_15.conda
-  sha256: 89fcfa57d1d394d7188575f702324f47f968f39048a559de16240c4c57ff98da
-  md5: fbada3c49201f5057e5a681470609bfe
+  size: 82032
+  timestamp: 1775548049758
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-fastdds-3.2.3-np2py312h2ed9cc7_17.conda
+  sha256: 58582fb1a847919a02d326d55530e3463f0796128a333b0510ef89307a41343e
+  md5: 332aff327eb1e7c656a0de6ace58f6b4
   depends:
   - openssl
   - python
   - ros-kilted-fastcdr
   - ros-kilted-foonathan-memory-vendor
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - tinyxml2
-  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - tinyxml2 >=11.0.0,<11.1.0a0
-  - openssl >=3.6.0,<4.0a0
+  - openssl >=3.6.1,<4.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 5031625
-  timestamp: 1769481881152
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-fastdds-3.2.3-np2py312h50b1e4c_15.conda
-  sha256: 170e4bd8d41812a0a7060e8162add3054f6c96e7f2e8c8567eaeac9db4d7c963
-  md5: ed095082192d4ef07916183d96b69dc9
+  size: 5049573
+  timestamp: 1775548161639
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-fastdds-3.2.3-np2py312h50b1e4c_17.conda
+  sha256: 4369087771a292db5f8811b22b223b35e8304e4897357946c970909caeda7966
+  md5: e8a1fff2562e33129cbb6f2a1f0a4245
   depends:
   - openssl
   - python
   - ros-kilted-fastcdr
   - ros-kilted-foonathan-memory-vendor
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - tinyxml2
   - __osx >=11.0
   - libcxx >=18
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  - openssl >=3.6.1,<4.0a0
   - tinyxml2 >=11.0.0,<11.1.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - openssl >=3.6.0,<4.0a0
-  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 3408509
-  timestamp: 1769488265415
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-foonathan-memory-vendor-1.3.1-np2py312h2ed9cc7_15.conda
-  sha256: 1736822350a45983ff0feb652ef02d5b9cc5eb096e0811d0156a3bfae8a711f0
-  md5: 193c26baeb2d6a32dde1ee345aca7610
+  size: 3418839
+  timestamp: 1775549142768
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-foonathan-memory-vendor-1.3.1-np2py312h2ed9cc7_17.conda
+  sha256: 18be30095916b7994944b89ff892c4d939935c7c8d8993e916a62e30b9e67bbb
+  md5: a8009c5e726b5bcb7e7e60da83de61f3
   depends:
   - foonathan-memory
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - cmake
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - foonathan-memory >=0.7.3,<0.7.4.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0 OR Zlib
-  size: 19577
-  timestamp: 1769481587716
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-foonathan-memory-vendor-1.3.1-np2py312h50b1e4c_15.conda
-  sha256: d7247443c561678767e0b745318c3ab4a35d08b42e45b082310854ee447f32db
-  md5: bcdf33184626900031f9fbfab8c7cb0a
+  size: 19363
+  timestamp: 1775547899377
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-foonathan-memory-vendor-1.3.1-np2py312h50b1e4c_17.conda
+  sha256: 88910e2373331062f85af0e5c8552e628df16cb4422b6a6de9eb1d009119b3bf
+  md5: a1f83b7e1b257951dedede912e8c3eac
   depends:
   - foonathan-memory
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - cmake
   - __osx >=11.0
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - foonathan-memory >=0.7.3,<0.7.4.0a0
   license: Apache-2.0 OR Zlib
-  size: 19998
-  timestamp: 1769487846871
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-geometry-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: 955954f1e6e3886cec3534504c77416f3b9a9be830bf3e8196170729865cd23a
-  md5: 7b5983f9f0138e75f1fcd7469bd3907e
+  size: 19957
+  timestamp: 1775548829717
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-geometry-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: 859dc87ad45729d28cf0bb292aeea3b1a0324a41d43bc3b01bf4f88fedb5d042
+  md5: 3692013ff016bfa6193c88ea6c6faa8b
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
   purls:
   - pkg:pypi/geometry_msgs?source=project-defined-mapping
-  size: 377527
-  timestamp: 1769483425900
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-geometry-msgs-5.5.1-np2py312h50b1e4c_15.conda
-  sha256: b69b2b32b7e3eb993b977e2aefdeb3b2ee65472c7e6585ee067415f16c79625f
-  md5: 0b5a05f55fb1bab9e7f38c3c52b3e35f
+  size: 385780
+  timestamp: 1775549600944
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-geometry-msgs-5.5.2-np2py312h50b1e4c_17.conda
+  sha256: 80f9c1a23484032608349a9b0fc9eeab61b3229e339f0b37ff5c092114eebcbc
+  md5: 7815ab7766c0782a796b0b393081a21e
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
   purls:
   - pkg:pypi/geometry_msgs?source=project-defined-mapping
-  size: 324601
-  timestamp: 1769491877447
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-gmock-vendor-1.15.1-np2py312h2ed9cc7_15.conda
-  sha256: f4ab267e542b25a8e7598d3d35f7b905a2b7c63a3c666308f7a16758ac9c8e64
-  md5: 0e6d9f0c42003a4c1765e4b96eed7f11
+  size: 332976
+  timestamp: 1775551700116
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-gmock-vendor-1.15.1-np2py312h2ed9cc7_17.conda
+  sha256: 3ecca7351a6432c10f97b7fec4271e7b0b46ec147fcad3e2958f99b39db32f12
+  md5: fb860d8d5f7637bebbd4f1a30f145ca0
   depends:
   - python
   - ros-kilted-gtest-vendor
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 122615
-  timestamp: 1769480803310
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-gmock-vendor-1.15.1-np2py312h50b1e4c_15.conda
-  sha256: cc75116ccdbb86ffc46ed75e665ea10e6c7acf4a92041266aff1f0dd23cbec3b
-  md5: 01cb85365c262534efb31efa3b67b093
+  size: 122361
+  timestamp: 1775546975636
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-gmock-vendor-1.15.1-np2py312h50b1e4c_17.conda
+  sha256: 95e060457bf9ff5a67bc56699a2622683768a865ababe0096efee75a998c9804
+  md5: c2458f61c6b01d3a42dff8feb1a332c8
   depends:
   - python
   - ros-kilted-gtest-vendor
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
-  size: 123245
-  timestamp: 1769481223681
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-gtest-vendor-1.15.1-np2py312h2ed9cc7_15.conda
-  sha256: 4af8d537e396af6c3ef9f17971ba8d819763150735acc12a460a31b7c456a52a
-  md5: 9b40cc926acd4b3e7fdfd76ee9e78751
+  size: 123239
+  timestamp: 1775547512663
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-gtest-vendor-1.15.1-np2py312h2ed9cc7_17.conda
+  sha256: 6c663a85eba955ca0c6d8327e546e03319037c2c546b72cd89a8ae70d2e4148b
+  md5: 4fee7e3a43a8c5f6e4ccacc273e6cf4a
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
-  size: 208999
-  timestamp: 1769480737380
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-gtest-vendor-1.15.1-np2py312h50b1e4c_15.conda
-  sha256: 2d0992a96091c8f8c5833f6e602f318aea5699ef6ff41a34190525f510330693
-  md5: 3cecd71efdadb5afe23774e6139885c3
+  size: 208755
+  timestamp: 1775546910580
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-gtest-vendor-1.15.1-np2py312h50b1e4c_17.conda
+  sha256: 28b01079955e0c11b83b8a75a5440eaca6224e6c1d2e67cf62476324ed11c846
+  md5: eca4a67ddfc84f6f014625783bf3ad55
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 209609
-  timestamp: 1769480984587
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-iceoryx-binding-c-2.0.5-np2py312h2ed9cc7_15.conda
-  sha256: d6bc356cd3195e23e63cb7d04ef0bbc85268019fee7d33103faa20df7db17be3
-  md5: 87accfd0d206e736a061491dedf49b27
+  size: 209642
+  timestamp: 1775547352143
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-iceoryx-binding-c-2.0.5-np2py312h2ed9cc7_17.conda
+  sha256: 13a706979570883418a83c27b1ecdb6a72db8c368a12ce848cc4e02ed7d7bb02
+  md5: a218e50d1b6919d3efa3a718b8c84e5e
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 93164
-  timestamp: 1769480901521
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-iceoryx-binding-c-2.0.5-np2py312h50b1e4c_15.conda
-  sha256: 8c832941c436b8174333abe9c782a78892a20d909b0c678fd975f9820d4175f1
-  md5: b58311b5763c520799c57be9bfca3515
+  size: 93027
+  timestamp: 1775547078762
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-iceoryx-binding-c-2.0.5-np2py312h50b1e4c_17.conda
+  sha256: 4f9e9595f2769e655d79595dd31c70d7b381dc7f7e723458b8a6b77c0ae13e49
+  md5: 7f3be461d2d605d765a86509a6aa16e3
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __osx >=11.0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 82173
-  timestamp: 1769481429370
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-iceoryx-hoofs-2.0.5-np2py312h2ed9cc7_15.conda
-  sha256: 5ca890a864bbcf7c9f4794fc5e23bffe388694b41f80000080388547b537a42d
-  md5: 6aa3efbaf985ab261e58e59367a20c0e
+  size: 82170
+  timestamp: 1775547671273
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-iceoryx-hoofs-2.0.5-np2py312h2ed9cc7_17.conda
+  sha256: 40b220c18f37c63074b1cd3d9f6da9fa58125adce78040dfadac46e5ecbb8a48
+  md5: 5c07a23e589224a315c4f33b26407b8c
   depends:
   - libacl
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - libacl >=2.3.2,<2.4.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 263978
-  timestamp: 1769480753737
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-iceoryx-hoofs-2.0.5-np2py312h50b1e4c_15.conda
-  sha256: 96e4865a20fef262e74f5ba19d20989eb99f36796e18d8e584a83ec97359db00
-  md5: f25d641b57379290735a51b243d80e3a
+  size: 263867
+  timestamp: 1775546927423
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-iceoryx-hoofs-2.0.5-np2py312h50b1e4c_17.conda
+  sha256: 011500bb414a42617c337673808faab86403f999792dcfda219087174f482614
+  md5: 3d976d57ea6773f79599739908060b4c
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 258399
-  timestamp: 1769480988393
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-iceoryx-posh-2.0.5-np2py312h2ed9cc7_15.conda
-  sha256: 569b69c0636f1f57c264dd2a1df8fac2659378f35b5a7f1b19e0373c10c045bc
-  md5: 9b7c315b79be4964dc28388344b03808
+  size: 258427
+  timestamp: 1775547347381
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-iceoryx-posh-2.0.5-np2py312h2ed9cc7_17.conda
+  sha256: 87525acc1d392d94638c1d1abd00c387f32d5f3055498123061f69d1df53659e
+  md5: c66292daa624d8c63bca49cd675c4cdf
   depends:
   - python
   - ros-kilted-iceoryx-hoofs
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 574060
-  timestamp: 1769480806728
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-iceoryx-posh-2.0.5-np2py312h50b1e4c_15.conda
-  sha256: dcdb6fde03c09f0f288242eb7c64873323ba6f89bd7054f67afa2b5515e4a1e7
-  md5: e4f470511d9ddf0ee51f3a6c0e71f941
+  size: 573973
+  timestamp: 1775546979949
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-iceoryx-posh-2.0.5-np2py312h50b1e4c_17.conda
+  sha256: b00e3dc0b6c4f74adc64279702939c720340039532e0496377a90ae375aeab08
+  md5: 8cc5ae0ac589d5640a04c8608412b1c3
   depends:
   - python
   - ros-kilted-iceoryx-hoofs
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - libcxx >=18
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 433828
-  timestamp: 1769481229818
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-3.8.7-np2py312h2ed9cc7_15.conda
-  sha256: c0b5e1a112944d36268d9ab3db7dc1a9238a8cab6a9cc4c59c6cc8d476a33e78
-  md5: 7fb99992549f0640473fa9b7bbbba794
+  size: 433826
+  timestamp: 1775547521480
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-3.8.7-np2py312h2ed9cc7_17.conda
+  sha256: b42a44c643b3641bfe94cd2f76226b7e3e57b42c9e720e2e2ae39434b8cc107e
+  md5: 3aa35e4726162bc26f90975de9309c77
   depends:
   - lark-parser
   - python
@@ -10223,19 +10410,19 @@ packages:
   - ros-kilted-ament-index-python
   - ros-kilted-osrf-pycommon
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 246546
-  timestamp: 1769481477621
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-3.8.7-np2py312h50b1e4c_15.conda
-  sha256: e5fa04ce4610a7583b27ec7297ee51e9f1db989e839936aaa56da0cf6f638842
-  md5: c4a3a0ee5dd42f289c591abfefaf795f
+  size: 246343
+  timestamp: 1775547783769
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-3.8.7-np2py312h50b1e4c_17.conda
+  sha256: d0b1cc270a32bb718839c17de18e09864dc993635079390bb1a3ca28c3eb609b
+  md5: 723a848a9f33904fd82a360fda5617fa
   depends:
   - lark-parser
   - python
@@ -10243,18 +10430,18 @@ packages:
   - ros-kilted-ament-index-python
   - ros-kilted-osrf-pycommon
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libcxx >=18
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 246871
-  timestamp: 1769487633682
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-ros-0.28.5-np2py312h2ed9cc7_15.conda
-  sha256: f4659895fba4f36d92f4e212aae219dff8e6eeb9b311ad3e25c459488c162aa6
-  md5: dfa7476220a6cc2342cd4f4042971be8
+  size: 246907
+  timestamp: 1775548385164
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-ros-0.28.5-np2py312h2ed9cc7_17.conda
+  sha256: 8056010714a6909e4eb1fe3f9bf1aa33e76c337bd66b8913fc43c821778ba5ea
+  md5: 5c398b0ef2f36c95e0a8a4d8fdf82d8c
   depends:
   - python
   - pyyaml
@@ -10265,19 +10452,19 @@ packages:
   - ros-kilted-osrf-pycommon
   - ros-kilted-rclpy
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 113950
-  timestamp: 1769485079708
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-ros-0.28.5-np2py312h50b1e4c_15.conda
-  sha256: 7ea780031db249333899373d7ba956d70b84256c7e99eefd3f3d67bcd13026b9
-  md5: fdb10a1bbc58e62601162110bc33b96f
+  size: 113717
+  timestamp: 1775551285595
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-ros-0.28.5-np2py312h50b1e4c_17.conda
+  sha256: 27f4c6e920b2a2bc1fe74efb13c30c7dd2aeb83538959fc1ac41dd7db0a19b05
+  md5: 656da961e8d829a2f121d1b8b652cab4
   depends:
   - python
   - pyyaml
@@ -10288,18 +10475,18 @@ packages:
   - ros-kilted-osrf-pycommon
   - ros-kilted-rclpy
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 114290
-  timestamp: 1769495579435
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-testing-3.8.7-np2py312h2ed9cc7_15.conda
-  sha256: a4c5ed0028dcfb16fe5b517c34d8c88676b894daefa7cb6d78a8355fbc565f9f
-  md5: bdf5e16e25065a12a22f16ba4565cb66
+  size: 114304
+  timestamp: 1775554546291
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-testing-3.8.7-np2py312h2ed9cc7_17.conda
+  sha256: 1e5738b8d7c24c2d87c8bd6825710944608cab8efa49a0f1266b5fde9c6af4e5
+  md5: 1914d6f860062d17c05a2cfce3eb712f
   depends:
   - pytest
   - python
@@ -10309,20 +10496,19 @@ packages:
   - ros-kilted-launch-yaml
   - ros-kilted-osrf-pycommon
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 116466
-  timestamp: 1769481581278
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-testing-3.8.7-np2py312h50b1e4c_15.conda
-  sha256: bf85ec4dd904130f0296e9fc420113c90cdc6e6b63542bfcf37e402161a26d53
-  md5: edc0c8bd3ec6939453f1e9f80b3609f7
+  size: 116270
+  timestamp: 1775547891466
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-testing-3.8.7-np2py312h50b1e4c_17.conda
+  sha256: a15181453d2f26023541920890dbc2eb1b81a7a22a048f8f748d29cced000b83
+  md5: ed8195c659d75f2f24a6426466e3db2c
   depends:
   - pytest
   - python
@@ -10332,54 +10518,53 @@ packages:
   - ros-kilted-launch-yaml
   - ros-kilted-osrf-pycommon
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 116773
-  timestamp: 1769487837002
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-testing-ament-cmake-3.8.7-np2py312h2ed9cc7_15.conda
-  sha256: 8beed9ea270008e803cba496bbd012f14705ef28cfc686bcf88786fd6558a689
-  md5: 7b39b4bc8a2c2f655178f74f3e51c0ec
+  size: 116822
+  timestamp: 1775548821212
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-testing-ament-cmake-3.8.7-np2py312h2ed9cc7_17.conda
+  sha256: 9b811ba8f257e31b3152ceec5517d7e02447077899c3755fc284c2c2eeffa43e
+  md5: 72a377657eb3124f6980d53b0ae6bcd3
   depends:
   - python
   - ros-kilted-ament-cmake-test
   - ros-kilted-launch-testing
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0 OR BSD-3-Clause
-  size: 27126
-  timestamp: 1769481902408
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-testing-ament-cmake-3.8.7-np2py312h50b1e4c_15.conda
-  sha256: 76cf2c89c567a2c5539b712ceaa10f8d41e75cb01a602f5fb5021d72c34539f6
-  md5: 13b1b0569411001ca82fa6cf8d44e5f0
+  size: 27160
+  timestamp: 1775548186030
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-testing-ament-cmake-3.8.7-np2py312h50b1e4c_17.conda
+  sha256: 38ac85bdb3f7f5ee89d734d86cf755d56f1dc5514cd827f18afd6e73cc1798ac
+  md5: 9b1e0473e6aa775854f4b5abf88968f2
   depends:
   - python
   - ros-kilted-ament-cmake-test
   - ros-kilted-launch-testing
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
+  - __osx >=11.0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0 OR BSD-3-Clause
-  size: 27744
-  timestamp: 1769488296943
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-testing-ros-0.28.5-np2py312h2ed9cc7_15.conda
-  sha256: a1f443e5544e76bae64c2f2b50323273449dfd79274ff08aed31d2e7566d6637
-  md5: 39c0644d25137f437194fee55cae014b
+  size: 27990
+  timestamp: 1775549179730
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-testing-ros-0.28.5-np2py312h2ed9cc7_17.conda
+  sha256: d131bf0bdfc26eccc83adbecb21f6a711f184a3763ac0c80218b581a5b663768
+  md5: 827ad125a189dec847eb0f0262ed0b4b
   depends:
   - python
   - ros-kilted-ament-index-python
@@ -10388,20 +10573,19 @@ packages:
   - ros-kilted-rclpy
   - ros-kilted-rmw-test-fixture-implementation
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 56488
-  timestamp: 1769485252596
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-testing-ros-0.28.5-np2py312h50b1e4c_15.conda
-  sha256: 4422092bf7c2ce1bdc6cec9d2eef54a89f55de9590b52776f040a32e463ae29f
-  md5: a59510b548054acdfc02122122a66d21
+  size: 56409
+  timestamp: 1775551548581
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-testing-ros-0.28.5-np2py312h50b1e4c_17.conda
+  sha256: 6bbe6ec33add30d7a855aa9d3dae5528e168cb66810c10912989138b9d019b3b
+  md5: 4e29322aa9399acf648ba974e382c96e
   depends:
   - python
   - ros-kilted-ament-index-python
@@ -10410,83 +10594,81 @@ packages:
   - ros-kilted-rclpy
   - ros-kilted-rmw-test-fixture-implementation
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 56751
-  timestamp: 1769496074843
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-xml-3.8.7-np2py312h2ed9cc7_15.conda
-  sha256: 5221cbff29742434f8a66e3998b6de659695a2d38425cdf48016140f8ced82a7
-  md5: 2125582063f53979f6b5d714db3bb25a
+  size: 56848
+  timestamp: 1775555875836
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-xml-3.8.7-np2py312h2ed9cc7_17.conda
+  sha256: cf6a2a0c3cd4616cd3015f7e47eeffabefb60b59370f92cb9303f52b1242f305
+  md5: 3db629d5df25d129e137b5d7ef1a3208
   depends:
   - python
   - ros-kilted-launch
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 25866
-  timestamp: 1769481528051
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-xml-3.8.7-np2py312h50b1e4c_15.conda
-  sha256: 44db5382601ab47fbed33666db0b2dced4efbaea585e7edb1fe125202aefa4bf
-  md5: f1366c8e99f85088fb22076c0e36eab1
+  size: 25629
+  timestamp: 1775547832174
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-xml-3.8.7-np2py312h50b1e4c_17.conda
+  sha256: 44b711961a56de83b16712197ab18623af75eff951e0d4cf7eb3e5ea41a6c1e7
+  md5: 1b52dab05138b73e1a7de6abdec26699
   depends:
   - python
   - ros-kilted-launch
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
+  - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 26220
-  timestamp: 1769487741785
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-yaml-3.8.7-np2py312h2ed9cc7_15.conda
-  sha256: 2885602164eaeb1bd6efc372376819df4563f5e53e9457a9500147998d0b28d4
-  md5: b2dbd5802d0bdb3f22ef0875b16e0619
+  size: 26207
+  timestamp: 1775548467432
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-launch-yaml-3.8.7-np2py312h2ed9cc7_17.conda
+  sha256: da1f5b713ba19aa6193de145dc35ab1bc529851b1d3d260c4818a7573c07d437
+  md5: 4c80531dff12163fe6cd5527692c53cd
   depends:
   - python
   - ros-kilted-launch
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 26472
-  timestamp: 1769481521692
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-yaml-3.8.7-np2py312h50b1e4c_15.conda
-  sha256: 281573897c65b7f944d262bdbdc61517027344c62dfe9b591248db2a1f7df8d2
-  md5: 65fb65ba8fd6f74eef1dad28a09f0f7a
+  size: 26190
+  timestamp: 1775547825048
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-launch-yaml-3.8.7-np2py312h50b1e4c_17.conda
+  sha256: 44dd7a64053bdbbc4a79fe441b2a3585363f0c0045d9df9bf0e48c7dece5ed2d
+  md5: 98a1edb2266fc353ce32e5f4b0b80071
   depends:
   - python
   - ros-kilted-launch
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __osx >=11.0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 26793
-  timestamp: 1769487731610
+  size: 26781
+  timestamp: 1775548458911
 - conda: aic_utils/lerobot_robot_aic
   name: ros-kilted-lerobot-robot-aic
   version: 0.0.1
@@ -10502,7 +10684,7 @@ packages:
   - ros-kilted-sensor-msgs
   - ros-kilted-std-msgs
   - ros2-distro-mutex
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - libcxx >=22
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
@@ -10522,16 +10704,16 @@ packages:
   - ros-kilted-sensor-msgs
   - ros-kilted-std-msgs
   - ros2-distro-mutex
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - libgcc >=15
   - libgcc >=15
   - libstdcxx >=15
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: LicenseRef-Apache-2.0
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-libstatistics-collector-2.0.1-np2py312h2ed9cc7_15.conda
-  sha256: d47f3cd0ffcd25e15ac65123c1d5a7a8d6aa3f6b214a036a1465429705546cfd
-  md5: 1dfcc8620055acd1210102130295d4b5
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-libstatistics-collector-2.0.1-np2py312h2ed9cc7_17.conda
+  sha256: 52b287e9bd7438299cf8ae2a6f7a50981f7d4d5755c81a5e1e86fe5996678ac8
+  md5: 4e8c759027a4aace9e41f1702f9541ea
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -10540,20 +10722,19 @@ packages:
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
   - ros-kilted-statistics-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 58336
-  timestamp: 1769484793834
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-libstatistics-collector-2.0.1-np2py312h50b1e4c_15.conda
-  sha256: 3e1018ae46d1808dce2f2bc2f789d08e00a1def8f2b459b1f181a4ace3749e65
-  md5: cd2317c3f3b9f8e60c611e6af9a73812
+  size: 58630
+  timestamp: 1775550984587
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-libstatistics-collector-2.0.1-np2py312h50b1e4c_17.conda
+  sha256: 6328468f800dc8b3296057e1f78a063b481a2e321291a51af02c9b0db280aab3
+  md5: b4f00ac0ca7509b669910a1e3f0ae7b3
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -10562,132 +10743,92 @@ packages:
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
   - ros-kilted-statistics-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 56874
-  timestamp: 1769494756481
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-libyaml-vendor-1.7.1-np2py312h2ed9cc7_15.conda
-  sha256: 21dcc6c0a7c7ae9b8f490ccf6481e3bccde746507663e14f69543bf1d49ed0a2
-  md5: b2fa6413d09e8921170f0cfff78f9d2a
+  size: 57084
+  timestamp: 1775554043722
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-libyaml-vendor-1.7.1-np2py312h2ed9cc7_17.conda
+  sha256: 419e2cba8585ad2c86ab4f602f0fe19153c5062cfd7b8fafd4a02d86fc69d0d1
+  md5: bf2bf710206d324708e7579fb3cf7908
   depends:
   - pkg-config
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - yaml
   - yaml-cpp
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - yaml-cpp >=0.8.0,<0.9.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   - yaml >=0.2.5,<0.3.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - yaml-cpp >=0.8.0,<0.9.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0 OR MIT
-  size: 29756
-  timestamp: 1769482319912
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-libyaml-vendor-1.7.1-np2py312h50b1e4c_15.conda
-  sha256: b8a2a70ca92312c3b20b06993469b1259829198f2613cf189d9a87327cc2d76d
-  md5: 43e2c57c608aff72e1fd2a4329d7ae0f
+  size: 29841
+  timestamp: 1775548600537
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-libyaml-vendor-1.7.1-np2py312h50b1e4c_17.conda
+  sha256: 8561d46331dff83b0ce1ccbb5014e151a9b8add00ea31d0a8322fb9d0412338d
+  md5: 974034f849742443af8ba66e788a663a
   depends:
   - pkg-config
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - yaml
   - yaml-cpp
-  - __osx >=11.0
   - libcxx >=18
-  - yaml-cpp >=0.8.0,<0.9.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - __osx >=11.0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - yaml >=0.2.5,<0.3.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - yaml-cpp >=0.8.0,<0.9.0a0
   license: Apache-2.0 OR MIT
-  size: 30135
-  timestamp: 1769489114419
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-lifecycle-0.36.4-np2py312h2ed9cc7_15.conda
-  sha256: 2f2635089a580b6fffe00bdb8a234f863b05d7a9a2a4c80a743bc394394b1b17
-  md5: 1a46f63cb7d4d9657e26581a56550cff
-  depends:
-  - python
-  - ros-kilted-lifecycle-msgs
-  - ros-kilted-rclcpp
-  - ros-kilted-rclcpp-lifecycle
-  - ros-kilted-ros-workspace
-  - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  license: Apache-2.0
-  size: 265297
-  timestamp: 1769486269
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-lifecycle-0.36.4-np2py312h50b1e4c_15.conda
-  sha256: 73d8953b5339b67045b9176c60c74e8bf46921c11bf32f3b16ba1851f09ed74d
-  md5: 18c65cad713dbd2ea8d55d2d209361fa
-  depends:
-  - python
-  - ros-kilted-lifecycle-msgs
-  - ros-kilted-rclcpp
-  - ros-kilted-rclcpp-lifecycle
-  - ros-kilted-ros-workspace
-  - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
-  - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  license: Apache-2.0
-  size: 195816
-  timestamp: 1769500725657
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-lifecycle-msgs-2.3.0-np2py312h2ed9cc7_15.conda
-  sha256: e0a0023e6743b4e8866d0289a82ccae9f9a7e0b8b39e5bbd188192198300b72a
-  md5: c48e5749478f5bc0bc1086a611df19ca
+  size: 30262
+  timestamp: 1775549586919
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-lifecycle-msgs-2.3.1-np2py312h2ed9cc7_17.conda
+  sha256: 7a4582125f61223c5e21ee609007c715c4c7d7a9df4c21ba83394ca53f1b6557
+  md5: d3d5b0255c46ffc6e82b2b55e6a1d252
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 266413
-  timestamp: 1769483120685
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-lifecycle-msgs-2.3.0-np2py312h50b1e4c_15.conda
-  sha256: 738ccc94f1029f55fe428691a1fb4913b717b2df8ca3df1945d77d8e8f351b6f
-  md5: 13e4cc904b0166e4018970cfd2e589a4
+  size: 271654
+  timestamp: 1775549324355
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-lifecycle-msgs-2.3.1-np2py312h50b1e4c_17.conda
+  sha256: 0b47c0c26faa9724ed50bdbd835c7ae3fcbcf2706d40c948b0b15ed158a9cee1
+  md5: dd39d58119914ecf4b25de64179a046d
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 232845
-  timestamp: 1769491057019
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-message-filters-7.1.5-np2py312h2ed9cc7_15.conda
-  sha256: 6d304444e22067963097e0b1ee789e573db63fc8ee1c101ff63ca03237060ea5
-  md5: 0cb972a2cb8809c2d64bb54d2fe26e38
+  size: 240185
+  timestamp: 1775550967208
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-message-filters-7.1.6-np2py312h2ed9cc7_17.conda
+  sha256: e2efdf131d8be50d6575d586b07d2dde0a11d962b5a035a33fff59b60ed7698b
+  md5: 3eee707cb8653c8cac8743ba810f0b9f
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -10696,19 +10837,19 @@ packages:
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 88511
-  timestamp: 1769485264930
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-message-filters-7.1.5-np2py312h50b1e4c_15.conda
-  sha256: b4a8635cc8f63868a5d49da86974337e5cc84a7672a2972fd5a465079fe1b7d3
-  md5: d9b686d3e495b31fb94f76a0437214f1
+  size: 88883
+  timestamp: 1775551566159
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-message-filters-7.1.6-np2py312h50b1e4c_17.conda
+  sha256: 3e7771d71174e9565c861b5eb85d3f7714827763ca049663fca9c8f7b6272125
+  md5: f8530734ed0386aa84612a1d3354c8f5
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -10717,18 +10858,18 @@ packages:
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __osx >=11.0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 87022
-  timestamp: 1769496113787
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-moveit-msgs-2.7.1-np2py312h2ed9cc7_15.conda
-  sha256: cb86adf83eb3a858bbdedc6d761bf1349fd3baf46a85287abc3aa0ac230531c1
-  md5: 4fa7cec1992c5b688662d759c51dd563
+  size: 87394
+  timestamp: 1775555919396
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-moveit-msgs-2.7.1-np2py312h2ed9cc7_17.conda
+  sha256: 89de27b88a19c8dd2320e8294c4fba3dbf106c82a736c74514dfe21a6c330ccd
+  md5: 916d67c6456678c0d3ef6daf6d5b9b94
   depends:
   - python
   - ros-kilted-action-msgs
@@ -10741,22 +10882,21 @@ packages:
   - ros-kilted-shape-msgs
   - ros-kilted-std-msgs
   - ros-kilted-trajectory-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
   purls:
   - pkg:pypi/moveit_msgs?source=project-defined-mapping
-  size: 3000249
-  timestamp: 1769483967668
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-moveit-msgs-2.7.1-np2py312h50b1e4c_15.conda
-  sha256: 96067ff64ab5a925508501f2cf032187feb4fa2705a9b7180de7a1bf4fe13b8c
-  md5: 0377e71e66971283954f23748415f2d6
+  size: 3042212
+  timestamp: 1775550168247
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-moveit-msgs-2.7.1-np2py312h50b1e4c_17.conda
+  sha256: faebc6c5cd227fb891db405a91d7057bdc342db058e0ff10512b5812aa5b8c09
+  md5: f3df151cef61cb1f3d2c9c60f74e719d
   depends:
   - python
   - ros-kilted-action-msgs
@@ -10769,20 +10909,20 @@ packages:
   - ros-kilted-shape-msgs
   - ros-kilted-std-msgs
   - ros-kilted-trajectory-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
   purls:
   - pkg:pypi/moveit_msgs?source=project-defined-mapping
-  size: 2132329
-  timestamp: 1769493246263
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-nav-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: 9baafb16cd27b577a27b47479ace2f36e2e408270f05a0af30d38625266ee4ee
-  md5: 592ac5acfed8b5f5ee15138386b08bf4
+  size: 2174436
+  timestamp: 1775552751328
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-nav-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: 0b1031044b7f1d764ac79060c29b692f59c8eb5f0e2962795e3ba314b5e049b6
+  md5: 8ea2c2a6b8910af2b24882187843ad2f
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -10790,20 +10930,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 314263
-  timestamp: 1769483551702
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-nav-msgs-5.5.1-np2py312h50b1e4c_15.conda
-  sha256: 1eed2f1568c4585f6b01b2c0c78e7e405ac9224392afd8d53a6dc91a77db7526
-  md5: d9c52b247965508e621072fe5de2feff
+  size: 347128
+  timestamp: 1775549745861
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-nav-msgs-5.5.2-np2py312h50b1e4c_17.conda
+  sha256: 471843d0e41df748eec086b7b093b78e52db5ddbc44f793fdcf8a8003da4a1f5
+  md5: 6f66b9e6d82e4db7b278fbffa8f4d804
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -10811,18 +10950,18 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 274653
-  timestamp: 1769492308522
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-object-recognition-msgs-2.0.0-np2py312h2ed9cc7_15.conda
-  sha256: b28b76cdb0e7822e16434504387399089ce6459141a8458fd69dad5d09805233
-  md5: dcaea5977ec1c9cb9f9bf70f47122b49
+  size: 303881
+  timestamp: 1775552050652
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-object-recognition-msgs-2.0.0-np2py312h2ed9cc7_17.conda
+  sha256: 52c64f633298bd295710be5e9de8c25c038621c2f12eb95fd27f251f0bf50042
+  md5: edd8426ddcd262b9abc2b003d31e35e3
   depends:
   - python
   - ros-kilted-action-msgs
@@ -10832,20 +10971,19 @@ packages:
   - ros-kilted-sensor-msgs
   - ros-kilted-shape-msgs
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 345371
-  timestamp: 1769483860427
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-object-recognition-msgs-2.0.0-np2py312h50b1e4c_15.conda
-  sha256: ff636eed89de33bc378034128479c2d316e70b1894f8001b38e5e68f85f48c7e
-  md5: 624cb9023cf28373e3db1dff20342f0d
+  size: 352621
+  timestamp: 1775550041156
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-object-recognition-msgs-2.0.0-np2py312h50b1e4c_17.conda
+  sha256: d31d8e9f6884cea86e48045f509b20fa64f5e5e1380d0faacce8a6a8fe127b25
+  md5: 4f3a6c88866f149d0c6b34ffd679ce9e
   depends:
   - python
   - ros-kilted-action-msgs
@@ -10855,89 +10993,88 @@ packages:
   - ros-kilted-sensor-msgs
   - ros-kilted-shape-msgs
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 294194
-  timestamp: 1769492938473
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-octomap-msgs-2.0.1-np2py312h2ed9cc7_15.conda
-  sha256: 67d692a3a0879448db8d39199949f67653354efbfa8005a81bbcfbd09a4b6004
-  md5: 9351888031aef5432f5a90f29861113b
+  size: 303401
+  timestamp: 1775552507235
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-octomap-msgs-2.0.1-np2py312h2ed9cc7_17.conda
+  sha256: e29590121b5f83615af7982897af55dd44d31f7c082dd612c47a0f57bcf5d20d
+  md5: b9c8857568018b15c56f56522d13df39
   depends:
   - python
   - ros-kilted-geometry-msgs
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 182687
-  timestamp: 1769483574675
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-octomap-msgs-2.0.1-np2py312h50b1e4c_15.conda
-  sha256: 85939a24a59035aa73952a5ecd6d455627a8e12fbfe0a6ffc8fa2c2eb6c7be6f
-  md5: 58bcd746c8999c5ec90b33dd566cd375
+  size: 186088
+  timestamp: 1775549729990
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-octomap-msgs-2.0.1-np2py312h50b1e4c_17.conda
+  sha256: 9cf55bac6dfd3084ad724b8fbc189bdf6b9547005a70438600521ab304879166
+  md5: a278ecf2ca40ba1698d76278d118b492
   depends:
   - python
   - ros-kilted-geometry-msgs
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 165571
-  timestamp: 1769492368103
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-osrf-pycommon-2.1.6-np2py312h2ed9cc7_15.conda
-  sha256: 295abb1c2a9ffc09ccc5844f22d11840dbdeb09a2f2e8ba219978b466fbfe0eb
-  md5: 2b503d9cd73621c4db78888a7be981b4
+  size: 168925
+  timestamp: 1775552014668
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-osrf-pycommon-2.1.6-np2py312h2ed9cc7_17.conda
+  sha256: 7362a92d20dbc98b188679de3ad770364f7dcc07b9c012a4e0d2821a5a6f1dee
+  md5: 0583f472a24e2b0a8fd7b6f444521a9a
   depends:
   - importlib-metadata
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 64789
-  timestamp: 1769480717674
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-osrf-pycommon-2.1.6-np2py312h50b1e4c_15.conda
-  sha256: 95410b523bf95c606566c69fe155dff641cde4c3dfa9020648534fbcc96315ab
-  md5: 701338dc5f570b36a65f44ad71cdbdb2
+  size: 64516
+  timestamp: 1775546889942
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-osrf-pycommon-2.1.6-np2py312h50b1e4c_17.conda
+  sha256: 65476d36bf3ae6dbe166f76fa03f3125c7c87878572b51ca14c1411b00fe00d6
+  md5: e4ff2627742c2c4e48348cfd9b256af1
   depends:
   - importlib-metadata
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 65391
-  timestamp: 1769480921641
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-pluginlib-5.6.2-np2py312h2ed9cc7_15.conda
-  sha256: 61cf7b8002f5db4f0b349a855ca9ea8e5d92bc1929fcd495ef4257a642c36f46
-  md5: 377ef9fb44bbdb73a1f43b0df07e86f1
+  size: 65398
+  timestamp: 1775547295092
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-pluginlib-5.6.2-np2py312h2ed9cc7_17.conda
+  sha256: c29229e8787efcbae0cf0ee72061696adb1fe26b8d1a55f2c85e0f6c64146a42
+  md5: 0049d3b99bd76199372fe39b8899943d
   depends:
   - python
   - ros-kilted-ament-index-cpp
@@ -10946,20 +11083,19 @@ packages:
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-tinyxml2-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 142080
-  timestamp: 1769484532531
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-pluginlib-5.6.2-np2py312h50b1e4c_15.conda
-  sha256: 1e68fc8aba8c8a7396e01bb17f9a85a579ba2a4701ad78e44c57fcd96640b154
-  md5: e2cf4404d1e56378343700bdc45e55f3
+  size: 142143
+  timestamp: 1775550717693
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-pluginlib-5.6.2-np2py312h50b1e4c_17.conda
+  sha256: e1cd85015e88447f21f8cefc534a340da2ac7c940691a75e7d7305c52716f75e
+  md5: 13acab4672db33472d3089de212983ea
   depends:
   - python
   - ros-kilted-ament-index-cpp
@@ -10968,18 +11104,18 @@ packages:
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-tinyxml2-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
+  - libcxx >=18
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 120013
-  timestamp: 1769494300148
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-10.1.4-np2py312h2ed9cc7_15.conda
-  sha256: 6577e8d0d079e86e530a5db952aadb0ec7b60bc8d730d2d731df4bff44cfe84b
-  md5: 9d6eb9bbad1b93d07dbeacf98f7a6e4e
+  size: 120223
+  timestamp: 1775553608845
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-10.1.4-np2py312h2ed9cc7_17.conda
+  sha256: d4cd6431a7e5b52a2e6c9722af06bebcf2524b91fb1a831d13a62ad5719800a2
+  md5: be5ba045cf2767c6fa53b5c191031862
   depends:
   - python
   - ros-kilted-libyaml-vendor
@@ -10995,24 +11131,23 @@ packages:
   - ros-kilted-service-msgs
   - ros-kilted-tracetools
   - ros-kilted-type-description-interfaces
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - yaml
   - yaml-cpp
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - yaml-cpp >=0.8.0,<0.9.0a0
   - yaml >=0.2.5,<0.3.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - yaml-cpp >=0.8.0,<0.9.0a0
   license: Apache-2.0
-  size: 200044
-  timestamp: 1769484624231
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-10.1.4-np2py312h50b1e4c_15.conda
-  sha256: e9718a70638e3be35d6693c7aecbb082e7d793ca86765cd5ed44c3b98bc82331
-  md5: 6984c672bf72a3b8a087acc823896fe4
+  size: 200334
+  timestamp: 1775550822899
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-10.1.4-np2py312h50b1e4c_17.conda
+  sha256: 344791feb5166380a8ba2c2f8fc72079ff3ad24a2a20b9c715713baa39475f73
+  md5: f216f063437d6286e72654f5150ddf8f
   depends:
   - python
   - ros-kilted-libyaml-vendor
@@ -11028,22 +11163,22 @@ packages:
   - ros-kilted-service-msgs
   - ros-kilted-tracetools
   - ros-kilted-type-description-interfaces
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - yaml
   - yaml-cpp
   - libcxx >=18
   - __osx >=11.0
-  - python_abi 3.12.* *_cp312
-  - yaml-cpp >=0.8.0,<0.9.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   - yaml >=0.2.5,<0.3.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - yaml-cpp >=0.8.0,<0.9.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 182819
-  timestamp: 1769494476458
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-action-10.1.4-np2py312h2ed9cc7_15.conda
-  sha256: acbdde105959c58ceb99133a4dd8c864dc60a181da04ebd16cac7fad19befb4b
-  md5: 584a41c8567d1be94797b3c521ec57ed
+  size: 183141
+  timestamp: 1775553787355
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-action-10.1.4-np2py312h2ed9cc7_17.conda
+  sha256: b75dc8b0e3a14c52e5a8bcff4d5f7945e81b87a61814ebde85de204b9136c759
+  md5: 4a4b91d8c5c295c109308c0c201021bd
   depends:
   - python
   - ros-kilted-action-msgs
@@ -11052,19 +11187,19 @@ packages:
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 82129
-  timestamp: 1769484819573
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-action-10.1.4-np2py312h50b1e4c_15.conda
-  sha256: ec93bf22c69f0787d31061707ce3a957ae83f060173e045b48e25d65d8969461
-  md5: 65c3b11dbf89c1d0f95e1bc804542854
+  size: 82345
+  timestamp: 1775551009861
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-action-10.1.4-np2py312h50b1e4c_17.conda
+  sha256: 3ad6f0be29d16bba53bb83c31188d15252ac4a83d468450ec2ab6eae365d3e9f
+  md5: aca6643ff7b66321cbebeab4b49f8734
   depends:
   - python
   - ros-kilted-action-msgs
@@ -11073,54 +11208,53 @@ packages:
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libcxx >=18
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 77516
-  timestamp: 1769494861558
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-interfaces-2.3.0-np2py312h2ed9cc7_15.conda
-  sha256: ffe83f46a46661a6e7cef9da910972bee13e772ff235695991885d18bb179e38
-  md5: 704dfdbec340e3566ef6239dc7ccd392
+  size: 77667
+  timestamp: 1775554115210
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-interfaces-2.3.1-np2py312h2ed9cc7_17.conda
+  sha256: 434e4750e1ba3eb848ac1ff35be4605280d36f8eec9bef68a396f3130c5eae08
+  md5: 75ee05e0642e9aa048af36aace07a2b9
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 569744
-  timestamp: 1769483208393
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-interfaces-2.3.0-np2py312h50b1e4c_15.conda
-  sha256: c29a2654e611acfa290f878e2f8311c13686e613a8c7e8c85996d4bc4fa1b129
-  md5: ab597963f697d2e26749c9247438bc25
+  size: 579256
+  timestamp: 1775549396880
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-interfaces-2.3.1-np2py312h50b1e4c_17.conda
+  sha256: 27e3d5b552d4f6aba8dbdee0016f91490ac4be96ff30d3ef6b1adc0bb72cde99
+  md5: 55d0f9d1e7fb07cb96df278466c4154b
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 466588
-  timestamp: 1769491215820
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-lifecycle-10.1.4-np2py312h2ed9cc7_15.conda
-  sha256: 05b635f7f2348fbee5cbe38938ede7e4e8e429f3bf1c85be9dd0bba385dc3551
-  md5: e41fada8061b5488f0db4b106a7be1fc
+  size: 475392
+  timestamp: 1775551097737
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-lifecycle-10.1.4-np2py312h2ed9cc7_17.conda
+  sha256: 7cbc04159e70060bda857c6f96acd6aeed1960cd604bc43ec7dfea4631b6fd8e
+  md5: 66fd4fab184105526d2610766ae4fbb9
   depends:
   - python
   - ros-kilted-lifecycle-msgs
@@ -11130,20 +11264,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-c
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 59110
-  timestamp: 1769484813191
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-lifecycle-10.1.4-np2py312h50b1e4c_15.conda
-  sha256: 182bb43a5df0d4e8e2680fa7933f2b5b529b7c21fb653710119846a68e4f363f
-  md5: ecd9aecf83401fe7023c87d7c6c78904
+  size: 59311
+  timestamp: 1775551002127
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-lifecycle-10.1.4-np2py312h50b1e4c_17.conda
+  sha256: dec21584a8ed36bb48859162b74e11087511fa44708cdf15eb50cfdbbf6ce27e
+  md5: 5d8460ffdc7e25d0972e664bcfa4381c
   depends:
   - python
   - ros-kilted-lifecycle-msgs
@@ -11153,52 +11286,51 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-c
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
+  - libcxx >=18
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 55506
-  timestamp: 1769494827557
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-logging-interface-3.2.4-np2py312h2ed9cc7_15.conda
-  sha256: b692debf6902b771da30ff6c69f5999a620337edba67f86df89e5b675781e668
-  md5: 6151236963f5fdba874bf8b65ca90f0b
+  size: 55770
+  timestamp: 1775554085890
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-logging-interface-3.2.4-np2py312h2ed9cc7_17.conda
+  sha256: 57a1b52c2f82998630cadcfd8be1819db48c84ab599fc3e932a6161dd1cb83d0
+  md5: a17c398dd42fdcf020bfc0182cae5d68
   depends:
   - python
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 36345
-  timestamp: 1769484328026
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-logging-interface-3.2.4-np2py312h50b1e4c_15.conda
-  sha256: e6ebeaf681878173e462c050d643b7b384f88fe0f622386d33b4ea89f5485d4f
-  md5: 015e9fa1bb41bdd98315bc90d37c3628
+  size: 36538
+  timestamp: 1775550515508
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-logging-interface-3.2.4-np2py312h50b1e4c_17.conda
+  sha256: 44d563ef0e567258d366530359f940799072a4cc39ab0060524f9e164b660bfd
+  md5: 86941afb795d5f36cf3136cb701f6078
   depends:
   - python
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 36107
-  timestamp: 1769493945139
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-logging-spdlog-3.2.4-np2py312h918b84f_15.conda
-  sha256: d6ef0e91e15e1157193ab7dae817049c2e7d04b7518529d05e98d00f58376f60
-  md5: bc68717512d2355becf7d4e1e296db04
+  size: 36313
+  timestamp: 1775553294092
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-logging-spdlog-3.2.4-np2py312h918b84f_17.conda
+  sha256: b638a3b6db149e5ddbea5c0361621fc468a2678b5b9c23df37c4dec6145441a4
+  md5: 41cb4c19a429564ca2ec865d6d7c8d10
   depends:
   - fmt
   - python
@@ -11207,22 +11339,22 @@ packages:
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-spdlog-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - spdlog
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - fmt >=12.1.0,<12.2.0a0
   - python_abi 3.12.* *_cp312
   - spdlog >=1.17.0,<1.18.0a0
-  - fmt >=12.1.0,<12.2.0a0
   license: Apache-2.0
-  size: 47114
-  timestamp: 1769484516374
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-logging-spdlog-3.2.4-np2py312h13c16a8_15.conda
-  sha256: c06438d93969db93c9d3f4caa63e328712a91957a1a736c2c955b9893487a6c9
-  md5: 48438e2d4e628079d4ee62d50a7e5a9e
+  size: 47230
+  timestamp: 1775550700155
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-logging-spdlog-3.2.4-np2py312h13c16a8_17.conda
+  sha256: 61e17505cb4a7505fca92ab4602ef562fdb8146dd4307476fae7fc397d5f28dd
+  md5: acd07dd8768cb5a10e654ea8d32821a7
   depends:
   - fmt
   - python
@@ -11231,66 +11363,66 @@ packages:
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-spdlog-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - spdlog
-  - __osx >=11.0
   - libcxx >=18
-  - python_abi 3.12.* *_cp312
+  - __osx >=11.0
   - fmt >=12.1.0,<12.2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - spdlog >=1.17.0,<1.18.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 46075
-  timestamp: 1769494267667
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-yaml-param-parser-10.1.4-np2py312h2ed9cc7_15.conda
-  sha256: 7c5e3d0c52c6e1c97ab1cba8d46fee35cc51697d3f7c64fbc6da1b997664bca0
-  md5: a73fd025b9e44fae030af213d9e2dfa2
+  size: 46307
+  timestamp: 1775553575047
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcl-yaml-param-parser-10.1.4-np2py312h2ed9cc7_17.conda
+  sha256: c8e1992763fa9a678b4cdfebb25041b2ba56c228ca1327095c8c15b8e0a2ac9a
+  md5: 0696ef97c78d29480ef095719ab33955
   depends:
   - python
   - ros-kilted-libyaml-vendor
   - ros-kilted-rcutils
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - yaml
   - yaml-cpp
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - yaml >=0.2.5,<0.3.0a0
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
   - yaml-cpp >=0.8.0,<0.9.0a0
   - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - yaml >=0.2.5,<0.3.0a0
   license: Apache-2.0
-  size: 52289
-  timestamp: 1769484343134
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-yaml-param-parser-10.1.4-np2py312h50b1e4c_15.conda
-  sha256: aa58652d3ba6aa6116e457187534ab001e0300a0ab8644552b91e745240863fa
-  md5: a18e8c1adef2237b30de1797da371db3
+  size: 52381
+  timestamp: 1775550528231
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcl-yaml-param-parser-10.1.4-np2py312h50b1e4c_17.conda
+  sha256: cf9b44c3e34e74bc541044f94bda62e15708f423163d0b29f0c94afa67b1ebe1
+  md5: 78fc577389a14fec2672e9aca9ddfea1
   depends:
   - python
   - ros-kilted-libyaml-vendor
   - ros-kilted-rcutils
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - yaml
   - yaml-cpp
-  - __osx >=11.0
   - libcxx >=18
-  - yaml >=0.2.5,<0.3.0a0
+  - __osx >=11.0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - yaml >=0.2.5,<0.3.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - yaml-cpp >=0.8.0,<0.9.0a0
   license: Apache-2.0
-  size: 50183
-  timestamp: 1769493968942
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rclcpp-29.5.6-np2py312h2ed9cc7_15.conda
-  sha256: 72db52619bd11a4190975c48c59ec47e0998df36bc626b5b680f35f559ef156b
-  md5: c10c35415c38e18fb2399a487e3a07f5
+  size: 50397
+  timestamp: 1775553313326
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rclcpp-29.5.7-np2py312h2ed9cc7_17.conda
+  sha256: 9b8583541811febca2fa0d41f42e45ad25fe392ba228363c4b59d57093eb72d6
+  md5: ac64994df47fd8fced41ff2682db8b77
   depends:
   - python
   - ros-kilted-ament-index-cpp
@@ -11312,20 +11444,19 @@ packages:
   - ros-kilted-rosidl-typesupport-cpp
   - ros-kilted-statistics-msgs
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 1084988
-  timestamp: 1769484860233
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rclcpp-29.5.6-np2py312h50b1e4c_15.conda
-  sha256: cb459a30c1d00b28072557763f55f5d5dc75792b59a1a67e6585e04c17525c7b
-  md5: e4f0f47b051a7b99999d45857c04a528
+  size: 1085475
+  timestamp: 1775551058360
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rclcpp-29.5.7-np2py312h50b1e4c_17.conda
+  sha256: 88d9d173952e5ffecd78f7e4d9f71130e95db93caf89fa751126e455a6f013f3
+  md5: 682b04e5bd5f6bc262d9ff0157e9d793
   depends:
   - python
   - ros-kilted-ament-index-cpp
@@ -11347,18 +11478,18 @@ packages:
   - ros-kilted-rosidl-typesupport-cpp
   - ros-kilted-statistics-msgs
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 771652
-  timestamp: 1769495008591
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rclcpp-action-29.5.6-np2py312h2ed9cc7_15.conda
-  sha256: 939f8d99c30817c02e8d82c7c16cf0c8bc850feee67fb6cf553e4e7ab87ff51f
-  md5: a5702a5f3a1f8fb7b7f6e15ba3c1993f
+  size: 771958
+  timestamp: 1775554209909
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rclcpp-action-29.5.7-np2py312h2ed9cc7_17.conda
+  sha256: 2b81b7b55c8def56241188fbd165f46bbfe46a531882ed8c54f707f158399922
+  md5: 40329a7692568cc0f23599e5bfeda6bd
   depends:
   - python
   - ros-kilted-action-msgs
@@ -11368,20 +11499,19 @@ packages:
   - ros-kilted-rcpputils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 153998
-  timestamp: 1769485100965
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rclcpp-action-29.5.6-np2py312h50b1e4c_15.conda
-  sha256: 222de73e8b8d34d30c565ec0249a2a5a05918d9ca043e700e5482b8f2eb75ee5
-  md5: f6bdc44dfa99810d268844ce37ab5709
+  size: 154287
+  timestamp: 1775551308759
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rclcpp-action-29.5.7-np2py312h50b1e4c_17.conda
+  sha256: e9d58713b6e7ea95818a058523f63f40e5e1e43f637ec034688bfec340bcc609
+  md5: e2c0f15a4a251fd1a06b95afa7cab235
   depends:
   - python
   - ros-kilted-action-msgs
@@ -11391,18 +11521,18 @@ packages:
   - ros-kilted-rcpputils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - libcxx >=18
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 129028
-  timestamp: 1769495638361
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rclcpp-components-29.5.6-np2py312h2ed9cc7_15.conda
-  sha256: c8277da67e139dea2f196ba318f99fd3ae6c422328118dd6aec10bbdebc3720c
-  md5: afa4b993e1382ef577778c57baaaa137
+  size: 129320
+  timestamp: 1775554588904
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rclcpp-components-29.5.7-np2py312h2ed9cc7_17.conda
+  sha256: a469253ff935d1905ec64fc9845913c68eb0b3b50e0bdc3ff4e7ba55aa1298e1
+  md5: ebb001f9dc892c6d62842d8d3d3750b6
   depends:
   - python
   - ros-kilted-ament-index-cpp
@@ -11410,20 +11540,19 @@ packages:
   - ros-kilted-composition-interfaces
   - ros-kilted-rclcpp
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 141025
-  timestamp: 1769485052378
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rclcpp-components-29.5.6-np2py312h50b1e4c_15.conda
-  sha256: 9eba26f9c5e71c9cac8b24d656d4b24f85e5e48dada2143003df13656a61b601
-  md5: 737bc2d39cc2dd8a4135780085ccbd43
+  size: 141269
+  timestamp: 1775551261492
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rclcpp-components-29.5.7-np2py312h50b1e4c_17.conda
+  sha256: 6d4b9bfd396bbdd0337ce023aed5cbff833339bf5dcefaa263fbf0b608f9580a
+  md5: 8be9127f91d084b87c4b8a3d0f53d599
   depends:
   - python
   - ros-kilted-ament-index-cpp
@@ -11431,18 +11560,18 @@ packages:
   - ros-kilted-composition-interfaces
   - ros-kilted-rclcpp
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libcxx >=18
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 118703
-  timestamp: 1769495327008
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rclcpp-lifecycle-29.5.6-np2py312h2ed9cc7_15.conda
-  sha256: 914dfbbee3e4e44deb535e3ec29478553412b76dbd84679919bff960ad36dec8
-  md5: faa66dec5c22e4004a9af2f523c7b444
+  size: 119030
+  timestamp: 1775554853195
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rclcpp-lifecycle-29.5.7-np2py312h2ed9cc7_17.conda
+  sha256: 5928d14cbfc313aa90a66cdde3287de6e2225ec150112a84173b859c8b7f67af
+  md5: 101d46ffd7bcb3ee77fb4601802825d8
   depends:
   - python
   - ros-kilted-lifecycle-msgs
@@ -11454,20 +11583,19 @@ packages:
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-typesupport-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 131333
-  timestamp: 1769485085949
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rclcpp-lifecycle-29.5.6-np2py312h50b1e4c_15.conda
-  sha256: e38ac5226a6325c02e7ca51c7bb98035c463067cb5f719b819fbab327b1b6259
-  md5: fe0f09bd10d507aca3e682d2274d535c
+  size: 131619
+  timestamp: 1775551293442
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rclcpp-lifecycle-29.5.7-np2py312h50b1e4c_17.conda
+  sha256: 6a151a4a96b946cbf32d4c7fc529d036563ac40818de8c30049b85206dc200f5
+  md5: 92b7e6da02fef7503a013a7e5e99a58d
   depends:
   - python
   - ros-kilted-lifecycle-msgs
@@ -11479,18 +11607,18 @@ packages:
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-typesupport-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 106142
-  timestamp: 1769495591615
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rclpy-9.1.4-np2py312h2ed9cc7_15.conda
-  sha256: da2abeb563108b8dd6f588b3ca4a239cb74d9912c9d2d08efc05b555008add89
-  md5: b20289f32f2f92314a1ee616cb03781d
+  size: 106441
+  timestamp: 1775554554879
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rclpy-9.1.5-np2py312h2ed9cc7_17.conda
+  sha256: b819df2a1429c40abd027cabd3bc890789fbac6dfb19b83973d73b13afab1412
+  md5: d7fc439036a1c8bc19d655e4d7761e84
   depends:
   - python
   - pyyaml
@@ -11513,23 +11641,22 @@ packages:
   - ros-kilted-service-msgs
   - ros-kilted-type-description-interfaces
   - ros-kilted-unique-identifier-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - typing_extensions
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
   purls:
   - pkg:pypi/rclpy?source=project-defined-mapping
-  size: 779858
-  timestamp: 1769484959352
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rclpy-9.1.4-np2py312h50b1e4c_15.conda
-  sha256: 9cd5e2933e8bdf7350721b97ca35374fa9c562f8255795baaa07e5e3d899a9c5
-  md5: 39494e26937ef980f20ec0cc491f127b
+  size: 796548
+  timestamp: 1775551161512
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rclpy-9.1.5-np2py312h50b1e4c_17.conda
+  sha256: b30d8afdf3a0886e90c511a9a5e8faf6cb5491f7b90849d09e47bc4c537a3c2a
+  md5: c78fe31f331d172a2fcafa589bceff3c
   depends:
   - python
   - pyyaml
@@ -11552,160 +11679,157 @@ packages:
   - ros-kilted-service-msgs
   - ros-kilted-type-description-interfaces
   - ros-kilted-unique-identifier-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - typing_extensions
-  - __osx >=11.0
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __osx >=11.0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
   purls:
   - pkg:pypi/rclpy?source=project-defined-mapping
-  size: 671323
-  timestamp: 1769495158026
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcpputils-2.13.5-np2py312h2ed9cc7_15.conda
-  sha256: 1199b772ff5753fe14531cb408f5145a2e74a39363b3e43ffa5ca2c8f6b69ce3
-  md5: b6eafb50b1183cd3e259a9aea7523d9d
+  size: 683813
+  timestamp: 1775554346797
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcpputils-2.13.5-np2py312h2ed9cc7_17.conda
+  sha256: 226c1e61f1139fd9cb4999dd95177351ab1ec4895dfb4e01da19a0b7a2f66769
+  md5: 56d73c532cab2355082342ceb3cdc366
   depends:
   - python
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0 OR BSD-3-Clause
-  size: 81193
-  timestamp: 1769482395135
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcpputils-2.13.5-np2py312h50b1e4c_15.conda
-  sha256: 4dadcee6d540af38c4e00a9d512b52b55abad3cb9a78d12787fbed1f9dc16042
-  md5: 7089ec27795d8320430d75deacd9fdbf
+  size: 81174
+  timestamp: 1775548674166
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcpputils-2.13.5-np2py312h50b1e4c_17.conda
+  sha256: fb70da88fb019d4fca8dc5fb30461434bee6e302ad9ae91a79015f7d946b5f17
+  md5: 33b6a994b2e8fb832fdcc88ef65fce08
   depends:
   - python
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0 OR BSD-3-Clause
-  size: 78813
-  timestamp: 1769489233132
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcutils-6.9.9-np2py312h2ed9cc7_15.conda
-  sha256: 79916bd06076c2de5fa417745a86aaf5286af8606999f677639a7f97a4f71d12
-  md5: 5bb98f92311be2e928276b25d1f321c7
+  size: 79039
+  timestamp: 1775549695235
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rcutils-6.9.10-np2py312h2ed9cc7_17.conda
+  sha256: 166534d5280affede23a0b39e78eb3d409b30dc5dc2f8d533067481da061d976
+  md5: 527943fb7c09036851b13b1c5b34b080
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 124639
-  timestamp: 1769482302421
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcutils-6.9.9-np2py312h50b1e4c_15.conda
-  sha256: 037679d647e3323c52f1eee6eef55737b175114f482135c305c7f8d6fd0618c4
-  md5: 9b096fbd9d03fa4999c09a110498ace4
+  size: 124801
+  timestamp: 1775548585370
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rcutils-6.9.10-np2py312h50b1e4c_17.conda
+  sha256: 095f307d5f585afe2e4cf7467afd8027964e8e17cde0ed1732fff5cb62f40a44
+  md5: 6960c7ef5844d3b1f0773aa0adf85808
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
-  - numpy >=1.23,<3
+  - libcxx >=18
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 117734
-  timestamp: 1769489091127
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-7.8.2-np2py312h2ed9cc7_15.conda
-  sha256: 89a7e4fe2c32f21e41e1a503ae8f75060e332aa4b2d261add38c2b19b64bd5a3
-  md5: bcc42e809b01f1d371f81106cf6b2bf4
+  size: 118106
+  timestamp: 1775549553377
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-7.8.2-np2py312h2ed9cc7_17.conda
+  sha256: aa5afa08cdb4efd1cd8e03bd62631a9760ac09fdf88c6804551242dc0921718e
+  md5: ee530185c3b6b4feea576655de014ee5
   depends:
   - python
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-dynamic-typesupport
   - ros-kilted-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 96661
-  timestamp: 1769482511168
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-7.8.2-np2py312h50b1e4c_15.conda
-  sha256: fddec80432be9aceff9fedb9915ff849e76c07eafe85275a51c4d45dc1ba6e9d
-  md5: f1ff3e8c4a471313eab097f12709c4ce
+  size: 96716
+  timestamp: 1775548790186
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-7.8.2-np2py312h50b1e4c_17.conda
+  sha256: 80d68199591cb345ecfdf78cb721c806a970f42cec20ac812c8a911e8eca8293
+  md5: 5380ff945725df6963925037351c31a1
   depends:
   - python
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-dynamic-typesupport
   - ros-kilted-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
+  - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 93020
-  timestamp: 1769489419540
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-connextdds-1.1.1-np2py312h2ed9cc7_15.conda
-  sha256: e74882e6de4a6bc78353cda16db14c6e47fd17d14721b64d8d2bd96641bd6904
-  md5: 4bac28b5915c3333607428786da0698d
+  size: 93178
+  timestamp: 1775549900243
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-connextdds-1.1.1-np2py312h2ed9cc7_17.conda
+  sha256: a668aebdb2f93d38ab678258074a53ecb69cc714a3ab93d906d2e4f655135500
+  md5: 6a9eb0ef2fca1a3d080b77a3987ae3fc
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-rmw-connextdds-common
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 30747
-  timestamp: 1769483562613
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-connextdds-1.1.1-np2py312h50b1e4c_15.conda
-  sha256: 997ba2091215e6df872979eb58cdef28b171c9558f71cf8a47e77febd7c3fc48
-  md5: bd544846ec5f749cb8ec713e13efdace
+  size: 30913
+  timestamp: 1775549732574
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-connextdds-1.1.1-np2py312h50b1e4c_17.conda
+  sha256: 5dbfa1a4bf96735edd8e6050c3456a223e474d89e2855710c8e8438af967a5b7
+  md5: 5834543914f775e34bad4331c4fc2ab8
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-rmw-connextdds-common
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
+  - libcxx >=18
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 30744
-  timestamp: 1769492386257
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-connextdds-common-1.1.1-np2py312h2ed9cc7_15.conda
-  sha256: c6773670b92bccc97676ff7a7385adc1b54fda17f123d472bd0e2c029aefb4a7
-  md5: 8a4144962bfe997fcd2b55ac1f4ec68c
+  size: 31027
+  timestamp: 1775551959337
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-connextdds-common-1.1.1-np2py312h2ed9cc7_17.conda
+  sha256: a8a983d684406b89e4a52b184c74cfaefc22ca6db2cbebb01d09dbb56f44616f
+  md5: a47e0b8b2d0418febc69ec23a32d0ea5
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -11724,19 +11848,19 @@ packages:
   - ros-kilted-rosidl-typesupport-introspection-cpp
   - ros-kilted-rti-connext-dds-cmake-module
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 53981
-  timestamp: 1769483386926
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-connextdds-common-1.1.1-np2py312h50b1e4c_15.conda
-  sha256: a5c54b62422dbc6ee932a2421dcfd17227e13a5c3442de96fd4a4f17345e02c8
-  md5: 22a43a9a12d14bbbfdf4b79ebda985b8
+  size: 54168
+  timestamp: 1775549557040
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-connextdds-common-1.1.1-np2py312h50b1e4c_17.conda
+  sha256: c8ceab4d3335488d65e39cc5d01b0f5ec874ec9b4a927e7c77e9bdbf5e8702f2
+  md5: b24e72d709305ead6a87e40b436c482e
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -11755,18 +11879,18 @@ packages:
   - ros-kilted-rosidl-typesupport-introspection-cpp
   - ros-kilted-rti-connext-dds-cmake-module
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 54013
-  timestamp: 1769491787760
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-cyclonedds-cpp-4.0.2-np2py312h2ed9cc7_15.conda
-  sha256: 97a959a21ee2d8af1e368c053a81d5a457d42d4b6e4f01d3012b9fee8d60b471
-  md5: a67fbabb64d831fe3181ff9e99212fea
+  size: 54230
+  timestamp: 1775551621756
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-cyclonedds-cpp-4.0.2-np2py312h2ed9cc7_17.conda
+  sha256: d5f88d022d81e3f960c34084b447dbde460cab41724588023d7a72464f16cba4
+  md5: 451053acfc9eef08b21b7c14fd605fb9
   depends:
   - python
   - ros-kilted-cyclonedds
@@ -11781,20 +11905,19 @@ packages:
   - ros-kilted-rosidl-typesupport-introspection-c
   - ros-kilted-rosidl-typesupport-introspection-cpp
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 260986
-  timestamp: 1769483391935
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-cyclonedds-cpp-4.0.2-np2py312h50b1e4c_15.conda
-  sha256: 415c455d9c8fac49faa19bf7f80e4ab9ed5a7870235c92ca20069f0c83d0089a
-  md5: 32966bdc4c3ff297a498471d5704bfe9
+  size: 261296
+  timestamp: 1775549564080
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-cyclonedds-cpp-4.0.2-np2py312h50b1e4c_17.conda
+  sha256: bc1fb257a1ceefe6bb9b4b02d822012c2f50fc0df36da642c0cf87d263a300ea
+  md5: fd364dfbdbca2e1b806ba93559d3258f
   depends:
   - python
   - ros-kilted-cyclonedds
@@ -11809,18 +11932,18 @@ packages:
   - ros-kilted-rosidl-typesupport-introspection-c
   - ros-kilted-rosidl-typesupport-introspection-cpp
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 187291
-  timestamp: 1769491809131
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-dds-common-5.0.0-np2py312h2ed9cc7_15.conda
-  sha256: 95cbcb0757439e2c21b7aec33ed7b3ff71865db97135be8ba3410157af0f8545
-  md5: ab06959a37278f17ce39dc71971d337d
+  size: 187572
+  timestamp: 1775551638834
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-dds-common-5.0.0-np2py312h2ed9cc7_17.conda
+  sha256: fde5b85c5e0f77d066705eaf97aa1e40ca910ab74f4d6571b874b7c4afc0204d
+  md5: b933f8ce3f5007bccc53558ae848e514
   depends:
   - python
   - ros-kilted-rcpputils
@@ -11831,20 +11954,19 @@ packages:
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-rosidl-runtime-c
   - ros-kilted-rosidl-runtime-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 164613
-  timestamp: 1769483120714
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-dds-common-5.0.0-np2py312h50b1e4c_15.conda
-  sha256: 8325927e3052045bfe517029a24abfda81410c1ee78b202f7fc077cdf54eb51d
-  md5: 633fb0f22fb6fe58abd81b3dfb89154b
+  size: 168450
+  timestamp: 1775549324266
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-dds-common-5.0.0-np2py312h50b1e4c_17.conda
+  sha256: 4347aed229fbbe9230236b0ad762723cf98ae8a242c043ff129fa7cbdb6911f5
+  md5: 8ff876223bfccdd710801a5f9befd176
   depends:
   - python
   - ros-kilted-rcpputils
@@ -11855,18 +11977,18 @@ packages:
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-rosidl-runtime-c
   - ros-kilted-rosidl-runtime-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
+  - __osx >=11.0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 150632
-  timestamp: 1769491056009
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-cpp-9.3.3-np2py312h2ed9cc7_15.conda
-  sha256: 1cf4f63119d38c97ca6f5e0b9293a6c57259e8a80a067664b4817c708d0ede3e
-  md5: 4010a448c3314064b57cccdcf28524f5
+  size: 153060
+  timestamp: 1775550962597
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-cpp-9.3.3-np2py312h2ed9cc7_17.conda
+  sha256: 24a5c493dc79e190b7dd7a28cbf7e230bbf789b3d17510575159b8da0a3a19f6
+  md5: f2fd0784a7c2e4f34c241e4081da6814
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -11885,20 +12007,19 @@ packages:
   - ros-kilted-rosidl-typesupport-fastrtps-c
   - ros-kilted-rosidl-typesupport-fastrtps-cpp
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 154349
-  timestamp: 1769483537019
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-fastrtps-cpp-9.3.3-np2py312h50b1e4c_15.conda
-  sha256: f6d6ce95dbfaf3a33ff3cad6317520e00edd5d2ca4e9347c6a9e2f9562127da6
-  md5: 7af3f155b633828b5fcf4356306a8ddf
+  size: 154573
+  timestamp: 1775549706343
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-fastrtps-cpp-9.3.3-np2py312h50b1e4c_17.conda
+  sha256: 222b23710612e09a1bea5e490aa13ce93769e329be1113fd6d0b534389f3121f
+  md5: 6adc7368979670abbe9b5e802c2b76b4
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -11917,18 +12038,18 @@ packages:
   - ros-kilted-rosidl-typesupport-fastrtps-c
   - ros-kilted-rosidl-typesupport-fastrtps-cpp
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 119491
-  timestamp: 1769492338075
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-dynamic-cpp-9.3.3-np2py312h2ed9cc7_15.conda
-  sha256: 19c353e3f95cd5593ebca60dc72e0be4055396a413e7db81873eaacd72752c7b
-  md5: 2999db357fff33f6b8d3a7a7c5ce5d61
+  size: 119806
+  timestamp: 1775551889726
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-dynamic-cpp-9.3.3-np2py312h2ed9cc7_17.conda
+  sha256: ad1be05b64f46fa8c5ca26a852b5339e02b29c695be543c00768e63c47977a65
+  md5: 459cc020fdf64943c389b93c5839d1a5
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -11944,20 +12065,19 @@ packages:
   - ros-kilted-rosidl-typesupport-introspection-c
   - ros-kilted-rosidl-typesupport-introspection-cpp
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 176875
-  timestamp: 1769483498087
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-fastrtps-dynamic-cpp-9.3.3-np2py312h50b1e4c_15.conda
-  sha256: ffa6543d1e43318bff893afd85e9d6a8c3f7413b689c8ee50e892fb96b8228d2
-  md5: 3181e94cbd030ae497398aaf94b4e7ac
+  size: 177083
+  timestamp: 1775549669958
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-fastrtps-dynamic-cpp-9.3.3-np2py312h50b1e4c_17.conda
+  sha256: 7027369146667cd87e6537c3e2c0fe78a542f8c9f41d92809d58d95e8c2f71a2
+  md5: 75d6c5a9825e6a1d104a1ca9eeca3ada
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -11973,18 +12093,18 @@ packages:
   - ros-kilted-rosidl-typesupport-introspection-c
   - ros-kilted-rosidl-typesupport-introspection-cpp
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - libcxx >=18
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 136955
-  timestamp: 1769492266569
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-shared-cpp-9.3.3-np2py312h2ed9cc7_15.conda
-  sha256: c8efbe9096379aff7cc8828f9aec5632fa436222e222d68f6fc336eab8fc1405
-  md5: 6d720f18474f9f5312ed105101353296
+  size: 137300
+  timestamp: 1775551807493
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-shared-cpp-9.3.3-np2py312h2ed9cc7_17.conda
+  sha256: 04f70d066722d7dafc1b5d355aaf6bfa0b3f36b81c3a344413d1e338d03b6982
+  md5: 51f7087e37401fef93f0e351c6513a50
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -12000,20 +12120,19 @@ packages:
   - ros-kilted-rosidl-typesupport-introspection-c
   - ros-kilted-rosidl-typesupport-introspection-cpp
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 231805
-  timestamp: 1769483338194
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-fastrtps-shared-cpp-9.3.3-np2py312h50b1e4c_15.conda
-  sha256: ec39ad01584e45474771fa84f4e71aa4aaef340704c065752a7e793f06591dcc
-  md5: fec2d4eafabe6f28aa1c5f8743cc15c7
+  size: 231956
+  timestamp: 1775549508545
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-fastrtps-shared-cpp-9.3.3-np2py312h50b1e4c_17.conda
+  sha256: b8bf14171263b965703fe6629549606e8252240764e024425c098742f746806d
+  md5: 3966bc2209e98b3248a34f069b172e28
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -12029,18 +12148,18 @@ packages:
   - ros-kilted-rosidl-typesupport-introspection-c
   - ros-kilted-rosidl-typesupport-introspection-cpp
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 186470
-  timestamp: 1769491674985
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-implementation-3.0.6-np2py312h2ed9cc7_15.conda
-  sha256: 8a7e656091bcedd378e9c1baacbbfaa03983bc134e263802f1e1948190879d52
-  md5: 12f2f5b4e7685a2654e4b06963eed3ea
+  size: 186794
+  timestamp: 1775551530673
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-implementation-3.0.6-np2py312h2ed9cc7_17.conda
+  sha256: a666e50b2717cad68d317c7696fe3e854cd60a354b5602d621abda6e126866c1
+  md5: 01831e174d4af43b5e6772d4113f9227
   depends:
   - python
   - ros-kilted-ament-index-cpp
@@ -12052,20 +12171,19 @@ packages:
   - ros-kilted-rmw-fastrtps-dynamic-cpp
   - ros-kilted-rmw-implementation-cmake
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 53323
-  timestamp: 1769483757605
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-implementation-3.0.6-np2py312h50b1e4c_15.conda
-  sha256: ecde44b7de82cade1e863c6f9c19c899a0f16f0dc583b0f244c2e92ef7f2218c
-  md5: 1165bf9c9e8a8fe011d9499b19eb900c
+  size: 53518
+  timestamp: 1775549916490
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-implementation-3.0.6-np2py312h50b1e4c_17.conda
+  sha256: a0200e8a65bc9528950a31c27b2f571a210d7dbb712aa04cb1686dec043ed14b
+  md5: eb1cd4c32173d982e0f6e76376e8410c
   depends:
   - python
   - ros-kilted-ament-index-cpp
@@ -12077,121 +12195,119 @@ packages:
   - ros-kilted-rmw-fastrtps-dynamic-cpp
   - ros-kilted-rmw-implementation-cmake
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 49750
-  timestamp: 1769492769302
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-implementation-cmake-7.8.2-np2py312h2ed9cc7_15.conda
-  sha256: 40d46154aae64f3baa1120ca18327eebaf2f8b188246e2cbb150a2f0e059d1eb
-  md5: 69758cdc840841f7d14d9f73853157d2
+  size: 50201
+  timestamp: 1775552345037
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-implementation-cmake-7.8.2-np2py312h2ed9cc7_17.conda
+  sha256: 0cc7571a93c5a2696586bcea1362041d82f3c828cb21cde5a76a8fe489011aab
+  md5: 76366ebbcf061a54ee8c5e07a36a0d5f
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 29440
-  timestamp: 1769482245508
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-implementation-cmake-7.8.2-np2py312h50b1e4c_15.conda
-  sha256: bb9640e6188cf90b22f0a167eee86eedba32d5fa2c0a9d1ffa9ba3ae3368729d
-  md5: 3f65a8125456d28e7fd0ee019d47e99e
+  size: 29634
+  timestamp: 1775548538232
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-implementation-cmake-7.8.2-np2py312h50b1e4c_17.conda
+  sha256: e096c475ecd8ed8c29ac8e3a1602e2e9bc00d8876ca8139e0181d01ba6741f8f
+  md5: 7d4a338d45ee7fb67a7b7b67674cbfb8
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - __osx >=11.0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 29846
-  timestamp: 1769488702380
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-security-common-7.8.2-np2py312h2ed9cc7_15.conda
-  sha256: e50f857408f10c1c86d298cbebfebab855f5cf11c0d5a4fd36b29556c333748b
-  md5: b3594ee9039c5a35c6e2774c3538d9a1
+  size: 29999
+  timestamp: 1775549457121
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-security-common-7.8.2-np2py312h2ed9cc7_17.conda
+  sha256: d57ede0c3f3939da996c3ad686f3cea41b8d8bdb35b7638a05da6d8c1528db93
+  md5: 69816448129cca4818d879fef6f5cc81
   depends:
   - python
   - ros-kilted-rcutils
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 51115
-  timestamp: 1769482626707
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-security-common-7.8.2-np2py312h50b1e4c_15.conda
-  sha256: daa71b3faa07cc65d86bb4a893ab7306aa27d383819dd125964f31d0e21c5b94
-  md5: fa3ca13d5dadc2c070bb9711f6c62a84
+  size: 51251
+  timestamp: 1775548884853
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-security-common-7.8.2-np2py312h50b1e4c_17.conda
+  sha256: 35bd2e4fd7ea6476919e5a1bbc9d08ceb7c1470952e59b697489c7955e0ecba5
+  md5: 5443b9e6e5435106dc91320d71788b8b
   depends:
   - python
   - ros-kilted-rcutils
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __osx >=11.0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 51427
-  timestamp: 1769489878748
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-test-fixture-0.14.7-np2py312h2ed9cc7_15.conda
-  sha256: c89feb8bfd6424bfee97c79b9cc7eb34e23184a53ad817d728344935aea84c7e
-  md5: 431c216708bd3e1860a429ed57064845
+  size: 51674
+  timestamp: 1775550044584
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-test-fixture-0.14.7-np2py312h2ed9cc7_17.conda
+  sha256: b0e766b073287e203e934e2b52ef47d06b4362c7a46e88382f7f9bf25c62d96e
+  md5: cc14fbda21b165c9980c075fcd062d40
   depends:
   - python
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 30538
-  timestamp: 1769482633737
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-test-fixture-0.14.7-np2py312h50b1e4c_15.conda
-  sha256: fda76f9b492d00fb19087fb2863785952927ba97c847827103d5f31cfb749c44
-  md5: bc44bfc3a56517c3c30b63a7da717f6d
+  size: 30661
+  timestamp: 1775548892777
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-test-fixture-0.14.7-np2py312h50b1e4c_17.conda
+  sha256: bcdc59551a21cb829bdc4eb6bc379cb071ccb4614600726c2700b4a048405c2a
+  md5: dbc78258e6cea3c71180c7814822e10a
   depends:
   - python
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 30960
-  timestamp: 1769489900316
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-test-fixture-implementation-0.14.7-np2py312h2ed9cc7_15.conda
-  sha256: 0dcbbb8f26e2aa026def344f0df6663eef3604dd94c6f95408297e61e1d0e06a
-  md5: a7dc858192bcfeaa7cdcf7eaef19c873
+  size: 31140
+  timestamp: 1775550058584
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-test-fixture-implementation-0.14.7-np2py312h2ed9cc7_17.conda
+  sha256: a6c0e2082a2f0b82b8e99c9a2723bb550e5f8ccffac1dbcd9194772d44bf0f70
+  md5: f47e870dfb282f8c597382b9ed2823c5
   depends:
   - python
   - ros-kilted-rcpputils
@@ -12200,20 +12316,19 @@ packages:
   - ros-kilted-rmw-test-fixture
   - ros-kilted-ros-workspace
   - ros-kilted-rpyutils
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 52380
-  timestamp: 1769483950404
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-test-fixture-implementation-0.14.7-np2py312h50b1e4c_15.conda
-  sha256: 5c696ee6b2c433036e6a57357d27312e8b8e52492e035b0a25e76d6017fae2c6
-  md5: b1d9242869152da368ea9201fef93f80
+  size: 52621
+  timestamp: 1775550152244
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-test-fixture-implementation-0.14.7-np2py312h50b1e4c_17.conda
+  sha256: 9204c06e554421943dc3679ac03ee8e9e9a692c57747541ec4ae1ddafc0f3b88
+  md5: 45432425ee35d0c612d0b450ef62847c
   depends:
   - python
   - ros-kilted-rcpputils
@@ -12222,18 +12337,18 @@ packages:
   - ros-kilted-rmw-test-fixture
   - ros-kilted-ros-workspace
   - ros-kilted-rpyutils
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
-  - python_abi 3.12.* *_cp312
+  - libcxx >=18
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 49608
-  timestamp: 1769493178088
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-zenoh-cpp-0.6.6-np2py312ha80d210_15.conda
-  sha256: 1c29117a3ed6bf8781bdd7db665acfd11805c80fd1ae9e2a788452cc3ec6213e
-  md5: e8a5098d8d5e9dce3d096dff87b51c6a
+  size: 49901
+  timestamp: 1775552707742
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rmw-zenoh-cpp-0.6.6-np2py312ha80d210_17.conda
+  sha256: 4b7af3ce3349dbb86ba96b19f2845d9504b7420c8d60ad4412c219db0e660214
+  md5: 0ff51a5f2e6a35983bde14c6d5cb90a4
   depends:
   - python
   - ros-kilted-ament-index-cpp
@@ -12247,21 +12362,20 @@ packages:
   - ros-kilted-rosidl-typesupport-fastrtps-cpp
   - ros-kilted-tracetools
   - ros-kilted-zenoh-cpp-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - libzenohc >=1.7.2,<1.7.3.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0 OR BSD-3-Clause
-  size: 334627
-  timestamp: 1769482870287
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-zenoh-cpp-0.6.6-np2py312h682da20_15.conda
-  sha256: 8474964f4405dfb3794b0b0026d975a5fe1a6dccb266b33d2fab2a9ca0783b1d
-  md5: 23ac5e150afce637d8574e581b76b1b9
+  size: 334707
+  timestamp: 1775549046785
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rmw-zenoh-cpp-0.6.6-np2py312h682da20_17.conda
+  sha256: 5ad253d5715f721680f3e83ef3f813ce8e61b581e61024addf264d2e800dfe29
+  md5: a02238c510fc033cb337b975b904936a
   depends:
   - python
   - ros-kilted-ament-index-cpp
@@ -12275,19 +12389,19 @@ packages:
   - ros-kilted-rosidl-typesupport-fastrtps-cpp
   - ros-kilted-tracetools
   - ros-kilted-zenoh-cpp-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - libzenohc >=1.7.2,<1.7.3.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  - libzenohc >=1.7.2,<1.7.3.0a0
   license: Apache-2.0 OR BSD-3-Clause
-  size: 266462
-  timestamp: 1769490499632
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros-core-0.12.0-np2py312h2ed9cc7_15.conda
-  sha256: b76f984e83e66b996fe9963f60101dd0f4641179c796d247eead2639162e7e6f
-  md5: 5675090d8fde356787ea88e63cb29858
+  size: 266673
+  timestamp: 1775550473139
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros-core-0.12.0-np2py312h2ed9cc7_17.conda
+  sha256: 2621c65e4d791f60c49bb6a44b34db129a3ed7291dcacfe277043153579f245e
+  md5: 65ac35c66b8422d83baed51c1d504e80
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -12323,19 +12437,19 @@ packages:
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-sros2
   - ros-kilted-sros2-cmake
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 23141
-  timestamp: 1769487744654
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros-core-0.12.0-np2py312h50b1e4c_15.conda
-  sha256: 14db7f08731b9e9db3392657bc3674f9afb4d7e398a472c9d99a9438f49b2c8d
-  md5: 7904ffa7ccdab8e49e8e1def556b0d61
+  size: 23094
+  timestamp: 1775604330348
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros-core-0.12.0-np2py312h50b1e4c_17.conda
+  sha256: bd8a116f9931335826c3c5fddaa1600d349c1df5a39731615959e0969885d28c
+  md5: f0d6b9e3308f4a941bdaf99ebc276565
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -12371,77 +12485,76 @@ packages:
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-sros2
   - ros-kilted-sros2-cmake
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 23728
-  timestamp: 1769505122977
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros-environment-4.3.1-np2py312h2ed9cc7_15.conda
-  sha256: fa07b737d84363ad94af7b67c5e25372d73c6f22fb830084c9a3122fb9b18b09
-  md5: 0b7b4a3be085491774335da001e7600e
+  size: 23937
+  timestamp: 1775560634628
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros-environment-4.3.1-np2py312h2ed9cc7_17.conda
+  sha256: 0a2b7df45929b66be4c99f1acd45bb64a40e146c6df57e32ce6bf23dab208fcf
+  md5: b9ffe9267430e19fc4e3e1dda15b2958
   depends:
   - python
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 21349
+  timestamp: 1775546867511
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros-environment-4.3.1-np2py312h50b1e4c_17.conda
+  sha256: da394bcb7fecf8db6e4224cac9507292545ab7c29c95d40c4615d55dcdfd3a77
+  md5: 9d92516306a67bfc889f64f6747f3e74
+  depends:
+  - python
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libcxx >=18
+  - __osx >=11.0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 22258
+  timestamp: 1775547036558
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros-workspace-1.0.3-np2py312h2ed9cc7_17.conda
+  sha256: 723deebd9977c765fcfd7d4bd1cfcc69b2a67f44fca3051a650999e784874bf2
+  md5: 0dc4c839cefa2d96bee05a205ece9f5e
+  depends:
+  - python
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 21431
-  timestamp: 1769480694236
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros-environment-4.3.1-np2py312h50b1e4c_15.conda
-  sha256: 374c92f6c1ce711ab1a4ef925c21b1e6822a813e3abf4da96f1bb1e2f672de3c
-  md5: d2c050b881e601f8f85591f724f5fc3b
-  depends:
-  - python
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
-  - libcxx >=18
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 22120
-  timestamp: 1769480886839
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros-workspace-1.0.3-np2py312h2ed9cc7_15.conda
-  sha256: 88269c8ef716917c734961ed99107553a562576e92b4d2a886237f0951030333
-  md5: fde5bbdacf0191dbe4d72dded6025c64
-  depends:
-  - python
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 35511
-  timestamp: 1769480681564
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros-workspace-1.0.3-np2py312h50b1e4c_15.conda
-  sha256: a031efbb6da2548c8cf685d4391dc3d961fa8d0dfb86877cc4c8ffbbe466f3bc
-  md5: 8ab5bb63c8efed2340abf989dd0c4925
+  size: 35269
+  timestamp: 1775546853784
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros-workspace-1.0.3-np2py312h50b1e4c_17.conda
+  sha256: f7d224a5957f5a89face68a3344e0878d0d40f1e9870a925b4efde74d7f94717
+  md5: 3ce13f751671473c25e0981dd6b36707
   depends:
   - python
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - __osx >=11.0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 36191
-  timestamp: 1769480869546
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2action-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: 019a522c85604fb61ea63555db41f0fc34728bbf3e02a16b9ab606d39b97c822
-  md5: 2540513e607e09f60f03e44e67d8cdb4
+  size: 36211
+  timestamp: 1775547016421
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2action-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 893b3fd899df270158f9fd81fce0cc45210322ab05be05970479b8139345a52d
+  md5: 2200b709455d17233145843ffe4cca2b
   depends:
   - python
   - ros-kilted-action-msgs
@@ -12451,19 +12564,19 @@ packages:
   - ros-kilted-ros2cli
   - ros-kilted-ros2topic
   - ros-kilted-rosidl-runtime-py
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 56907
-  timestamp: 1769485926708
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2action-0.38.2-np2py312h50b1e4c_15.conda
-  sha256: a0a8e417b514c1420b46ec1d8dcb0cc632f9f1ceae1c6db54a0b612ff6670f48
-  md5: 6fecd1ebd24dc4915bfbda36e946ac9f
+  size: 56751
+  timestamp: 1775602447842
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2action-0.38.3-np2py312h50b1e4c_17.conda
+  sha256: a0876c1e3010c41bfc55484db4eec4ad35be8899800e26632b9d2f18409b58a1
+  md5: 1e0ea44fffa6401fbb87b47fd0decb3f
   depends:
   - python
   - ros-kilted-action-msgs
@@ -12473,18 +12586,18 @@ packages:
   - ros-kilted-ros2cli
   - ros-kilted-ros2topic
   - ros-kilted-rosidl-runtime-py
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __osx >=11.0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 56659
-  timestamp: 1769498669501
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2cli-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: 96d322ae56d1859214719aac84f757cfff1f0a015c7ea02768365859878dd8aa
-  md5: 26430602d162f840327bb0ce8c8ebe15
+  size: 56669
+  timestamp: 1775557568710
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2cli-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 08fd099543e01a030d9a867d0fbe00b281cbbe537d4622e717663f5e1ff8e914
+  md5: 552f34df46237e24b74619ea30a92335
   depends:
   - argcomplete
   - packaging
@@ -12492,20 +12605,19 @@ packages:
   - python
   - ros-kilted-rclpy
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 75285
-  timestamp: 1769485113379
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2cli-0.38.2-np2py312h50b1e4c_15.conda
-  sha256: a2e60c9e0f40fea4541d51a92edde4979fc0f10280f221e1dd7f3a2664507f19
-  md5: 231070aa70cb477eec5b421142637d75
+  size: 76065
+  timestamp: 1775551322006
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2cli-0.38.3-np2py312h50b1e4c_17.conda
+  sha256: e3dc69f7506435f1949de9f8de7d304a4b6ea0b2c69d5de3abff82ace197c1b8
+  md5: 46eee7c25326d3e8279001b2e3c10392
   depends:
   - argcomplete
   - packaging
@@ -12513,18 +12625,18 @@ packages:
   - python
   - ros-kilted-rclpy
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 75497
-  timestamp: 1769495679765
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2cli-common-extensions-0.4.1-np2py312h2ed9cc7_15.conda
-  sha256: c47f03a72653c920ce1093c8935a278736058dc260b83151cd5c9ac2fd425fb3
-  md5: 6e5b2a57d32332a87b3f6c381085c650
+  size: 76444
+  timestamp: 1775554617983
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2cli-common-extensions-0.4.1-np2py312h2ed9cc7_17.conda
+  sha256: 17e767b1d71c36d29bbd7118e5a02ab4a69af899513f030f157a93aa90213e66
+  md5: 6a353a72f30340a55d74834a92232aea
   depends:
   - python
   - ros-kilted-launch-xml
@@ -12546,20 +12658,19 @@ packages:
   - ros-kilted-ros2service
   - ros-kilted-ros2topic
   - ros-kilted-sros2
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 26880
-  timestamp: 1769487321970
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2cli-common-extensions-0.4.1-np2py312h50b1e4c_15.conda
-  sha256: affe460533c0c9c14b49f4e3c0f2e5d0d6cfc6efd5d67426fd2f0f1d996de0c1
-  md5: 19b1eb72949144ab397f46bde2841d66
+  size: 26956
+  timestamp: 1775604034634
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2cli-common-extensions-0.4.1-np2py312h50b1e4c_17.conda
+  sha256: ac4bd22b8ca2700035c55febaaca70cbc547c30013ce667d1fdfac5697de32c3
+  md5: ceb52c2ebdd96805edeacc003f83a736
   depends:
   - python
   - ros-kilted-launch-xml
@@ -12581,18 +12692,18 @@ packages:
   - ros-kilted-ros2service
   - ros-kilted-ros2topic
   - ros-kilted-sros2
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 27198
-  timestamp: 1769503390992
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2component-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: 78f773b80ba3cb4d0c893eb94141a688697bcfa94e8c8e7a99e14d24a6d4cfed
-  md5: 656f2964767e27d8cf966641ef1fae42
+  size: 27428
+  timestamp: 1775560048103
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2component-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 20efe3b862c34d2c5c2174efeca823c29b3a6150a14c01b3d89397c675db89cb
+  md5: 98a3e9a6ac667541c2c9e1e2e5eae04d
   depends:
   - python
   - ros-kilted-ament-index-python
@@ -12605,20 +12716,19 @@ packages:
   - ros-kilted-ros2node
   - ros-kilted-ros2param
   - ros-kilted-ros2pkg
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 38297
-  timestamp: 1769486521193
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2component-0.38.2-np2py312h50b1e4c_15.conda
-  sha256: 30309d3f004522b2c494e53072413d0ea41baf6a83522c7144825dbcdd2d1b58
-  md5: 79a105fa606858c50f47078d1393accb
+  size: 37886
+  timestamp: 1775603168404
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2component-0.38.3-np2py312h50b1e4c_17.conda
+  sha256: 913df43a5b240210b04bbe9a337315b926154ff29f83ed4703e6074359454004
+  md5: f95230851661c7e77bc59fcb2b223dc6
   depends:
   - python
   - ros-kilted-ament-index-python
@@ -12631,18 +12741,18 @@ packages:
   - ros-kilted-ros2node
   - ros-kilted-ros2param
   - ros-kilted-ros2pkg
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - libcxx >=18
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 38605
-  timestamp: 1769501529248
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2doctor-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: 024d3173d9b396631fef798e11e392044b789705ac1f96a97ce4e631227d6c8c
-  md5: 347c995b1718be605216299c014c609e
+  size: 38580
+  timestamp: 1775559171561
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2doctor-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 42fb2904050b6af006c2aa2a0e6e7fac936d72038e60c7113c5e2ecaffcfe0c9
+  md5: 6e0d8793f76dad30197f1157066d4dd0
   depends:
   - catkin_pkg
   - psutil
@@ -12653,21 +12763,20 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - rosdistro
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 66142
-  timestamp: 1769485606208
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2doctor-0.38.2-np2py312h50b1e4c_15.conda
-  sha256: 57fd6ea6209d7b6b34210ec10a0dcb599488690751c95fda1a7fe355b2d9aa23
-  md5: 61825d1a5a3aca485dcf9e0420d76ced
+  size: 66106
+  timestamp: 1775552009135
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2doctor-0.38.3-np2py312h50b1e4c_17.conda
+  sha256: 1313ee3ca1429c6eaa8bfa0421c4eae7dfb453da6dbb5ee22ea1712cb2479ceb
+  md5: 08cc72bd98abec838358280bef776ca2
   depends:
   - catkin_pkg
   - psutil
@@ -12678,19 +12787,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - rosdistro
-  - __osx >=11.0
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - __osx >=11.0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 65896
-  timestamp: 1769497115506
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2interface-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: 41c51b3389d8c703a3b93a5866680431638d0d5693ea75276376c1d0c17a4743
-  md5: 62e424ae8d06284a3e66aeda632319e5
+  size: 65911
+  timestamp: 1775556643111
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2interface-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 372bc038194c2ec230faee79045ee8434d551da2e3dcbb763d0fb4525544f83d
+  md5: f0c7924a5f0437efc6d3f3eaa1e9e412
   depends:
   - python
   - ros-kilted-ament-index-python
@@ -12698,19 +12807,19 @@ packages:
   - ros-kilted-ros2cli
   - ros-kilted-rosidl-adapter
   - ros-kilted-rosidl-runtime-py
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 46167
-  timestamp: 1769485599797
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2interface-0.38.2-np2py312h50b1e4c_15.conda
-  sha256: 1ce4916c5a93d76efc4a61ca5a9421473f5ecd04c7f7e68e4ec72a77a8d0f877
-  md5: d700895ed382516b22472eb772750ef6
+  size: 46151
+  timestamp: 1775552001968
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2interface-0.38.3-np2py312h50b1e4c_17.conda
+  sha256: 374fa73b418a2ac2d323a6242f9010a0e06951b32e59ab025d86453ec661e1c8
+  md5: d366ba7fb6968e16634caf90b2daded4
   depends:
   - python
   - ros-kilted-ament-index-python
@@ -12718,18 +12827,18 @@ packages:
   - ros-kilted-ros2cli
   - ros-kilted-rosidl-adapter
   - ros-kilted-rosidl-runtime-py
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 45875
-  timestamp: 1769497103597
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2launch-0.28.5-np2py312h2ed9cc7_15.conda
-  sha256: 3c5e8ec32729c4577fec5ecd2c5d13b119c0c53e64bd72cdcc673724871d4775
-  md5: 5f67bf26a04af230f38a5c0a9d3549b8
+  size: 45888
+  timestamp: 1775556632934
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2launch-0.28.5-np2py312h2ed9cc7_17.conda
+  sha256: 091747592c074bab1adb3b79e3f7ba8bd23682c4eba2ae954cd3c4726719ee9d
+  md5: b648348a7223709182b773b40f8e8ed1
   depends:
   - python
   - ros-kilted-ament-index-python
@@ -12740,19 +12849,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-ros2pkg
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 33758
-  timestamp: 1769485921112
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2launch-0.28.5-np2py312h50b1e4c_15.conda
-  sha256: b09d57935dd48c0eb3cad6445c11067bae3afeb28ce85c8111b70a13e7f7b2bf
-  md5: 36bfb0699ef1e4d3f5dfe1abd939e5e1
+  size: 33380
+  timestamp: 1775602440796
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2launch-0.28.5-np2py312h50b1e4c_17.conda
+  sha256: eb5229f801070149c647fc7e714542e66af6df3e1e94c51db79f19b0155139f5
+  md5: 36d004d9571bbcb2ececad0b529cfdba
   depends:
   - python
   - ros-kilted-ament-index-python
@@ -12763,18 +12872,18 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-ros2pkg
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __osx >=11.0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 34101
-  timestamp: 1769498657221
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2lifecycle-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: 63f58180568ff4ef1257226bf704e153b75c8f29987827a8cc7ee4b590197551
-  md5: 8e3368e8ff5ac6b84a99d125c48fe962
+  size: 34120
+  timestamp: 1775557555711
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2lifecycle-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 0d9dc6616acf7c10b787cfba0211aaf7c37cc93271e88235d941f5e9e12cf599
+  md5: 050065b48e51a0ea877f3f1cde5c67a0
   depends:
   - python
   - ros-kilted-lifecycle-msgs
@@ -12783,19 +12892,19 @@ packages:
   - ros-kilted-ros2cli
   - ros-kilted-ros2node
   - ros-kilted-ros2service
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 44804
-  timestamp: 1769486251309
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2lifecycle-0.38.2-np2py312h50b1e4c_15.conda
-  sha256: 34c34c04d3355b1193c0166f7ad185ac91017dc48eb1b74f3e0eeea2d34ab52a
-  md5: d6154fe1b32558a55ec27e9d3e46da04
+  size: 44663
+  timestamp: 1775602772580
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2lifecycle-0.38.3-np2py312h50b1e4c_17.conda
+  sha256: 28241c25fd820601346d2993e9866d2704f25d9315d6200ac70649a233d12db1
+  md5: fcfb6d4b336e5445a45846a42c07e8ba
   depends:
   - python
   - ros-kilted-lifecycle-msgs
@@ -12804,87 +12913,86 @@ packages:
   - ros-kilted-ros2cli
   - ros-kilted-ros2node
   - ros-kilted-ros2service
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - numpy >=1.23,<3
+  - __osx >=11.0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 44607
-  timestamp: 1769500463683
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2multicast-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: d43c35fc8acb69cf62d056b1ed747f9bc26116e4a83ecee7aace7e2142913de1
-  md5: af75e9c6af7883502d0cc8932cd07dcf
+  size: 44643
+  timestamp: 1775558482369
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2multicast-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 11dd81f13ebaa46422e5be6d4501f245a9c533d3efe74be282f7342edbfe8548
+  md5: 37cbf0b93703581b10f16f9c537ea165
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 25816
-  timestamp: 1769485266939
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2multicast-0.38.2-np2py312h50b1e4c_15.conda
-  sha256: 051b2cf687e3e393e0bcae7bcc86adbf60b4613a2b4fc9d85fa44922d0c535e1
-  md5: 4898651ed5f06a51ec664d5a88b09682
+  size: 25552
+  timestamp: 1775551645136
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2multicast-0.38.3-np2py312h50b1e4c_17.conda
+  sha256: f145f425380b42b004732cc1ed053f32e524e9723b8a12990f5b8e352830405e
+  md5: 61cc70ca83d7abb515d7104d5442645d
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 26151
-  timestamp: 1769496139665
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2node-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: 87e04c7ea721df57d6b80c985658af94910e41558ae344e92293898ad9af3b26
-  md5: 76d3d697e3ac508f993c01ee0bee492d
+  size: 26121
+  timestamp: 1775555713600
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2node-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 72938863a9b4b9f49c4fcf7815aa92e96fd7e9bf741d3380c271c3a130d93f05
+  md5: f77af7e81cc80877a576e5c1b1d4dee1
   depends:
   - python
   - ros-kilted-rclpy
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 42635
-  timestamp: 1769485582672
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2node-0.38.2-np2py312h50b1e4c_15.conda
-  sha256: e0b0cd4b97e47a282380e80555728b1a2bab6a6dec3ffaebff6ce0737618111c
-  md5: 11e3e53236927bdc6669b4afefeac3b3
+  size: 42554
+  timestamp: 1775551996263
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2node-0.38.3-np2py312h50b1e4c_17.conda
+  sha256: 0c5affdbd25e8b7b81fb71d2aeaa883264319797e8b15922eca0fd64d834ec2c
+  md5: 4056eb808ec71b59527e37abe2c3e9e6
   depends:
   - python
   - ros-kilted-rclpy
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
+  - __osx >=11.0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 42379
-  timestamp: 1769497455484
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2param-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: d0e3f814ebd94d57eb1c622d0c940a872f55f85fa72722df7cdcce8a87e0d7ff
-  md5: f19cff95740d12bc70379b8958c90636
+  size: 42369
+  timestamp: 1775556481592
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2param-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 580b303ab05b1d01875fbf66282f979bd278d004899613d90d23d9dc44c8a2ba
+  md5: 6b0f5f21fee721918487846740d26589
   depends:
   - python
   - ros-kilted-rcl-interfaces
@@ -12893,19 +13001,19 @@ packages:
   - ros-kilted-ros2cli
   - ros-kilted-ros2node
   - ros-kilted-ros2service
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 49844
-  timestamp: 1769486226351
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2param-0.38.2-np2py312h50b1e4c_15.conda
-  sha256: 227b8a985bc507bd5acc6755e02e80cfb6835e4df3340ed8472ee1ff18d32807
-  md5: 61ffb47b57761b1a38c514cfaf5f9764
+  size: 49895
+  timestamp: 1775602755295
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2param-0.38.3-np2py312h50b1e4c_17.conda
+  sha256: 1ff651a569159d9ab3931320747f67b79487ec55638cac920622e6a2331c6955
+  md5: 5f0ac18d456ea172bc33adf04292611a
   depends:
   - python
   - ros-kilted-rcl-interfaces
@@ -12914,18 +13022,18 @@ packages:
   - ros-kilted-ros2cli
   - ros-kilted-ros2node
   - ros-kilted-ros2service
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
+  - __osx >=11.0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 49623
-  timestamp: 1769500428461
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2pkg-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: 464c44f61d226c92acdfcaeb6e867154fa2007730112636c740b4eba92d97e3e
-  md5: 4266879b46d711461d81c4740c204ca2
+  size: 49765
+  timestamp: 1775558447214
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2pkg-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 41cf16ccb5dd3bf0a70febaf813c825aeccd9a7499407d7c7c2eefdf65f0dbca
+  md5: 4c7d4ce967901f9fc2c98e1606e4eaa2
   depends:
   - catkin_pkg
   - empy
@@ -12934,20 +13042,19 @@ packages:
   - ros-kilted-ament-index-python
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 59365
-  timestamp: 1769485572826
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2pkg-0.38.2-np2py312h50b1e4c_15.conda
-  sha256: 15d12f3fe03f73898e50d5bd01f6b4dbe5e549945360197f5385a9b215e64095
-  md5: ceb12585b4f9c70cda46bba4ffb6321b
+  size: 59283
+  timestamp: 1775551969597
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2pkg-0.38.3-np2py312h50b1e4c_17.conda
+  sha256: 7f64e964781acda0c5d7cb6c8217d2e6bf9d1484907371e9e1721e6552d8b726
+  md5: 15cf56e9e69eeb47166655efbc224607
   depends:
   - catkin_pkg
   - empy
@@ -12956,18 +13063,18 @@ packages:
   - ros-kilted-ament-index-python
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 59088
-  timestamp: 1769497053649
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2plugin-5.6.2-np2py312h2ed9cc7_15.conda
-  sha256: b477dd5ba20c8dc9af43e1a51f268fa3e95d52ea4642c833728d73e894291605
-  md5: fdad45671c9fddf9535198b6e1a002ac
+  size: 59068
+  timestamp: 1775556577770
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2plugin-5.6.2-np2py312h2ed9cc7_17.conda
+  sha256: 5fb2574f1262d74d53bd4f4f87f42e51d35d9518cfde18d78fb521a9a4b833b1
+  md5: 0a70b22b8bee4d0f11521275c92b64dc
   depends:
   - python
   - ros-kilted-ament-index-python
@@ -12975,20 +13082,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-ros2pkg
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 25891
-  timestamp: 1769485914960
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2plugin-5.6.2-np2py312h50b1e4c_15.conda
-  sha256: e5831dfe747898bdb2f90353c994836a6f9f0f1833e5afcb3d09e1cd72280356
-  md5: 31339ff410fcd4d0d6774c438b9a7bd1
+  size: 25516
+  timestamp: 1775602428516
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2plugin-5.6.2-np2py312h50b1e4c_17.conda
+  sha256: 4481447a1cf9c513a20d8b8938214fc80282a1f4b28a13147d5238fae6643b8e
+  md5: 913ba33e7502d3db3d91a5b5098e10e6
   depends:
   - python
   - ros-kilted-ament-index-python
@@ -12996,54 +13102,53 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-ros2pkg
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
+  - libcxx >=18
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 26229
-  timestamp: 1769498646584
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2run-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: 939e6b5b3c840b65d6c37a70d01f350f7996bf935238b6a709489c21c3b2934a
-  md5: 34f1040f292333448d2625641b91bab8
+  size: 26207
+  timestamp: 1775557535539
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2run-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 79181d8c6a4c471ddaed6bb021195508a3bc5e0f8bc0a5360b92a6167cdad22d
+  md5: 8917fd512603bbf4d80e2808673ca281
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-ros2pkg
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 25358
-  timestamp: 1769485907598
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2run-0.38.2-np2py312h50b1e4c_15.conda
-  sha256: 6d0495c8ed8893600e51e7792c478ccbc6f12cedb634dc14f4d8e33fb87919c6
-  md5: 289b88eef52b5054e0d4e431efa54570
+  size: 24976
+  timestamp: 1775602502571
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2run-0.38.3-np2py312h50b1e4c_17.conda
+  sha256: 80f73e32bc7af888d8f33f7db5dce7635f125c05485426bd17111005a2fbec3d
+  md5: c80db926f2c5428bcb2acdffa12bc4bc
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-ros2pkg
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 25715
-  timestamp: 1769498632075
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2service-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: 969d313c0f263f0652933167ae681eacdc0b01e970c5dcf1a70dafde43ef6922
-  md5: b43cef1efe0aac90ccac3483e059ed70
+  size: 25668
+  timestamp: 1775558080331
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2service-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 6c1efe40369da04b1ef1e82e685a7fdb7c11c66cabc72765ba5b9e7410d7d036
+  md5: d6356dc1004cf5a427dadfff0d0d038d
   depends:
   - python
   - pyyaml
@@ -13052,20 +13157,19 @@ packages:
   - ros-kilted-ros2cli
   - ros-kilted-ros2topic
   - ros-kilted-rosidl-runtime-py
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 51364
-  timestamp: 1769485927953
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2service-0.38.2-np2py312h50b1e4c_15.conda
-  sha256: fb1722ea39825a5d89d74b37fbb6da37ef98dc0284c6a2e9bfb4371646bd952d
-  md5: f7caffa3e2aea7c89feadf12ba191285
+  size: 51215
+  timestamp: 1775602461911
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2service-0.38.3-np2py312h50b1e4c_17.conda
+  sha256: b299e331524e98839d90cfc52aa472f4dd796f2f1c1ece8897ff9e85f06f1475
+  md5: faa6f426bd9a0b9694e87c63114f97ab
   depends:
   - python
   - pyyaml
@@ -13074,18 +13178,18 @@ packages:
   - ros-kilted-ros2cli
   - ros-kilted-ros2topic
   - ros-kilted-rosidl-runtime-py
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libcxx >=18
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 51105
-  timestamp: 1769498381813
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2topic-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: 9ec2b4ab4fb70f735b618a4065c8853eea36b9c813a1b5ef63918ec8691e95b0
-  md5: dce0445c1eb12ad7354b0f10c33f430e
+  size: 51067
+  timestamp: 1775557993581
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ros2topic-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: e44b018d4a3b42d4974970d81690ae6bdd1ce3db0a286b1f474621ec4f0f4f45
+  md5: c999706429bc4828c3e83311c936bf36
   depends:
   - numpy
   - python
@@ -13094,20 +13198,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-rosidl-runtime-py
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0 OR BSD-3-Clause
-  size: 79695
-  timestamp: 1769485574837
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2topic-0.38.2-np2py312h50b1e4c_15.conda
-  sha256: b3dd9526ea1e5e38797e89439954bf8c9a6d282a9700866c983beb5d949152da
-  md5: 78271573af564dd6ee884213107f6c3b
+  size: 79674
+  timestamp: 1775551985552
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-ros2topic-0.38.3-np2py312h50b1e4c_17.conda
+  sha256: f90f1eee4dedd0a92647ef4db3322ed36426ecf8e6c5f758d0b0149a13f4ce79
+  md5: aa441e74a58945640e6eabf5abbd82bc
   depends:
   - numpy
   - python
@@ -13116,164 +13219,160 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-rosidl-runtime-py
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0 OR BSD-3-Clause
-  size: 79432
-  timestamp: 1769497443025
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosgraph-msgs-2.3.0-np2py312h2ed9cc7_15.conda
-  sha256: c5f933be110810b1d01142178b51518f174900b6d65280f2388f57d0aa790232
-  md5: 5cf7dd341916a47df0d161209efa5822
+  size: 79445
+  timestamp: 1775556465755
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosgraph-msgs-2.3.1-np2py312h2ed9cc7_17.conda
+  sha256: f0af66807d0730331561b9ba7c419f7d99c51396782d688f846a799945dd5097
+  md5: d19b7401588ce789c5d80dce598646a7
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 70760
-  timestamp: 1769483152399
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosgraph-msgs-2.3.0-np2py312h50b1e4c_15.conda
-  sha256: 8967efbda3a4d2ca3545320d4e3e9244a2daa563237a49432fadb730d571f6d2
-  md5: ce79f999baceb404f26b181d7322c0b4
+  size: 72126
+  timestamp: 1775549353749
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosgraph-msgs-2.3.1-np2py312h50b1e4c_17.conda
+  sha256: 37dde64a3d2101b0b31f6eb97c6d2ffe68a16f709aa0ad332b6a3d1043b225ce
+  md5: 10682548e1e0f1367054077fb2db7295
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
+  - __osx >=11.0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 68705
-  timestamp: 1769491128677
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-adapter-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: dc8d3b310ac0234484d25402236b65c266cd29b002e84d262dc4527df736589a
-  md5: ac468ffb8a3f1085fb43f14e7a6b8fc8
+  size: 70641
+  timestamp: 1775551021983
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-adapter-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: afa24d8dfa0e07970836392106741b353d07e1bf622473e84ba82bbce73e2289
+  md5: 954f036f738e4572c15fc1ef4ecdb3ef
   depends:
   - empy
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-cli
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - numpy >=1.23,<3
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 67986
-  timestamp: 1769481881616
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-adapter-4.9.6-np2py312h50b1e4c_15.conda
-  sha256: 830d9c7abe855e52bd39ae8a1e7ca89072468b29c1054bb8057ce59dcfc54339
-  md5: 9b976bffecb1a91e0ba4d564ea7cca55
+  size: 68058
+  timestamp: 1775548162761
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-adapter-4.9.6-np2py312h50b1e4c_17.conda
+  sha256: 602a868f8e0298cfec27ce3c49fc5b711aa50c6cc43a324171930937024d86c6
+  md5: a2868cc6628f2fb59ecdbfbacebb1104
   depends:
   - empy
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-cli
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
-  - python_abi 3.12.* *_cp312
+  - libcxx >=18
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 68405
-  timestamp: 1769488268007
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-cli-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: 221734b04e8d9676d3c4391b22eef4c6b049367579df1af5e5cf0d94e110dbde
-  md5: d0bc37dcba0a8178a99c7b80234646c8
+  size: 68598
+  timestamp: 1775549145759
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-cli-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: a75b74550cf32b76bea63a93887597b31eb71429c1a178ee63db2f5456ed78c8
+  md5: e8dc5116bb1a57913279a115098105c5
   depends:
   - argcomplete
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 46623
-  timestamp: 1769481352265
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-cli-4.9.6-np2py312h50b1e4c_15.conda
-  sha256: 341a385146bd81c38721cbd8866389a743936e8b65463bb67d2eda661c85e143
-  md5: 5a54c62b3bb6538cf287f66f409cb163
+  size: 46323
+  timestamp: 1775547612547
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-cli-4.9.6-np2py312h50b1e4c_17.conda
+  sha256: d359e347fe98900af39665ad0193c9c2387a39491288f3ec1e5f9e77de5b18b7
+  md5: 93daa6066e7ecd334f89154cbdb62ad3
   depends:
   - argcomplete
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 46888
-  timestamp: 1769487446003
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-cmake-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: 9106e7059f114c956f2d9fccc5cfde64d70ac812eab4ccafd7263319bc86e883
-  md5: 4c880fd84d6e7f450049e4a632733f59
+  size: 46882
+  timestamp: 1775548273977
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-cmake-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: 2db7fa58d4e05fbaa1c2993615f3a35839fe991254ff840bdc9d9c6f8b71b681
+  md5: 290c6d215ae864b4dc91dc31e73684fa
   depends:
   - empy
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-pycommon
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 36308
-  timestamp: 1769482423899
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-cmake-4.9.6-np2py312h50b1e4c_15.conda
-  sha256: 89e8603558ac4bfd44a2daf1337ca75f3501dd241c5b6b766dd6e31fe6c9124c
-  md5: 6fe3fe40f83877c0e1636ee1dd8b920a
+  size: 36353
+  timestamp: 1775548703786
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-cmake-4.9.6-np2py312h50b1e4c_17.conda
+  sha256: 4f303e3d147b1b746b3cf8b74542e47c81cc7ce323507d8d674b53a72007d78f
+  md5: 6c8dbbf2c90b7fc2a2e13ae399779276
   depends:
   - empy
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-pycommon
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libcxx >=18
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 36643
-  timestamp: 1769489285636
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-core-generators-0.3.1-np2py312h2ed9cc7_15.conda
-  sha256: b9114145ae0ca04c4925ecb6790a5f61b6cda224957cd2edf2f78d91a006276d
-  md5: ed4a6fb067a7a8cbba259a0c2bf87a43
+  size: 36869
+  timestamp: 1775549744533
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-core-generators-0.3.2-np2py312h2ed9cc7_17.conda
+  sha256: 07fb9a95381b966ef435e7dde79cf7df789f7f21cf3c1effb831e91749b81e4a
+  md5: 42b12fd154aadf7e5fd9bcf4031f8592
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -13282,6 +13381,7 @@ packages:
   - ros-kilted-rosidl-generator-c
   - ros-kilted-rosidl-generator-cpp
   - ros-kilted-rosidl-generator-py
+  - ros-kilted-rosidl-generator-rs
   - ros-kilted-rosidl-generator-type-description
   - ros-kilted-rosidl-typesupport-c
   - ros-kilted-rosidl-typesupport-cpp
@@ -13289,20 +13389,19 @@ packages:
   - ros-kilted-rosidl-typesupport-fastrtps-cpp
   - ros-kilted-rosidl-typesupport-introspection-c
   - ros-kilted-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 30831
-  timestamp: 1769482955528
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-core-generators-0.3.1-np2py312h50b1e4c_15.conda
-  sha256: 8322d4b618d67b620a165bdab3748fd4daef797dda0af49afa9d4016ed4b95cc
-  md5: 1df3b7783b2691b0a6b4f93264a4440f
+  size: 31000
+  timestamp: 1775549160407
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-core-generators-0.3.2-np2py312h50b1e4c_17.conda
+  sha256: c56f1ebdeca16a566901f426a5474a67b379301815f0f641f692ef41679dccfd
+  md5: a833edec4bb20b034408a92208ff8646
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -13311,6 +13410,7 @@ packages:
   - ros-kilted-rosidl-generator-c
   - ros-kilted-rosidl-generator-cpp
   - ros-kilted-rosidl-generator-py
+  - ros-kilted-rosidl-generator-rs
   - ros-kilted-rosidl-generator-type-description
   - ros-kilted-rosidl-typesupport-c
   - ros-kilted-rosidl-typesupport-cpp
@@ -13318,22 +13418,23 @@ packages:
   - ros-kilted-rosidl-typesupport-fastrtps-cpp
   - ros-kilted-rosidl-typesupport-introspection-c
   - ros-kilted-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 31170
-  timestamp: 1769490627743
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-core-runtime-0.3.1-np2py312h2ed9cc7_15.conda
-  sha256: de43e8fcc1ef452938b354575c75477af87201eec68e2c664a6588e4bae45455
-  md5: 4489eef04cbcbdf18b44abb974fad63f
+  size: 31508
+  timestamp: 1775550619170
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-core-runtime-0.3.2-np2py312h2ed9cc7_17.conda
+  sha256: 1e010f618fb959e825a612f5943852acb87e4b5d6bd5549637a9e4a5d6076ddc
+  md5: 2be81c9da2284ebf645a36ed66ae6fb1
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-generator-py
+  - ros-kilted-rosidl-generator-rs
   - ros-kilted-rosidl-runtime-c
   - ros-kilted-rosidl-runtime-cpp
   - ros-kilted-rosidl-typesupport-c
@@ -13342,24 +13443,24 @@ packages:
   - ros-kilted-rosidl-typesupport-fastrtps-cpp
   - ros-kilted-rosidl-typesupport-introspection-c
   - ros-kilted-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 29832
-  timestamp: 1769482941167
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-core-runtime-0.3.1-np2py312h50b1e4c_15.conda
-  sha256: a124b5195cccfb4c5eb75c33db608bb94c0a28d30fdefa6a1bc1d28427067a2d
-  md5: 9e9644c240f3ddcb42ae8b5eadda50e6
+  size: 30037
+  timestamp: 1775549143380
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-core-runtime-0.3.2-np2py312h50b1e4c_17.conda
+  sha256: 0f981952a07fc9662d80cc805ba4be48e439348e0bc12fdfd6202899100f956b
+  md5: 04438f7de3d454fd10b4f230a513f36f
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-generator-py
+  - ros-kilted-rosidl-generator-rs
   - ros-kilted-rosidl-runtime-c
   - ros-kilted-rosidl-runtime-cpp
   - ros-kilted-rosidl-typesupport-c
@@ -13368,18 +13469,18 @@ packages:
   - ros-kilted-rosidl-typesupport-fastrtps-cpp
   - ros-kilted-rosidl-typesupport-introspection-c
   - ros-kilted-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __osx >=11.0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 30184
-  timestamp: 1769490600097
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-default-generators-1.7.1-np2py312h2ed9cc7_15.conda
-  sha256: 1f682f3ef0e77ed8b3c42b006e5d8323238888e5a4ea71b900f7531fcf437613
-  md5: 1db32e38b3f14ff4c941151ce80428ae
+  size: 30479
+  timestamp: 1775550596470
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-default-generators-1.7.2-np2py312h2ed9cc7_17.conda
+  sha256: c7c950774a9b93b2362145676f939a2d479f8d6dd26a49a55957183ac4cf3fdc
+  md5: 271a94345f31731de1b29c64e4af736e
   depends:
   - python
   - ros-kilted-action-msgs
@@ -13387,19 +13488,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-generators
   - ros-kilted-service-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 30970
-  timestamp: 1769483094357
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-default-generators-1.7.1-np2py312h50b1e4c_15.conda
-  sha256: cba3ca0d07b45872d19db6fb49a99ff350de8929d2ee25d96a6f3f4db4371cef
-  md5: 14efe486b6c422881c7494e70a3db884
+  size: 31187
+  timestamp: 1775549306536
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-default-generators-1.7.2-np2py312h50b1e4c_17.conda
+  sha256: d5f60464e24ac53e6e2b7daab9bbe017df591b459ae83313c6294a23b9b64a61
+  md5: ffb789305ee70297441b7e449d9cc327
   depends:
   - python
   - ros-kilted-action-msgs
@@ -13407,91 +13508,90 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-generators
   - ros-kilted-service-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
+  - __osx >=11.0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 31391
-  timestamp: 1769491009132
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-default-runtime-1.7.1-np2py312h2ed9cc7_15.conda
-  sha256: 0fa246ff3721ce8aff2d4a08cfda89019dd24d3cd5c8e16e846004d412b0641a
-  md5: 628dc9bd7669b3f033f0a0767f759ccb
+  size: 31612
+  timestamp: 1775550930869
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-default-runtime-1.7.2-np2py312h2ed9cc7_17.conda
+  sha256: 4b518e323e254550d38a6aa604742db25b083c5da5c6c37aa7d45c2193976d38
+  md5: 2195ee91e70e85a3f2e153484c11836f
   depends:
   - python
   - ros-kilted-action-msgs
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-runtime
   - ros-kilted-service-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 30444
-  timestamp: 1769483080744
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-default-runtime-1.7.1-np2py312h50b1e4c_15.conda
-  sha256: 80ecb688f618c60a8588edc2346f596baf083bcc9c5bab2ed3c6c742277652ca
-  md5: 4287bb09e371f445d15460bb04815367
+  size: 30596
+  timestamp: 1775549294628
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-default-runtime-1.7.2-np2py312h50b1e4c_17.conda
+  sha256: 3d55d18dc0938a9593d3a38aff9e546e05b933536fb3de58335625a9e75f4ef3
+  md5: cf5d99fb0a8a9fb4c3e60ab3bf3f4c11
   depends:
   - python
   - ros-kilted-action-msgs
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-runtime
   - ros-kilted-service-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __osx >=11.0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 30763
-  timestamp: 1769490974353
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-dynamic-typesupport-0.3.1-np2py312h2ed9cc7_15.conda
-  sha256: 97882153533d1b30bd831fcec3d645369e5fa02a4e73090f42948dacbd28e78f
-  md5: 0416db063f3c4e1ae812a19e4b2a6db4
+  size: 31032
+  timestamp: 1775550902962
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-dynamic-typesupport-0.3.1-np2py312h2ed9cc7_17.conda
+  sha256: 4906df07d3114bae86c4bf26e33edc664cb8b51fdb5d57d31e2c48cbb2b06bdc
+  md5: 47c6032fc6973ff645c66ba07b13a123
   depends:
   - python
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 60888
-  timestamp: 1769482443045
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-dynamic-typesupport-0.3.1-np2py312h50b1e4c_15.conda
-  sha256: a1f9efda40431d9fc720ddf787d14d9c61eb8cc5ed4cc7855edcef87e0a5231a
-  md5: 90b8465a496c7640ea22d0ef67022f10
+  size: 60857
+  timestamp: 1775548724987
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-dynamic-typesupport-0.3.1-np2py312h50b1e4c_17.conda
+  sha256: ec5eeafbb626b421718f578d77e3b6d26fa016c842a08166b14eb7233fb5fc15
+  md5: c9f372941fba2cd2079783cdb7f1334c
   depends:
   - python
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
+  - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 54850
-  timestamp: 1769489320785
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-dynamic-typesupport-fastrtps-0.4.2-np2py312h2ed9cc7_15.conda
-  sha256: 1a0b327c2e27741ff020f1674a81f61753e64389e56dc9cb3b8e92a2ddc45e01
-  md5: 7cd31823c6ab1f3ddaf19c80f492b506
+  size: 55033
+  timestamp: 1775549788753
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-dynamic-typesupport-fastrtps-0.4.2-np2py312h2ed9cc7_17.conda
+  sha256: 9fbbbfb5dca949c61f7ebdbab3ee9c11f141b1c83bcf1cc8350f88367960ae5a
+  md5: 3a0f7f051811a80734813a4145c6db8d
   depends:
   - python
   - ros-kilted-fastcdr
@@ -13500,19 +13600,19 @@ packages:
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-dynamic-typesupport
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 82893
-  timestamp: 1769482516443
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-dynamic-typesupport-fastrtps-0.4.2-np2py312h50b1e4c_15.conda
-  sha256: 5274b554820295ddad3675300ba426481570ce4c308e3b1fb98a6e59c4187072
-  md5: 71de4290f10e7bde99758a9e93bf0f56
+  size: 82842
+  timestamp: 1775548797862
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-dynamic-typesupport-fastrtps-0.4.2-np2py312h50b1e4c_17.conda
+  sha256: 7340847ee0158e99e9d16c91ab1e6353f8f1798ba24710683d2e8b1464170918
+  md5: 1d2d172de326d2bda6c8bd9ed20626be
   depends:
   - python
   - ros-kilted-fastcdr
@@ -13521,18 +13621,18 @@ packages:
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-dynamic-typesupport
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __osx >=11.0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 72771
-  timestamp: 1769489435212
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-generator-c-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: 576e9638664b90b903ce2baa8434ad0042811b256877f9f2e7b99fffea1250a7
-  md5: d746b4b081a43de064518fd0001bb4ac
+  size: 72997
+  timestamp: 1775549914984
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-generator-c-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: 115e8c14df561db8378822746e2b0322830b8bbffe645b2124cbe4017ae23664
+  md5: a91a7a7411d06bab060699791f11617c
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -13545,19 +13645,19 @@ packages:
   - ros-kilted-rosidl-parser
   - ros-kilted-rosidl-pycommon
   - ros-kilted-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 51989
-  timestamp: 1769482496349
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-generator-c-4.9.6-np2py312h50b1e4c_15.conda
-  sha256: 3ba9f9f54d5d72303745ed53fb5e3cc815c3edce5e83c5267535f0de1e63e6a0
-  md5: 00f127416008abbb2944928e1714b53c
+  size: 52092
+  timestamp: 1775548776012
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-generator-c-4.9.6-np2py312h50b1e4c_17.conda
+  sha256: 3e8ea8772c17b0cc944ea7513787ed59c3894097619445baf372a6854108e581
+  md5: 595ea66e5a9518c5a23bd9198c6e177e
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -13570,18 +13670,18 @@ packages:
   - ros-kilted-rosidl-parser
   - ros-kilted-rosidl-pycommon
   - ros-kilted-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 52391
-  timestamp: 1769489396562
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-generator-cpp-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: f9dc88dc1c0a2efeb640ded038320f879da2289253092bae47c8422c2a2314b1
-  md5: c2c2ff8062f7c730958b3b5f855424a5
+  size: 52609
+  timestamp: 1775549876648
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-generator-cpp-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: e00fe1214d5e6525e734b0e66281fd907142780b5cb8d66a4bdd6e2a14c4e28d
+  md5: 3df7e60cd553d97e0824e98d53e3acde
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -13594,20 +13694,19 @@ packages:
   - ros-kilted-rosidl-parser
   - ros-kilted-rosidl-pycommon
   - ros-kilted-rosidl-runtime-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 50192
-  timestamp: 1769482607759
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-generator-cpp-4.9.6-np2py312h50b1e4c_15.conda
-  sha256: 1d74a56395a56a7254e64d7f33b3acba724e1316c5b2b1ccc579a647ae01b68d
-  md5: 4ce018decc7f857eb1bce3c1965e33fb
+  size: 50379
+  timestamp: 1775548863529
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-generator-cpp-4.9.6-np2py312h50b1e4c_17.conda
+  sha256: 3808dec4802e595406c278503a42a58bb52c8dd2f82500b4e9566ccd0283305b
+  md5: 670875e7188f929098b2558d87af5206
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -13620,18 +13719,18 @@ packages:
   - ros-kilted-rosidl-parser
   - ros-kilted-rosidl-pycommon
   - ros-kilted-rosidl-runtime-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 50661
-  timestamp: 1769489823687
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-generator-py-0.24.2-np2py312h2ed9cc7_15.conda
-  sha256: 7452bfa643e605accc386ebcaaac9d7fcec1bdf4cb15524860696004627f043d
-  md5: dbed13626bffb18928ce49738eec6458
+  size: 50833
+  timestamp: 1775550008868
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-generator-py-0.24.2-np2py312h2ed9cc7_17.conda
+  sha256: f63a6886e563102ec4dbd8fd2c6a1660434f4ff119ed6c5e836f6473c9f71f4b
+  md5: a7ee198e55aab0d19a3f644b3c2fb0a6
   depends:
   - numpy
   - python
@@ -13652,19 +13751,19 @@ packages:
   - ros-kilted-rosidl-typesupport-c
   - ros-kilted-rosidl-typesupport-interface
   - ros-kilted-rpyutils
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 59687
-  timestamp: 1769482913157
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-generator-py-0.24.2-np2py312h50b1e4c_15.conda
-  sha256: 0ea2b0655763b263939155691bda94da441fdf14c1685007c860c67f294300ad
-  md5: 827a8e0c16a1cc2a8ec41a0a5faa7d8b
+  size: 59865
+  timestamp: 1775549115024
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-generator-py-0.24.2-np2py312h50b1e4c_17.conda
+  sha256: 0c3004953e7a3529b4527a3b1895d994a6a7ac8f128b060effb7924610dbcdb7
+  md5: 11f7d0ef60380434e9c2ea169ee7ed15
   depends:
   - numpy
   - python
@@ -13685,18 +13784,63 @@ packages:
   - ros-kilted-rosidl-typesupport-c
   - ros-kilted-rosidl-typesupport-interface
   - ros-kilted-rpyutils
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __osx >=11.0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 60736
-  timestamp: 1769490542803
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-generator-type-description-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: 766411c88737a7051a6b61d9b7637b0918ca683fe66942050b2a59150b58d328
-  md5: 0b79b46a6562a7f642aaae70000bc26a
+  size: 60346
+  timestamp: 1775550556173
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-generator-rs-0.4.11-np2py312h2ed9cc7_17.conda
+  sha256: e7e8d714a79910176f7cdfcc28b48f4c3869aca380dea4e5c76297a139e03f4b
+  md5: 3926d41972bf349610e0eeef57a94e32
+  depends:
+  - python
+  - ros-kilted-ament-cmake
+  - ros-kilted-ros-environment
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-generator-c
+  - ros-kilted-rosidl-parser
+  - ros-kilted-rosidl-pycommon
+  - ros-kilted-rosidl-typesupport-c
+  - ros-kilted-rosidl-typesupport-interface
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  license: Apache-2.0
+  size: 48181
+  timestamp: 1775549107872
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-generator-rs-0.4.11-np2py312h50b1e4c_17.conda
+  sha256: a3053f624a3b4da07f73420b7308f6319e7c0c7a212b650bfd51dee895e97cfe
+  md5: a625c7f38e6f64d0a3038d58bc9feb85
+  depends:
+  - python
+  - ros-kilted-ament-cmake
+  - ros-kilted-ros-environment
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-generator-c
+  - ros-kilted-rosidl-parser
+  - ros-kilted-rosidl-pycommon
+  - ros-kilted-rosidl-typesupport-c
+  - ros-kilted-rosidl-typesupport-interface
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libcxx >=18
+  - __osx >=11.0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 48666
+  timestamp: 1775550544108
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-generator-type-description-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: b55d73a44e05bc236f1318e6293310e54a1533be29fc08f0b096f6ef0475d486
+  md5: 0f1ca425d929ddcabed574353056843a
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -13704,20 +13848,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-cli
   - ros-kilted-rosidl-parser
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 47033
-  timestamp: 1769482390164
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-generator-type-description-4.9.6-np2py312h50b1e4c_15.conda
-  sha256: bf393b3b3c5e115f7ee76bc8948bb17965137e57c98d83197e1f38344c8f91d6
-  md5: 3af1ce10262104839ce03ce554193afd
+  size: 47000
+  timestamp: 1775548668462
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-generator-type-description-4.9.6-np2py312h50b1e4c_17.conda
+  sha256: 7c253a7428882dce052c33345d31872f3233bfb7954243e6404114423053a8b1
+  md5: 29d7bced5cf2e254e6fd36a36c55b74c
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -13725,200 +13868,195 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-cli
   - ros-kilted-rosidl-parser
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __osx >=11.0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 47338
-  timestamp: 1769489224599
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-parser-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: c8b04339c7996b046507dbb059c1f246645ebdcc1e53fd414a2306d2de3f536c
-  md5: 250a81cbda88b524963f66c7322a9fcf
+  size: 47550
+  timestamp: 1775549687164
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-parser-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: bf910c6f7efff7b3c6a395241e5929fb14af35c4f641c5ee74c11a33c668321b
+  md5: 51e30b7f4ec7565d89353a3b3d97d557
   depends:
   - lark-parser
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-adapter
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 66098
-  timestamp: 1769482281599
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-parser-4.9.6-np2py312h50b1e4c_15.conda
-  sha256: f1d4ae4cd6fa10142f141a21a9dad1d79b38ca7622bd6370fa3692577ba36196
-  md5: 16339f769f8b242bed095bc1ea8d7bf3
+  size: 66198
+  timestamp: 1775548572622
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-parser-4.9.6-np2py312h50b1e4c_17.conda
+  sha256: 2d286a4fa113601ff2342074a481bf0a90fa34b2d8592b3b3e7315781e80bd33
+  md5: da1ff7c78bfbd13e2e2da99cdab1464d
   depends:
   - lark-parser
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-adapter
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
+  - libcxx >=18
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 66435
-  timestamp: 1769489070080
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-pycommon-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: 32b52b99ccb90c9c360ecf8360b7cd761786c7db488f7c029866446ac8eff3a1
-  md5: d3e370625987b7251b26cf1eead8c500
+  size: 66636
+  timestamp: 1775549531257
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-pycommon-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: 324b3cce6233c6265b8de0530723c8b4953f4d0e13f731958f1a27c352283b78
+  md5: 3e7348d8e981f3942dfbac76fe1143c2
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-parser
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 27110
-  timestamp: 1769482371986
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-pycommon-4.9.6-np2py312h50b1e4c_15.conda
-  sha256: 01d8ba8cfc6b9ec103a7960fc38952b3feeb3d804730ee0b8cc87d12b6361c6d
-  md5: 686404d159fee384684b569250a7d52a
+  size: 26841
+  timestamp: 1775548648164
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-pycommon-4.9.6-np2py312h50b1e4c_17.conda
+  sha256: af434ce7a615c8795a2765ad094dec5276bf914a9f44a296bda2930009dd40f2
+  md5: 14c519e5b0a5b73a94fb32ae47f86fc5
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-parser
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 27482
-  timestamp: 1769489182601
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-c-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: 62971d039a7181c97bc3f6542d04f6dd77c1d3068c55fa57ba81e88633f13663
-  md5: cf6f96fdf32816b18b5517d9e81bd2fb
+  size: 27442
+  timestamp: 1775549658534
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-c-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: 9895249f8bca1408fc40c1c2e8361b98f0ea50cd9d5bc419efe990cb850ff7d7
+  md5: df39d5771d57bed0dc7512dd020ead21
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 82676
-  timestamp: 1769482384701
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-runtime-c-4.9.6-np2py312h50b1e4c_15.conda
-  sha256: e076e8085c7c6dc61d9178250252ed2da21ec942a945a89bd05f990c08f7bbd9
-  md5: 6d449edb862a80b6deceb77c6fb7f2b4
+  size: 82792
+  timestamp: 1775548659989
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-runtime-c-4.9.6-np2py312h50b1e4c_17.conda
+  sha256: 77333f547901d08e6d59dcc0f7f61cd531a23ff609314913fef4ad512fa87d72
+  md5: 743575f61e1b37bb8f4228dae49e2468
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 77783
-  timestamp: 1769489204308
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-cpp-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: 7facdef1c23941e809c1d77c46d108d71aab4a49ca582023674f754b1b892f7f
-  md5: 018a57582f5e73d052ffcae7925a9969
+  size: 77956
+  timestamp: 1775549671445
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-cpp-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: 1e212a8663d153099ae8b42ef2bd86cbce5e42b166dcedf56438370717408aa5
+  md5: 925258be4a6502e45b177bf7a53e2ea2
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 41058
-  timestamp: 1769482438892
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-runtime-cpp-4.9.6-np2py312h50b1e4c_15.conda
-  sha256: ba3c59efdbd9c6a4670b056b4ff8cdaab00a6d2ccb66f81e020cbdb2102bec14
-  md5: 05dd151411c77519ced4ac9e29885ed0
+  size: 41144
+  timestamp: 1775548717841
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-runtime-cpp-4.9.6-np2py312h50b1e4c_17.conda
+  sha256: 8641455a1250a2d118b3f8285d17fba19af7b9cdd99e7d341ce87fc52211ea44
+  md5: 2ecde65532dddf21b8570e85f7f7c9cf
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libcxx >=18
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 41929
-  timestamp: 1769489306960
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-py-0.14.1-np2py312h2ed9cc7_15.conda
-  sha256: 75d7ab0bf3fcb57830c79ba6f3dd3955046f623185030ec61b074a2e94adfa03
-  md5: 0e96c9b6ac2c491c3594d47965770190
+  size: 42156
+  timestamp: 1775549768404
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-py-0.14.1-np2py312h2ed9cc7_17.conda
+  sha256: de70dfa132c4b75aab5af5383593d5342d60edce8de182d7e58a633efab5197f
+  md5: c110346daab2f2803d28adc964742268
   depends:
   - numpy
   - python
   - pyyaml
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-parser
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 46767
-  timestamp: 1769483337887
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-runtime-py-0.14.1-np2py312h50b1e4c_15.conda
-  sha256: 36f21f64add075c81ef63cf0ff040935b99a53c2dd12eddc7ee9e29dabe34203
-  md5: 8bc4c2392e186e1d78c7f0a3533a064c
+  size: 46744
+  timestamp: 1775549509587
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-runtime-py-0.14.1-np2py312h50b1e4c_17.conda
+  sha256: bfc50f5c6f440970eab95483135e0316c21763dd5e3f74fa5e2319c6b52b76c1
+  md5: a82be1942295553c5a2d69afda0ff3a9
   depends:
   - numpy
   - python
   - pyyaml
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-parser
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 47023
-  timestamp: 1769491508663
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-c-3.3.3-np2py312h2ed9cc7_15.conda
-  sha256: 4978b52e5dd277c80697b93c0ea5aefb843a96a7dd0a5255a0448d3ac6094eb4
-  md5: e5f7438e5838d1dc9b78208adb0950d0
+  size: 47145
+  timestamp: 1775551463998
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-c-3.3.3-np2py312h2ed9cc7_17.conda
+  sha256: 746dec7dddaebe79eb1dca4250fcf0dd0942811d606310f28f6d0ea750bd311a
+  md5: 667a53c6d49455b75fcb31fd8f33563d
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -13933,20 +14071,19 @@ packages:
   - ros-kilted-rosidl-typesupport-fastrtps-c
   - ros-kilted-rosidl-typesupport-interface
   - ros-kilted-rosidl-typesupport-introspection-c
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 50776
-  timestamp: 1769482852546
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-c-3.3.3-np2py312h50b1e4c_15.conda
-  sha256: 1983478b4abe04cbfe7bc7d0c8a0835c0e70be69ac70b25b7ef639a68def8d6d
-  md5: 603578d979529019df91b4dde9f47f15
+  size: 50797
+  timestamp: 1775549027907
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-c-3.3.3-np2py312h50b1e4c_17.conda
+  sha256: c587e9a47a94f15dd2f699e8ae455d94fe87fe78dac1c727b0df129020f421f9
+  md5: 66f782bd213cd4b7cd500764e022d680
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -13961,18 +14098,18 @@ packages:
   - ros-kilted-rosidl-typesupport-fastrtps-c
   - ros-kilted-rosidl-typesupport-interface
   - ros-kilted-rosidl-typesupport-introspection-c
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 50114
-  timestamp: 1769490469282
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-cpp-3.3.3-np2py312h2ed9cc7_15.conda
-  sha256: 43340b30c9ae136342ba941b2df8dcf9a9cb79a6f1de7efa04295544421709ea
-  md5: b60ed66dae675cc741a87fae3ac31dac
+  size: 50270
+  timestamp: 1775550449559
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-cpp-3.3.3-np2py312h2ed9cc7_17.conda
+  sha256: f41bd9ba46669dfd98bf13caccbb944d009f854007b08ce09863f8938dd31905
+  md5: 81236956925f5028d838f80f5b33cb61
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -13990,20 +14127,19 @@ packages:
   - ros-kilted-rosidl-typesupport-fastrtps-cpp
   - ros-kilted-rosidl-typesupport-interface
   - ros-kilted-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 49871
-  timestamp: 1769482907754
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-cpp-3.3.3-np2py312h50b1e4c_15.conda
-  sha256: 50ed5af56026ba67f230f7a1a65aeb7038f8391b09a4cab58898d3c176ae0d94
-  md5: f4dcdc5ae756a4a40969e7b64b3ad33b
+  size: 49934
+  timestamp: 1775549093601
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-cpp-3.3.3-np2py312h50b1e4c_17.conda
+  sha256: c6633870fb3cdc4ede3f608c537b5ef692a0109d1e017d69216ee7ddb4fa2197
+  md5: e1c5d3aaee9e3830dfc1f9bfaaf40735
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -14021,18 +14157,18 @@ packages:
   - ros-kilted-rosidl-typesupport-fastrtps-cpp
   - ros-kilted-rosidl-typesupport-interface
   - ros-kilted-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - __osx >=11.0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 49413
-  timestamp: 1769490530384
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-fastrtps-c-3.8.2-np2py312h2ed9cc7_15.conda
-  sha256: 6bfffbb1b9ccf318bb6b140393371ed11f42b708e2694291c2872e8e2c90f0ac
-  md5: 7b7fa115106e75675e30b6b127c3c190
+  size: 49475
+  timestamp: 1775550522768
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-fastrtps-c-3.8.2-np2py312h2ed9cc7_17.conda
+  sha256: 57fe83272bfa784aa6dac676af296ef4b2ce7508e185908c909f16f0b43f2397
+  md5: 52d1acb9c41365ae860755583f11bc7b
   depends:
   - python
   - ros-kilted-ament-cmake-ros-core
@@ -14047,20 +14183,19 @@ packages:
   - ros-kilted-rosidl-runtime-cpp
   - ros-kilted-rosidl-typesupport-fastrtps-cpp
   - ros-kilted-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 51489
-  timestamp: 1769482816210
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-fastrtps-c-3.8.2-np2py312h50b1e4c_15.conda
-  sha256: a755a5b1016fa3e7abf3c7d0fc937bb0e9be75a3c63e32d91bfbf422b1a6dbef
-  md5: 7722eb866011a0f2b262d8643719c2dd
+  size: 51519
+  timestamp: 1775549000182
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-fastrtps-c-3.8.2-np2py312h50b1e4c_17.conda
+  sha256: b0fc09c786d1becda115d50f901f57dc33af911349b3f0697af7f83a7ced00a6
+  md5: 22e6387f7dea20c767a42aa59622e9a2
   depends:
   - python
   - ros-kilted-ament-cmake-ros-core
@@ -14075,18 +14210,18 @@ packages:
   - ros-kilted-rosidl-runtime-cpp
   - ros-kilted-rosidl-typesupport-fastrtps-cpp
   - ros-kilted-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 51160
-  timestamp: 1769490265547
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-fastrtps-cpp-3.8.2-np2py312h2ed9cc7_15.conda
-  sha256: d45a2ca6c6cd2d9f02148ba480db02f69830fc96b3299dd1beb75187d0ea4815
-  md5: 1a2843a4d4325daa7a5fe3d5f83a71c6
+  size: 51398
+  timestamp: 1775550250031
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-fastrtps-cpp-3.8.2-np2py312h2ed9cc7_17.conda
+  sha256: 68798d8d7a2abaa7c0c18cbb8469b0fbaea4c94a88fdbb9b101262d68ed00265
+  md5: 91f82320477325e3969f24d7cfebbb49
   depends:
   - python
   - ros-kilted-ament-cmake-ros-core
@@ -14101,20 +14236,19 @@ packages:
   - ros-kilted-rosidl-runtime-c
   - ros-kilted-rosidl-runtime-cpp
   - ros-kilted-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 53533
-  timestamp: 1769482716985
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-fastrtps-cpp-3.8.2-np2py312h50b1e4c_15.conda
-  sha256: 96054d95979416d0ddf5e4c0a0c5f9f9bf6a40840d60bfa3bf9912f80038ed3e
-  md5: 5fc9cd8acadc0f9335ef485a49723a37
+  size: 53575
+  timestamp: 1775548946298
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-fastrtps-cpp-3.8.2-np2py312h50b1e4c_17.conda
+  sha256: a464629c9df7ce95d5e393db5848d12abc1130a8dac600dc24986bfdb09b92db
+  md5: 407b8ce37d72cfba820b57f9323dfbeb
   depends:
   - python
   - ros-kilted-ament-cmake-ros-core
@@ -14129,50 +14263,49 @@ packages:
   - ros-kilted-rosidl-runtime-c
   - ros-kilted-rosidl-runtime-cpp
   - ros-kilted-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 53022
-  timestamp: 1769490035447
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-interface-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: 98774d0ef51368f0ef9f57d59a4d61e95443dc3f0f484de18e132e88f37acf0e
-  md5: 308c601ff98fdc30a46a589c65b9c754
+  size: 53198
+  timestamp: 1775550130543
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-interface-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: 1fab34e62e88ad7862e32a5be615730e6168e73c75396a73e07883a243f6f9e4
+  md5: e0db7d98c1123de149deae7183970f11
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 29404
-  timestamp: 1769481910931
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-interface-4.9.6-np2py312h50b1e4c_15.conda
-  sha256: 326f69d7a5bdfdb17fd18dfacad18d893535e614eb8b7e14b7f358a27ba00673
-  md5: 098483e9a2e0df36ffe5a62160b05d7e
+  size: 29511
+  timestamp: 1775548197735
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-interface-4.9.6-np2py312h50b1e4c_17.conda
+  sha256: 7a277852bf36501f677d2f7df288d479fedd38f06881ed3d18063527e5d2b07b
+  md5: 0071229287617b086a50f4bee3a6191a
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 29731
-  timestamp: 1769488313681
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-introspection-c-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: 8b619c01e76ac83e0ac2edcfa911cc823845c9f0931f2deff36f86a625e9300a
-  md5: 2a6f5e96388cdb7c8e0e836564833a84
+  size: 29937
+  timestamp: 1775549199527
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-introspection-c-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: f7265f55f768118f4c5342fad729a0afc18a0986d24d9fb5b0f068a88c62f1c4
+  md5: be8495e2538e03c4b023fd2fd2188f24
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -14185,20 +14318,19 @@ packages:
   - ros-kilted-rosidl-pycommon
   - ros-kilted-rosidl-runtime-c
   - ros-kilted-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 46962
-  timestamp: 1769482622127
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-introspection-c-4.9.6-np2py312h50b1e4c_15.conda
-  sha256: 5bcfdccef18bf280163d20b5509e78e6c1e3bd2e3eb5e704ac7e64706faca217
-  md5: 81a5e7cd889996d95498a67c2bbc5e24
+  size: 47093
+  timestamp: 1775548878046
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-introspection-c-4.9.6-np2py312h50b1e4c_17.conda
+  sha256: a8739187a0a7047c4b9eaf66707c86c0d7379d62b9658aa469af6758e018d62d
+  md5: 96ef13b511ca4fbf573786fae47990e2
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -14211,18 +14343,18 @@ packages:
   - ros-kilted-rosidl-pycommon
   - ros-kilted-rosidl-runtime-c
   - ros-kilted-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __osx >=11.0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 46781
-  timestamp: 1769489862111
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-introspection-cpp-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: a8cc5cd4b6591d3743fa6c9bf25d2d841c9ab1a27629d677ce8454d198b6374a
-  md5: eccb9878cf4c7c550f102be51a0cff31
+  size: 46951
+  timestamp: 1775550033813
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-introspection-cpp-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: 2201ef93ab02874a424d0ade7a85b2105c8a32e6aad667f9407d65d0c11ee473
+  md5: 0e0bdcff89c23360de7dbb0050baba5b
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -14238,19 +14370,19 @@ packages:
   - ros-kilted-rosidl-runtime-cpp
   - ros-kilted-rosidl-typesupport-interface
   - ros-kilted-rosidl-typesupport-introspection-c
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 47249
-  timestamp: 1769482735677
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-introspection-cpp-4.9.6-np2py312h50b1e4c_15.conda
-  sha256: c7506682aa9aa9b8cf954ded3da97e50d2c77d0f932a706f8d645d9392eacf8b
-  md5: 1649a5a758551e650247501ed1548d9a
+  size: 47348
+  timestamp: 1775548959858
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rosidl-typesupport-introspection-cpp-4.9.6-np2py312h50b1e4c_17.conda
+  sha256: cab3fceb4f233406159606de7d18409fce0f89f3fbf996dac34f78b01186c5aa
+  md5: 2b4152b0f5fea61a6ae3147ae28546aa
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -14266,83 +14398,82 @@ packages:
   - ros-kilted-rosidl-runtime-cpp
   - ros-kilted-rosidl-typesupport-interface
   - ros-kilted-rosidl-typesupport-introspection-c
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - python_abi 3.12.* *_cp312
+  - __osx >=11.0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 47046
-  timestamp: 1769490079898
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rpyutils-0.6.3-np2py312h2ed9cc7_15.conda
-  sha256: 3a75d028d115e404d9e4bbddf3c5c3a3b1f3ff317eb3bf5c45aea4a95c62372e
-  md5: 3f46db697e7dd8933ddcc300bea39db1
+  size: 47210
+  timestamp: 1775550156798
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rpyutils-0.6.3-np2py312h2ed9cc7_17.conda
+  sha256: f2b57bf7c1c6ac318b46687afd7421eabaa0ff6cbe02edceeacef3750eface68
+  md5: 5fe497cec126cde31afc98eb26101c2b
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 27556
-  timestamp: 1769481316939
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rpyutils-0.6.3-np2py312h50b1e4c_15.conda
-  sha256: ab877260c867b7a27b69ea981dc3b34317a7cc65ac2bc9b75de36c05f94089dd
-  md5: 0a79c8a149beaee90a3bfde9a96bbd0c
+  size: 27300
+  timestamp: 1775547588505
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rpyutils-0.6.3-np2py312h50b1e4c_17.conda
+  sha256: 25d1cd59aab509cf295a7b62ab8a88720eaf2ccd30874b1aa9ce39d4ef571a3c
+  md5: 1356f0b03b1c767b81fdd0b499fcb12f
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - libcxx >=18
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 27916
-  timestamp: 1769487391455
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rti-connext-dds-cmake-module-1.1.1-np2py312h2ed9cc7_15.conda
-  sha256: 7ee327a74010f94bbff865fe6442fdf272b645ef6220d98676ef5a66113a0139
-  md5: 0e85abfc01ee7d8bab1d9b5c72f2850e
+  size: 27898
+  timestamp: 1775548237669
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-rti-connext-dds-cmake-module-1.1.1-np2py312h2ed9cc7_17.conda
+  sha256: 702753c3e50332b0d5e66abfec0d5823d16cad05a73a263b7e93606d0ddb11a4
+  md5: e708387f4b1310725ef002e757a76c9e
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 31691
-  timestamp: 1769482237058
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rti-connext-dds-cmake-module-1.1.1-np2py312h50b1e4c_15.conda
-  sha256: abc096580a92aac85ed5a8eae8787502c801d95983a27d33d2769dcb9af9e303
-  md5: 1bbaf1076d79abf13bc4673b794b02a1
+  size: 31800
+  timestamp: 1775548531328
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-rti-connext-dds-cmake-module-1.1.1-np2py312h50b1e4c_17.conda
+  sha256: d007faa54d304acd467422f7673e60a3c3d5820c035a1cb2d62de3c3cd85a361
+  md5: fecd84b579a86cfeca9453ae4a121a81
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 32016
-  timestamp: 1769488688689
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-sensor-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: c4926f585c45a84e1fbb67d9100c35205551a98d2c4eea20bd6814025a33c9af
-  md5: b722f712ccf4594e768b8d7cce61dabb
+  size: 32244
+  timestamp: 1775549442095
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-sensor-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: 916ae0e718b4b379b109ebba85672388fc4019dbbbadb39f43e647250ce0ddf6
+  md5: 3d62cbc0fe34432ba29e0fac7bbe52cd
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -14350,21 +14481,21 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
   purls:
   - pkg:pypi/sensor_msgs?source=project-defined-mapping
-  size: 547407
-  timestamp: 1769483569069
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-sensor-msgs-5.5.1-np2py312h50b1e4c_15.conda
-  sha256: f55a42456950ad9723a947b2bf90cacb13732fa69cc6b2993b863067f495dc19
-  md5: 51dbc33622af85f4a4c36d55a4fb3349
+  size: 559852
+  timestamp: 1775549739340
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-sensor-msgs-5.5.2-np2py312h50b1e4c_17.conda
+  sha256: 30ee14d0c434779cb95c3ec0431f1c94dd03105e5b07689785265469cc78548b
+  md5: 148747ae26bec2703e7ff3391b631255
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -14372,132 +14503,129 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
   purls:
   - pkg:pypi/sensor_msgs?source=project-defined-mapping
-  size: 466183
-  timestamp: 1769492399240
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-service-msgs-2.3.0-np2py312h2ed9cc7_15.conda
-  sha256: d296a9850fea6bc2bd3b0311cb650f15995088585737d7d65b0640aa4a727d75
-  md5: 062fe0b07be95d751d788a904d7458c8
+  size: 478729
+  timestamp: 1775551977724
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-service-msgs-2.3.1-np2py312h2ed9cc7_17.conda
+  sha256: be21a42f1d0f20b707137a5c49aba972a2a8f3e19b43f9fa6908bb6d49713350
+  md5: 4244444b56603cd22565e4131e90b46a
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 78656
-  timestamp: 1769483003435
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-service-msgs-2.3.0-np2py312h50b1e4c_15.conda
-  sha256: 64de564e6b410ba9602417d7d131aa92f27e5f09c923c6bacd8552b14c6d9c5b
-  md5: bc143d5a47106715bef7565beecef820
+  size: 80039
+  timestamp: 1775549210336
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-service-msgs-2.3.1-np2py312h50b1e4c_17.conda
+  sha256: 6017eb086f9f5240167ce39f9761b07c216a5cdecd135e11dde28d7b6b054c5e
+  md5: 28903a964e3d48dbe1a4350097d5bdea
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
+  - __osx >=11.0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 76101
-  timestamp: 1769490756014
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-shape-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: 41f673feff322149bf69a1068a5bb016f5cfff907d54b08280f1f29ad7703e8a
-  md5: b4ea50e647448df92d0cde15a0a13c4a
+  size: 78192
+  timestamp: 1775550725530
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-shape-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: 73e1e7fd0a38ecd4a38f5d0b44e1ba12cb95615ac4d71ff7661e8ff7f26d650e
+  md5: 0e4b7c26fae15dfe21a957d732933c97
   depends:
   - python
   - ros-kilted-geometry-msgs
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 125384
-  timestamp: 1769483539253
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-shape-msgs-5.5.1-np2py312h50b1e4c_15.conda
-  sha256: f5b92303be5db5a24537cd383cea3a64ecea26cec88a1092b12de871b4cd5b59
-  md5: 87348daa1a7f9bc7a79cccfe1772e812
+  size: 128975
+  timestamp: 1775549715986
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-shape-msgs-5.5.2-np2py312h50b1e4c_17.conda
+  sha256: 06991ee72e088841583593dbde84bcc4b2953898d4a88f4372db764a6d78a540
+  md5: 0c80906fae2c0c0dc6ada7d291c256df
   depends:
   - python
   - ros-kilted-geometry-msgs
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __osx >=11.0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 116593
-  timestamp: 1769492263164
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-spdlog-vendor-1.7.0-np2py312h918b84f_15.conda
-  sha256: b33654e8fa4bc61d1badfbbd2610106aa5b930553b3ea3f208fc4352dcf59df9
-  md5: 29394bc532205f32ff9281e2ac4d39bc
+  size: 119540
+  timestamp: 1775551981442
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-spdlog-vendor-1.7.0-np2py312h918b84f_17.conda
+  sha256: 6ce4e9d274ba5b92d4d8207604143bb48072836e2668743e3ead339abf3d2e1f
+  md5: db38ceaef47d42c992bdb986aae6eeb1
   depends:
   - fmt
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - spdlog
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - spdlog >=1.17.0,<1.18.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - fmt >=12.1.0,<12.2.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - spdlog >=1.17.0,<1.18.0a0
   license: Apache-2.0 OR MIT
-  size: 27438
-  timestamp: 1769482254517
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-spdlog-vendor-1.7.0-np2py312h13c16a8_15.conda
-  sha256: 679d791793f3273f427f93d4d4d3d0f5fbe9e2bfd7a7dc6be4b00a1d1746ffce
-  md5: 1adb5ab6462615cf34d69a84966f8d0f
+  size: 27520
+  timestamp: 1775548550496
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-spdlog-vendor-1.7.0-np2py312h13c16a8_17.conda
+  sha256: bdfa6061f2b371e293f6c59922b6ebe0bbd9f479259f3df86d14a05346037ae8
+  md5: 74b8eb418a291885dd2f3650c0863551
   depends:
   - fmt
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - spdlog
   - __osx >=11.0
   - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - fmt >=12.1.0,<12.2.0a0
   - spdlog >=1.17.0,<1.18.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0 OR MIT
-  size: 27789
-  timestamp: 1769488721403
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-sros2-0.15.4-np2py312h2ed9cc7_15.conda
-  sha256: 72316caa2d04a7fe7097f9a95b468d9243e5a751a184cd3133d1d8df351b4623
-  md5: d9ff57e62399a9c8acdb7d5893df56cf
+  size: 27969
+  timestamp: 1775549476900
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-sros2-0.15.5-np2py312h2ed9cc7_17.conda
+  sha256: 487cd97d6dd5944aa22a0e49b34f6ce886dbfc97a2b5ba7a6a8ff1b85d79c512
+  md5: 3a486c2d5c53aa9238e0fb40614a4bf3
   depends:
   - argcomplete
   - cryptography
@@ -14507,20 +14635,19 @@ packages:
   - ros-kilted-rclpy
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 74456
-  timestamp: 1769486240589
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-sros2-0.15.4-np2py312h50b1e4c_15.conda
-  sha256: 4a84b0d64a71c55c724639cbbaf8db00c03cde8d446fef579a2d74ac0519425a
-  md5: f49fc3d25398244ef5d31540a81b0fa3
+  size: 74553
+  timestamp: 1775602764502
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-sros2-0.15.5-np2py312h50b1e4c_17.conda
+  sha256: 18c9c9af31900c9e3cdd72a52f2374881309791de33cb3a178b0225f4ec20717
+  md5: 4b1eeee98a7725fbf8a1e36d600b07c0
   depends:
   - argcomplete
   - cryptography
@@ -14530,199 +14657,197 @@ packages:
   - ros-kilted-rclpy
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libcxx >=18
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 73423
-  timestamp: 1769500450526
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-sros2-cmake-0.15.4-np2py312h2ed9cc7_15.conda
-  sha256: c2bedf4db0bfdcc102d6c8b1b275ef9bdfab66e28ae451f97788bb31709f0100
-  md5: 3c8c59485dbb9ee1154a7e83bff8dfd7
+  size: 73545
+  timestamp: 1775558467693
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-sros2-cmake-0.15.5-np2py312h2ed9cc7_17.conda
+  sha256: f651799c27d41bdedeaa0ffac152dddc14419f614b16d74f8f0d4bc5cc7564e3
+  md5: 20b2702d5bab44c11f4bea5a54d2f80f
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-sros2
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 36917
-  timestamp: 1769486535351
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-sros2-cmake-0.15.4-np2py312h50b1e4c_15.conda
-  sha256: 5de7fa00852f64c71609888f1f60d5952286e2753a68b5a293d7743ce078f6e7
-  md5: 32330ba0b79748f88bf5ad3d91c9f5f3
+  size: 37168
+  timestamp: 1775603172427
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-sros2-cmake-0.15.5-np2py312h50b1e4c_17.conda
+  sha256: 414bbfbf209078284c9e0f47117b18c1f2b65021c4fc204ab58fb0beb6d86193
+  md5: 16a4ff6082ef1e953dd65f0d5cff0878
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-sros2
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
+  - libcxx >=18
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 36748
-  timestamp: 1769501270606
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-statistics-msgs-2.3.0-np2py312h2ed9cc7_15.conda
-  sha256: 64f8240a1b5e5d59babcf099b19c671524a79e849b915be271333d204c30ace6
-  md5: 34c83ff7f48c1a8ee741273663c282fe
+  size: 37007
+  timestamp: 1775558891970
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-statistics-msgs-2.3.1-np2py312h2ed9cc7_17.conda
+  sha256: 13f723839f97ef913c8f7f9e4030d7d1b20535639d008e76469e78b1802852c2
+  md5: beb39a19ee3bce988c9b73b732a2ad6d
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 108998
-  timestamp: 1769483297417
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-statistics-msgs-2.3.0-np2py312h50b1e4c_15.conda
-  sha256: ffc3d204890de704b0f0d2c5f418b36af11d51fdbd7855f2002b623b57c1a158
-  md5: c569dc6effac8355bb97025b9c4934c0
+  size: 111690
+  timestamp: 1775549474470
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-statistics-msgs-2.3.1-np2py312h50b1e4c_17.conda
+  sha256: 3d389956ad018df1d44093bec25dd852698dedccf3fd0649590d6ccfa46d9d2a
+  md5: b3cee611af574a8ed54037445c1fa376
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 101557
-  timestamp: 1769491381053
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-std-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: 42c4c74ec8da4d3a445d53b15282b0619a8aaaa90bf052530ee1431149ecd6c1
-  md5: b43fa15f4a99e3262b5dd1f3fb36c0fb
+  size: 104385
+  timestamp: 1775551238042
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-std-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: 45cdf7dafbfbea19445011ec1ec28c7abb348418e7eb62b215789c50d61a1131
+  md5: ea31fec6f7573829595007b1f584a588
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
   purls:
   - pkg:pypi/std_msgs?source=project-defined-mapping
-  size: 339229
-  timestamp: 1769483254088
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-std-msgs-5.5.1-np2py312h50b1e4c_15.conda
-  sha256: c93529e81e7efee595e1a1b92974c15fe8efba18c67dbbc2a7dd3f4261b812f7
-  md5: b804f708ca0bdcd323a579daa566ae2e
+  size: 346071
+  timestamp: 1775549436612
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-std-msgs-5.5.2-np2py312h50b1e4c_17.conda
+  sha256: ae799610444061af0803d9fb0092f4ec66b84061763cfac25e981c5afee7a402
+  md5: 6c65f6860444a30ba296f7759c4dd83f
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
+  - __osx >=11.0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
   purls:
   - pkg:pypi/std_msgs?source=project-defined-mapping
-  size: 285978
-  timestamp: 1769491295873
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-std-srvs-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: b86b61ebdfb8f479d8a1c44b011deb4bfdccba6b09f3c6ed1b61cc91ef42b8bb
-  md5: 1898d1ab56a921fbe9f09921d5ab952f
+  size: 292581
+  timestamp: 1775551160125
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-std-srvs-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: 81b13f1c7681c1856c139a4018f58ac384eb47622f80b69224261a49a96ef401
+  md5: cde75201099bd1f2904b9b15be072d50
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 168026
-  timestamp: 1769483160456
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-std-srvs-5.5.1-np2py312h50b1e4c_15.conda
-  sha256: 7cff674739b0aeb7a70b7691561a7a6ea2d4d4294a904ad88b968ee21f9f0bd7
-  md5: f115ade01950946ecd716a8f03c90fb7
+  size: 170866
+  timestamp: 1775549362675
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-std-srvs-5.5.2-np2py312h50b1e4c_17.conda
+  sha256: 5c403b2f42b194df90543de95c059323a6093105c17a3d4b935c5653bfa7735c
+  md5: 8eaa81fff1fd25887bf15118933680f4
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 150394
-  timestamp: 1769491158908
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-stereo-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: 393187a5ee7a567f0ef673cfb847b5ad1716aa7064fee0c5cd23a2d2468c1041
-  md5: e93999a96851bf91e74537effb4591e1
+  size: 153287
+  timestamp: 1775551045956
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-stereo-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: 5449b1de2dd5adccbf3c6b304d6bdb97e74860d026e2a114c1241f7700793173
+  md5: e2daa3ce82eb5223db9c7f0f6fb8cabb
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-sensor-msgs
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 81773
-  timestamp: 1769483909956
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-stereo-msgs-5.5.1-np2py312h50b1e4c_15.conda
-  sha256: f01d6c239339e677f4a8a692d28c8b9053e1f832d385c263293e7c50af779c9d
-  md5: 8205ee62b02daa598c42c550fbaa9773
+  size: 83956
+  timestamp: 1775550103727
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-stereo-msgs-5.5.2-np2py312h50b1e4c_17.conda
+  sha256: e00d44c11819a68e1b20b2637a53ab1d02ffb1b0ce4b93c7065688f3160f3320
+  md5: 99453ffcfa2c0e31cdca54cc0b8928f2
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-sensor-msgs
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
+  - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 79508
-  timestamp: 1769493037028
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tf2-0.41.6-np2py312h2ed9cc7_15.conda
-  sha256: 4426db48ff1533b7fd9c336ebb0d2ccaa0280631d00523e454ca683621a5bb47
-  md5: d75437970e2934dc81eaf091e5cc4ec2
+  size: 81635
+  timestamp: 1775552596197
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tf2-0.41.6-np2py312h2ed9cc7_17.conda
+  sha256: 6f8996909cccea8c4fa2c980aab2578770b96c832165dbb135aecc71aacc89b8
+  md5: 31b570b9d2f30aa2cb2ced390d130bcd
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -14730,19 +14855,19 @@ packages:
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 136669
-  timestamp: 1769484361363
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tf2-0.41.6-np2py312h50b1e4c_15.conda
-  sha256: 12e4e062939114f0738d3627c53244b95fcba792fc879d18d67a229938a4c051
-  md5: 2dff031eca964005a3f92fc26f5aab6e
+  size: 136865
+  timestamp: 1775550549013
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tf2-0.41.6-np2py312h50b1e4c_17.conda
+  sha256: 35db80c95d49debaee72903432a41f0330fcc9e27dbb59cc5249b5363e7b117d
+  md5: 8e65f0d1ef1c8e59464de663be756149
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -14750,56 +14875,55 @@ packages:
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 124511
-  timestamp: 1769494017939
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tf2-msgs-0.41.6-np2py312h2ed9cc7_15.conda
-  sha256: 0353225b0e0b525f2dbf60e0a0c1c18823027ef3fa83ceb9637a9776a4453a48
-  md5: fefa2ba2abaac62c628ef300196e9b57
+  size: 124878
+  timestamp: 1775553360428
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tf2-msgs-0.41.6-np2py312h2ed9cc7_17.conda
+  sha256: dfde05dff89a0ef8b4768fbb8ba09ddd67fca0d8dbb78e38960b81096a655c36
+  md5: 3a0c11422932906d44c3c0f8b606868a
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-geometry-msgs
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 257119
-  timestamp: 1769483520948
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tf2-msgs-0.41.6-np2py312h50b1e4c_15.conda
-  sha256: 9e0e42bb6f85b6a3013f49559650c3210a12936641fe2a6abe592d07c2f9aa0b
-  md5: 2affa4ee9bed59cf1c80f48034cff588
+  size: 262647
+  timestamp: 1775549695165
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tf2-msgs-0.41.6-np2py312h50b1e4c_17.conda
+  sha256: f4991169fb2a5a89af2e84dc6cebd17b426ff192407a709ef94a8259cede4710
+  md5: c1bf4669f46cfc0670a69d1d4566aa08
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-geometry-msgs
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libcxx >=18
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
+  - libcxx >=18
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
-  size: 227466
-  timestamp: 1769492206202
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tf2-py-0.41.6-np2py312h2ed9cc7_15.conda
-  sha256: e7024c02667f385a4fafc75217786cab04c54a1b045a09631c11757841f6795c
-  md5: bb5308a0a66ce79c3b0228e68e1adf22
+  size: 232932
+  timestamp: 1775551944583
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tf2-py-0.41.6-np2py312h2ed9cc7_17.conda
+  sha256: aa7905ea35c876fcef47ade40f5657d94794e4b32eaa78aed9cbd85e23c90ab3
+  md5: 59ed4f9799d5240026f86e0863541cec
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -14808,20 +14932,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rpyutils
   - ros-kilted-tf2
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 58183
-  timestamp: 1769485080772
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tf2-py-0.41.6-np2py312h50b1e4c_15.conda
-  sha256: 332fb0e0707fb19591e31b6fdeb6021afd008019cb06a48a670a3d6d9d8d7196
-  md5: 86648e22b5b4ee838a47e83a015b28bd
+  size: 58402
+  timestamp: 1775551287371
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tf2-py-0.41.6-np2py312h50b1e4c_17.conda
+  sha256: 83d24e4e8df17050676cd3a64cd234ed6ecdb501a5c85348958817623e04c2ab
+  md5: b46a38fceb6ddfb950217e0aaee551cd
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -14830,18 +14953,18 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rpyutils
   - ros-kilted-tf2
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __osx >=11.0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 50485
-  timestamp: 1769495379349
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tf2-ros-0.41.6-np2py312h2ed9cc7_15.conda
-  sha256: 7df967525743aa81ceede8ca3094e25903fb1c9b273f4aed81c0bad7e362c16e
-  md5: 41520013813a7dd61d019521a2cffda0
+  size: 50769
+  timestamp: 1775554908803
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tf2-ros-0.41.6-np2py312h2ed9cc7_17.conda
+  sha256: 5756d1a1b0f0fe143b0628f9c8d96f2e9ad599b3cf1aa118e876591b9a77e57e
+  md5: 08c78fda72d7110881b9b3618d132dba
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -14854,20 +14977,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-tf2
   - ros-kilted-tf2-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
   - libgcc >=14
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 467234
-  timestamp: 1769485587108
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tf2-ros-0.41.6-np2py312h50b1e4c_15.conda
-  sha256: 6425b339c54e3b38121b744a451296b4d64a864100223aac07ec62a7315b45a2
-  md5: e216a6bdc48d672dc0ced058a7e0a0e8
+  size: 467561
+  timestamp: 1775552002735
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tf2-ros-0.41.6-np2py312h50b1e4c_17.conda
+  sha256: 8f3ae0e95f546e7e1464bbbd38ab189e2c5fe97c4fce71d57613f2eea1a67b81
+  md5: f88ee8448bae12c454821466483e18aa
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -14880,18 +15002,18 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-tf2
   - ros-kilted-tf2-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 332414
-  timestamp: 1769497463567
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tf2-ros-py-0.41.6-np2py312h2ed9cc7_15.conda
-  sha256: 06152bb6e22f1cf6300417e08388b475bb2bfed72869bcdfd072e63453c32c19
-  md5: 3ec772c6a3b77ac5ca62a0ca0a9c2a64
+  size: 332805
+  timestamp: 1775556491961
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tf2-ros-py-0.41.6-np2py312h2ed9cc7_17.conda
+  sha256: 0e3f08946eb176f09efdfebaf563fb08832daf2898eeab71e0d3f5c792e3c872
+  md5: ab6931a9db4f86fe526f1b1f838f9a10
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -14902,19 +15024,19 @@ packages:
   - ros-kilted-std-msgs
   - ros-kilted-tf2-msgs
   - ros-kilted-tf2-py
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 49085
-  timestamp: 1769485272336
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tf2-ros-py-0.41.6-np2py312h50b1e4c_15.conda
-  sha256: d21b3c734ba73998a6d1f9414a5c6780a6cfbbb9d3640505b83fe37274cbb8ab
-  md5: 1739e1a60e32990ed00db4cfd63f9e0e
+  size: 49143
+  timestamp: 1775551655268
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tf2-ros-py-0.41.6-np2py312h50b1e4c_17.conda
+  sha256: 2364f28d88c6d98e5c82ab596ce50115ff32d6eeb6989f82a225f44c24e0e639
+  md5: eded91eb90df32d55ef4eb08658f44de
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -14925,87 +15047,86 @@ packages:
   - ros-kilted-std-msgs
   - ros-kilted-tf2-msgs
   - ros-kilted-tf2-py
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 49446
-  timestamp: 1769496150036
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tinyxml2-vendor-0.10.1-np2py312h2ed9cc7_15.conda
-  sha256: 9a380496ccb6bcd409ed31aed29d922540edf334da9582ced959ba4dbaf4c056
-  md5: 3e60e3276f0e46cdbcf2cdc8af8ba9bb
+  size: 49475
+  timestamp: 1775555724535
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tinyxml2-vendor-0.10.1-np2py312h2ed9cc7_17.conda
+  sha256: 08c70fa04422722a87f2419126983f9a398230238047be913cf86a6ed51ba25b
+  md5: a473818310e452e8e9863ac2855e6360
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - tinyxml2
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - tinyxml2 >=11.0.0,<11.1.0a0
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 24855
-  timestamp: 1769481229257
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tinyxml2-vendor-0.10.1-np2py312h50b1e4c_15.conda
-  sha256: d3fda2c4fe36936539d1d7c9d4e260b81b3beb6e8f1d6a69bdd367bd5b01c7b3
-  md5: 7eca0e90e4c2b23b3b544d02c856e017
+  size: 24783
+  timestamp: 1775547438429
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tinyxml2-vendor-0.10.1-np2py312h50b1e4c_17.conda
+  sha256: e50a5c4818b94a2c26f2c15acbce9cc01012e0dbf0bc576534d4cb811c6cc261
+  md5: 4f17630faafe74a03a86a8c853bca30c
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - tinyxml2
-  - __osx >=11.0
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - __osx >=11.0
   - tinyxml2 >=11.0.0,<11.1.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 25477
-  timestamp: 1769481982223
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tracetools-8.6.0-np2py312h2ed9cc7_15.conda
-  sha256: cd49380f0231563273d7b2b74ae3235dabe64d2cbc1a83b4e67785c34afdbce5
-  md5: 9ce955faabad6097ffd847b986c313a6
+  size: 25624
+  timestamp: 1775548080058
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-tracetools-8.6.0-np2py312h2ed9cc7_17.conda
+  sha256: 9f48c07d31ae6b3006380b496457b53d1b99b5d12cd7378be48d585a20315634
+  md5: c3e695824ffe01938410661abea237b7
   depends:
   - lttng-ust
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   - lttng-ust >=2.13.9,<2.14.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 76254
-  timestamp: 1769482314136
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tracetools-8.6.0-np2py312h50b1e4c_15.conda
-  sha256: b0f96c49e92cee95e12ca86b352fe5fde904178c15854c200cd777915a80e991
-  md5: 170971026b1bf370edabe979240427b5
+  size: 76346
+  timestamp: 1775548593677
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-tracetools-8.6.0-np2py312h50b1e4c_17.conda
+  sha256: 2ef0ea638b6a6c20e3a678c414e8097d201ea45a469a5d0883c99efb8c1be3c0
+  md5: 133b1f6291dc020473a75b44fb1deb20
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 34477
-  timestamp: 1769489105304
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-trajectory-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: f4be2ab368049eb4e1daa33efc8303e23222a4937a96a952e27090290424cbaa
-  md5: 21993146f7a41ca3e0fc104635c3dce6
+  size: 34740
+  timestamp: 1775549573089
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-trajectory-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: fe6ebb7b00093a6c8999df0db06d06e0098c51a0d3fc879c2b7d53294a3ea6c8
+  md5: 6ac65657c02fa4898618dc8dc48b0c72
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -15013,19 +15134,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 148135
-  timestamp: 1769483622608
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-trajectory-msgs-5.5.1-np2py312h50b1e4c_15.conda
-  sha256: 1ae785ed944730cec8b2733d3681206c7adf16f9d637c92ecda9228c028e8124
-  md5: c9e9d2e042ff3050774a5eb9c6ad70c4
+  size: 151655
+  timestamp: 1775549794297
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-trajectory-msgs-5.5.2-np2py312h50b1e4c_17.conda
+  sha256: b49bef2ffe315782bcc454d111d7788a8302cd488061750221fcb9f6d32425d4
+  md5: a7b067458e95358edb540bcaa909dfa5
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -15033,123 +15154,121 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 132138
-  timestamp: 1769492496536
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-type-description-interfaces-2.3.0-np2py312h2ed9cc7_15.conda
-  sha256: 3f95072511a525047578375234c3294e68cf4cbda58f11399102fad56278f328
-  md5: 06d29b78a2456161e1885c8f6a516027
+  size: 135216
+  timestamp: 1775552089500
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-type-description-interfaces-2.3.1-np2py312h2ed9cc7_17.conda
+  sha256: 9512668d66b1e0199575324e44521f2df06d34f0449379f4c1734b28a02e33ef
+  md5: f778a5a8f1f134b668307f49c514da49
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-runtime
   - ros-kilted-service-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 231650
-  timestamp: 1769483041168
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-type-description-interfaces-2.3.0-np2py312h50b1e4c_15.conda
-  sha256: 59ed113265d1f31b60da91338f77b585ede1714c4fb4019b1891fe16b8513ea0
-  md5: dfb3e5fc35a154ab1fc7b7321f9c6eaa
+  size: 238904
+  timestamp: 1775549253022
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-type-description-interfaces-2.3.1-np2py312h50b1e4c_17.conda
+  sha256: a4add2a3ed4d8c17315fe410c997e67631af3f13d0e0079033be1f872ae767e0
+  md5: aa0270488b46f2d69f472c5da719620d
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-runtime
   - ros-kilted-service-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 203830
-  timestamp: 1769490869184
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-uncrustify-vendor-3.1.0-np2py312h2ed9cc7_15.conda
-  sha256: 5f16f44a386f76d3f19f53e3c7fba9b725ea0da9d112301ffdea4a31fb5e4319
-  md5: b11182b2740e933097cd1c47567c4468
+  size: 209021
+  timestamp: 1775550827741
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-uncrustify-vendor-3.1.0-np2py312h2ed9cc7_17.conda
+  sha256: f98e582d0075803efd6abd804e9bf878ad1e73f022da697e80c650fe91c61f78
+  md5: f4482bcc85149c765462a18568586813
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - uncrustify
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - uncrustify >=0.81.0,<0.82.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0 OR GPL-2.0-only
-  size: 23220
-  timestamp: 1769481210362
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-uncrustify-vendor-3.1.0-np2py312h50b1e4c_15.conda
-  sha256: 76fa77458de01f2fd09cb43d37d8cf12b65467f5d0bb6966c6719808c7073d2e
-  md5: 836285bc799d00fe48aa046fc7327652
+  size: 23181
+  timestamp: 1775547450582
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-uncrustify-vendor-3.1.0-np2py312h50b1e4c_17.conda
+  sha256: de06cd317b8780416f802f2ef464ee1e0040bb4bca97489d2bf798f309e17c55
+  md5: 4b3eb141e5a15e047061f2e88680d1a4
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - uncrustify
   - libcxx >=18
   - __osx >=11.0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - uncrustify >=0.81.0,<0.82.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0 OR GPL-2.0-only
-  size: 23758
-  timestamp: 1769481963319
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-unique-identifier-msgs-2.7.0-np2py312h2ed9cc7_15.conda
-  sha256: 26ded34629a4c8fb6f99716c6de6fee16b937f20e27b4da1274ca36c555db5e9
-  md5: d38d14edffcf6cab6090a4e4d4686856
+  size: 23950
+  timestamp: 1775548065061
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-unique-identifier-msgs-2.7.0-np2py312h2ed9cc7_17.conda
+  sha256: a6dd7b813f2c78f105123fed06a430e8035b0cc2dc47852d96b30d8a8fc7484b
+  md5: 62c529c0ddeffa4946a095f4a044bacb
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 72136
-  timestamp: 1769482969283
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-unique-identifier-msgs-2.7.0-np2py312h50b1e4c_15.conda
-  sha256: dc63ff1ba1221c0c7f9dde799f8dbd4c52a5c1cf9d33f292ec1a4fa6caea527b
-  md5: 19acc7475474cc405da42499022b0473
+  size: 74256
+  timestamp: 1775549179433
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-unique-identifier-msgs-2.7.0-np2py312h50b1e4c_17.conda
+  sha256: 252588ef33b90d1116b5a2bed79645a9404e6c61ab34c0d9fe3f6fa46a72470d
+  md5: b1604bfe93fc7bab9cbedd6da2e4a600
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __osx >=11.0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - __osx >=11.0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 69295
-  timestamp: 1769490674319
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-visualization-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: 388a00d4daa1d8c276665ffb65397926551a113ab41e63d89a82f4472945df84
-  md5: e6fe410aaceb38dca2d90880c05a55fd
+  size: 71274
+  timestamp: 1775550666823
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-visualization-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: 1dcc37fcb6d2310c46d39b3c60c425f7dc98a0ad213465318023fc775cb135b2
+  md5: 827644d6ac0e61684b4560c96a808e12
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -15158,20 +15277,19 @@ packages:
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-sensor-msgs
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 373668
-  timestamp: 1769483881721
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-visualization-msgs-5.5.1-np2py312h50b1e4c_15.conda
-  sha256: 105365f2e4c6f500edf7dec25f5aef36ec5025ae2a972d26b9cf116b6bc738c6
-  md5: 7a4f6f60857f2103785dad7bf4b15aa3
+  size: 381360
+  timestamp: 1775550068206
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-visualization-msgs-5.5.2-np2py312h50b1e4c_17.conda
+  sha256: 622673164eb21acca9e16f635c395fc82450127baf8786a4484cd0508f51b7f5
+  md5: 5f3a67e1defd55e94a3c6242c460c7df
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -15180,77 +15298,76 @@ packages:
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-sensor-msgs
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __osx >=11.0
   - libcxx >=18
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 318289
-  timestamp: 1769492983116
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-zenoh-cpp-vendor-0.6.6-np2py312ha80d210_15.conda
-  sha256: bc77073722a6f7a237a621177f2bab18907dfd5d532389ad8e58ad0a6ecb8f69
-  md5: 46a85de5cf6b5c9adfcee92f3c6e9c9c
+  size: 325967
+  timestamp: 1775552547619
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-zenoh-cpp-vendor-0.6.6-np2py312ha80d210_17.conda
+  sha256: b32ae9c07a98c0f4c8fc1eca60afeaa381d95f6a163defdf90b30c303f499c40
+  md5: 3a4ae82d191b545252f504ca6727d5bd
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
   - libzenohc >=1.7.2,<1.7.3.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   constrains:
   - __glibc >=2.17
   license: Apache-2.0
-  size: 25619
-  timestamp: 1769481227235
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-zenoh-cpp-vendor-0.6.6-np2py312h682da20_15.conda
-  sha256: 7675e956f35c316f9e013b316df63999029e93516102c71d879a50133f60abd9
-  md5: e9228f840724d30e1eb13064c6f7a509
+  size: 25590
+  timestamp: 1775547453174
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros-kilted-zenoh-cpp-vendor-0.6.6-np2py312h682da20_17.conda
+  sha256: 05dbdbc76c24b9fbbf96662675b61ab6ae0cb97f737dc59d5759457ba1ba152d
+  md5: b911018dcc05a92fa75a848b0721d6ab
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libcxx >=18
   - __osx >=11.0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - libzenohc >=1.7.2,<1.7.3.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - libzenohc >=1.7.2,<1.7.3.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 25571
-  timestamp: 1769481954406
-- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros2-distro-mutex-0.13.0-kilted_15.conda
-  sha256: 601514ec30473279742045a389ca0fabaa1374dd9101a472fc675894078f53e5
-  md5: c651abe39b40eb47c091c4ad2c922cf7
+  size: 25792
+  timestamp: 1775548082638
+- conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros2-distro-mutex-0.14.0-kilted_17.conda
+  sha256: a873b2e7941451eca28a3e21709fed27f2e1c459d161926d19d216ff6be7b6a6
+  md5: 88effae5298227990e25f078da06b982
   constrains:
   - libboost 1.88.*
   - libboost-devel 1.88.*
   - pcl 1.15.1.*
   - gazebo 11.*
-  - libprotobuf 6.31.1.*
-  - vtk 9.5.2.*
+  - libprotobuf 6.33.5.*
+  - vtk 9.6.0.*
   license: BSD-3-Clause
-  size: 2338
-  timestamp: 1769480640069
-- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros2-distro-mutex-0.13.0-kilted_15.conda
-  sha256: 8af73feacc9bb0fd3dfca1d18f6160f415f462983a425a32fae3d88385fde9cd
-  md5: d52ee4cac7bad60d4f799bc88920edde
+  size: 2372
+  timestamp: 1775546815643
+- conda: https://conda.anaconda.org/robostack-kilted/osx-arm64/ros2-distro-mutex-0.14.0-kilted_17.conda
+  sha256: 1ef2bf7feaa47a861a37a142b1e1be3ce3e5c732efdcffe79d6afff045ca5727
+  md5: c7b7acf593962644567769e2a1fba18c
   constrains:
   - libboost 1.88.*
   - libboost-devel 1.88.*
   - pcl 1.15.1.*
   - gazebo 11.*
-  - libprotobuf 6.31.1.*
-  - vtk 9.5.2.*
+  - libprotobuf 6.33.5.*
+  - vtk 9.6.0.*
   license: BSD-3-Clause
-  size: 2317
-  timestamp: 1769480804538
+  size: 2349
+  timestamp: 1775546957330
 - conda: https://conda.anaconda.org/conda-forge/noarch/rosdistro-1.0.1-pyhd8ed1ab_0.conda
   sha256: bff3b2fe7afe35125669ffcb7d6153db78070a753e1e4ac3b3d8d198eb6d6982
   md5: b7ed380a9088b543e06a4f73985ed03a
@@ -15280,6 +15397,18 @@ packages:
   - pkg:pypi/rospkg?source=hash-mapping
   size: 31852
   timestamp: 1766125246079
+- conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.1-h1cbb8d7_1.conda
+  sha256: dbbe4ab36b90427f12d69fc14a8b601b6bca4185c6c4dd67b8046a8da9daec03
+  md5: 9d978822b57bafe72ebd3f8b527bba71
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - openssl >=3.5.5,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 395083
+  timestamp: 1773251675551
 - pypi: https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: safetensors
   version: 0.7.0
@@ -15592,6 +15721,11 @@ packages:
   purls: []
   size: 112531
   timestamp: 1770209178534
+- pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
+  name: shellingham
+  version: 1.5.4
+  sha256: 7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686
+  requires_python: '>=3.7'
 - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   sha256: 458227f759d5e3fcec5d9b7acce54e10c9e1f4f4b7ec978f3bfd54ce4ee9853d
   md5: 3339e3b65d58accf4ca4fb8748ab16b3
@@ -15696,9 +15830,9 @@ packages:
   purls: []
   size: 1613001
   timestamp: 1770089883327
-- conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-4.0.0-hecca717_0.conda
-  sha256: e5e036728ef71606569232cc94a0480722e14ed69da3dd1e363f3d5191d83c01
-  md5: 9a6117aee038999ffefe6082ff1e9a81
+- conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-4.0.1-hecca717_0.conda
+  sha256: 4a1d2005153b9454fc21c9bad1b539df189905be49e851ec62a6212c2e045381
+  md5: 2a2170a3e5c9a354d09e4be718c43235
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -15706,19 +15840,19 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls: []
-  size: 2620937
-  timestamp: 1769280649780
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-4.0.0-h0cb729a_0.conda
-  sha256: f7fc5a18f4a6cf61fa4b6697c6aa28426b07a3df2b53a96b25dda28641991532
-  md5: 3dc1d4f4c9829c82c7f6660878abcd32
+  size: 2619743
+  timestamp: 1769664536467
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-4.0.1-h0cb729a_0.conda
+  sha256: bdef3c1c4d2a396ad4f7dc64c5e9a02d4c5a21ff93ed07a33e49574de5d2d18d
+  md5: 8badc3bf16b62272aa2458f138223821
   depends:
   - __osx >=11.0
   - libcxx >=19
   license: BSD-2-Clause
   license_family: BSD
   purls: []
-  size: 1455052
-  timestamp: 1769280806030
+  size: 1456245
+  timestamp: 1769664727051
 - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
   name: sympy
   version: 1.14.0
@@ -15973,6 +16107,16 @@ packages:
   - matplotlib ; extra == 'tutorials'
   - pandas ; extra == 'tutorials'
   - tabulate ; extra == 'tutorials'
+- pypi: https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl
+  name: typer
+  version: 0.24.1
+  sha256: 112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e
+  requires_dist:
+  - click>=8.2.1
+  - shellingham>=1.3.0
+  - rich>=12.3.0
+  - annotated-doc>=0.0.2
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl
   name: typing-inspect
   version: 0.9.0
@@ -16203,11 +16347,6 @@ packages:
   purls: []
   size: 140476
   timestamp: 1765821981856
-- pypi: https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl
-  name: wcwidth
-  version: 0.6.0
-  sha256: 1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad
-  requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
   sha256: 175315eb3d6ea1f64a6ce470be00fa2ee59980108f246d3072ab8b977cb048a5
   md5: 6c99772d483f566d59e25037fea2c4b1

--- a/pixi.toml
+++ b/pixi.toml
@@ -13,7 +13,7 @@ evdev = ">=1.9.2,<2"
 [dependencies]
 isort = "==5.13.2"                                                                     # version bundled by the vscode extension
 json5 = ">=0.13.0,<0.14"                                                               # version bundled by the vscode extension
-opencv = "<4.13.0"
+numpy = "<2.3.0"
 packaging = ">=24.2,<26.0"                                                             # required by lerobot==0.4.3
 pyright = "==1.1.408"
 ros-kilted-aic-control-interfaces = { path = "aic_interfaces/aic_control_interfaces" }
@@ -36,10 +36,10 @@ ros-kilted-tf2-ros-py = "*"
 setuptools = ">=71.0.0,<81.0.0"                                                        # required by lerobot==0.4.3
 
 [pypi-dependencies]
-huggingface-hub = { version = "==0.35.3", extras = ["hf-transfer", "cli"] }
-lerobot = "==0.4.3"
-lerobot_robot_ros = { git = "https://github.com/koonpeng/lerobot-ros", rev = "b4a635fc5264266bd1575f07d54be3d4bbd620e0", subdirectory = "lerobot_robot_ros" }
-lerobot_teleoperator_devices = { git = "https://github.com/koonpeng/lerobot-ros", rev = "b4a635fc5264266bd1575f07d54be3d4bbd620e0", subdirectory = "lerobot_teleoperator_devices" }
+huggingface-hub = { version = "~=1.7" }
+lerobot = "==0.5.1"
+lerobot_robot_ros = { git = "https://github.com/koonpeng/lerobot-ros", rev = "87708d0ae14a724bca78f8ae9d55448332509a57", subdirectory = "lerobot_robot_ros" }
+lerobot_teleoperator_devices = { git = "https://github.com/koonpeng/lerobot-ros", rev = "87708d0ae14a724bca78f8ae9d55448332509a57", subdirectory = "lerobot_teleoperator_devices" }
 mujoco = "==3.5.0"
 pynput = ">=1.7.6,<2"
 pyspacemouse = ">=2.0.0, <3"


### PR DESCRIPTION
Cherry picking PR #467 to build `aic_model` for Phase 1.

Changes:
- update lerobot
- remove nonexistent `lifecycle` dep
- update pixi lock
