### PR TITLE
Support up to 3 SC ports per rail for phase 1

### DIFF
--- a/aic_description/urdf/task_board.urdf.xacro
+++ b/aic_description/urdf/task_board.urdf.xacro
@@ -72,6 +72,34 @@
   <xacro:arg name="sc_port_1_pitch" default="0.0"/>
   <xacro:arg name="sc_port_1_yaw" default="0.0"/>
 
+  <!-- SC Port 2 (SC_RAIL_0) -->
+  <xacro:arg name="sc_port_2_present" default="false"/>
+  <xacro:arg name="sc_port_2_translation" default="0.0"/>
+  <xacro:arg name="sc_port_2_roll" default="0.0"/>
+  <xacro:arg name="sc_port_2_pitch" default="0.0"/>
+  <xacro:arg name="sc_port_2_yaw" default="0.0"/>
+
+  <!-- SC Port 3 (SC_RAIL_1) -->
+  <xacro:arg name="sc_port_3_present" default="false"/>
+  <xacro:arg name="sc_port_3_translation" default="0.0"/>
+  <xacro:arg name="sc_port_3_roll" default="0.0"/>
+  <xacro:arg name="sc_port_3_pitch" default="0.0"/>
+  <xacro:arg name="sc_port_3_yaw" default="0.0"/>
+
+  <!-- SC Port 4 (SC_RAIL_1) -->
+  <xacro:arg name="sc_port_4_present" default="false"/>
+  <xacro:arg name="sc_port_4_translation" default="0.0"/>
+  <xacro:arg name="sc_port_4_roll" default="0.0"/>
+  <xacro:arg name="sc_port_4_pitch" default="0.0"/>
+  <xacro:arg name="sc_port_4_yaw" default="0.0"/>
+
+  <!-- SC Port 5 (SC_RAIL_1) -->
+  <xacro:arg name="sc_port_5_present" default="false"/>
+  <xacro:arg name="sc_port_5_translation" default="0.0"/>
+  <xacro:arg name="sc_port_5_roll" default="0.0"/>
+  <xacro:arg name="sc_port_5_pitch" default="0.0"/>
+  <xacro:arg name="sc_port_5_yaw" default="0.0"/>
+
   <!-- NIC Card Mount 0 -->
   <xacro:arg name="nic_card_mount_0_present" default="false"/>
   <xacro:arg name="nic_card_mount_0_translation" default="0.0"/>
@@ -187,13 +215,57 @@
     </gazebo>
   </xacro:if>
 
-  <!-- SC Port 1 -->
+  <!-- SC Port 1 (SC_RAIL_0, Y=0.0295) -->
   <xacro:if value="$(arg sc_port_1_present)">
-    <xacro:sc_port prefix="sc_port_1" pose="${-0.075 + $(arg sc_port_1_translation)} 0.0705 0.0165 ${1.57 + $(arg sc_port_1_roll)} $(arg sc_port_1_pitch) ${1.57 + $(arg sc_port_1_yaw)}"/>
+    <xacro:sc_port prefix="sc_port_1" pose="${-0.075 + $(arg sc_port_1_translation)} 0.0295 0.0165 ${1.57 + $(arg sc_port_1_roll)} $(arg sc_port_1_pitch) ${1.57 + $(arg sc_port_1_yaw)}"/>
     <gazebo>
       <joint name="sc_port_1_joint" type="fixed">
         <parent>task_board_base_link</parent>
         <child>sc_port_1::sc_port_link</child>
+      </joint>
+    </gazebo>
+  </xacro:if>
+
+  <!-- SC Port 2 (SC_RAIL_0, Y=0.0295) -->
+  <xacro:if value="$(arg sc_port_2_present)">
+    <xacro:sc_port prefix="sc_port_2" pose="${-0.075 + $(arg sc_port_2_translation)} 0.0295 0.0165 ${1.57 + $(arg sc_port_2_roll)} $(arg sc_port_2_pitch) ${1.57 + $(arg sc_port_2_yaw)}"/>
+    <gazebo>
+      <joint name="sc_port_2_joint" type="fixed">
+        <parent>task_board_base_link</parent>
+        <child>sc_port_2::sc_port_link</child>
+      </joint>
+    </gazebo>
+  </xacro:if>
+
+  <!-- SC Port 3 (SC_RAIL_1, Y=0.0705) -->
+  <xacro:if value="$(arg sc_port_3_present)">
+    <xacro:sc_port prefix="sc_port_3" pose="${-0.075 + $(arg sc_port_3_translation)} 0.0705 0.0165 ${1.57 + $(arg sc_port_3_roll)} $(arg sc_port_3_pitch) ${1.57 + $(arg sc_port_3_yaw)}"/>
+    <gazebo>
+      <joint name="sc_port_3_joint" type="fixed">
+        <parent>task_board_base_link</parent>
+        <child>sc_port_3::sc_port_link</child>
+      </joint>
+    </gazebo>
+  </xacro:if>
+
+  <!-- SC Port 4 (SC_RAIL_1, Y=0.0705) -->
+  <xacro:if value="$(arg sc_port_4_present)">
+    <xacro:sc_port prefix="sc_port_4" pose="${-0.075 + $(arg sc_port_4_translation)} 0.0705 0.0165 ${1.57 + $(arg sc_port_4_roll)} $(arg sc_port_4_pitch) ${1.57 + $(arg sc_port_4_yaw)}"/>
+    <gazebo>
+      <joint name="sc_port_4_joint" type="fixed">
+        <parent>task_board_base_link</parent>
+        <child>sc_port_4::sc_port_link</child>
+      </joint>
+    </gazebo>
+  </xacro:if>
+
+  <!-- SC Port 5 (SC_RAIL_1, Y=0.0705) -->
+  <xacro:if value="$(arg sc_port_5_present)">
+    <xacro:sc_port prefix="sc_port_5" pose="${-0.075 + $(arg sc_port_5_translation)} 0.0705 0.0165 ${1.57 + $(arg sc_port_5_roll)} $(arg sc_port_5_pitch) ${1.57 + $(arg sc_port_5_yaw)}"/>
+    <gazebo>
+      <joint name="sc_port_5_joint" type="fixed">
+        <parent>task_board_base_link</parent>
+        <child>sc_port_5::sc_port_link</child>
       </joint>
     </gazebo>
   </xacro:if>

--- a/aic_engine/config/sample_config.yaml
+++ b/aic_engine/config/sample_config.yaml
@@ -49,11 +49,14 @@ task_board_limits:
     max_translation: 0.0234   # Maximum translation from center along the rail (in meters)
   sc_rail:
     min_translation: -0.06  # Minimum translation from center along the rail (in meters)
-    max_translation: 0.055   # Maximum translation from center along the rail (in meters)
+    max_translation: 0.055  # Maximum translation from center along the rail (in meters)
   mount_rail:
     min_translation: -0.09425  # Minimum translation from center along the rail (in meters)
     max_translation: 0.09425   # Maximum translation from center along the rail (in meters)
+
 trials:
+  # ── Trial 1: 2 SC ports ────────────────────────────────────────────────────
+  # SC_PORT_0 and SC_PORT_1 both on SC_RAIL_0, gap = 40 mm (> 30 mm minimum)
   trial_1:
     scene:
         task_board:
@@ -65,13 +68,7 @@ trials:
             pitch: 0.0
             yaw: 3.1415
           nic_rail_0:
-            entity_present: True # True if a NIC card is present on this rail.
-            entity_name: "nic_card_0" # Name of the NIC card entity to spawn.
-            entity_pose:
-              translation: 0.036
-              roll: 0.0 # roll orientation for the NIC card.
-              pitch: 0.0 # pitch orientation for the NIC card.
-              yaw: 0.0 # yaw orientation for the NIC card.
+            entity_present: False
           nic_rail_1:
             entity_present: False
           nic_rail_2:
@@ -81,47 +78,39 @@ trials:
           nic_rail_4:
             entity_present: False
           sc_rail_0:
-            entity_present: True
-            entity_name: "sc_mount_0" # Name of the SC port entity to spawn.
-            entity_pose:
-              translation: 0.042
-              roll: 0.0 # roll orientation for the SC port.
-              pitch: 0.0 # pitch orientation for the SC port.
-              yaw: 0.1 # yaw orientation for the SC port.
+            sc_port_0:
+              entity_present: True
+              entity_name: "sc_port_0"
+              entity_pose:
+                translation: -0.030
+                roll: 0.0
+                pitch: 0.0
+                yaw: 0.0
+            sc_port_1:
+              entity_present: True
+              entity_name: "sc_port_1"
+              entity_pose:
+                translation: 0.010  # 40 mm from sc_port_0
+                roll: 0.0
+                pitch: 0.0
+                yaw: 0.0
+            sc_port_2:
+              entity_present: False
           sc_rail_1:
-            entity_present: False
+            sc_port_3:
+              entity_present: False
+            sc_port_4:
+              entity_present: False
+            sc_port_5:
+              entity_present: False
           lc_mount_rail_0:
-            entity_present: True
-            entity_name: "lc_mount_0"  # Name of the LC mount entity
-            entity_pose:
-              translation: 0.02  # Translation along Y axis
-              roll: 0.0
-              pitch: 0.0
-              yaw: 0.0
+            entity_present: False
           sfp_mount_rail_0:
-            entity_present: True
-            entity_name: "sfp_mount_0"
-            entity_pose:
-              translation: 0.03
-              roll: 0.0
-              pitch: 0.0
-              yaw: 0.0
+            entity_present: False
           sc_mount_rail_0:
-            entity_present: True
-            entity_name: "sc_mount_0"
-            entity_pose:
-              translation: -0.02
-              roll: 0.0
-              pitch: 0.0
-              yaw: 0.0
+            entity_present: False
           lc_mount_rail_1:
-            entity_present: True
-            entity_name: "lc_mount_1"
-            entity_pose:
-              translation: -0.01
-              roll: 0.0
-              pitch: 0.0
-              yaw: 0.0
+            entity_present: False
           sfp_mount_rail_1:
             entity_present: False
           sc_mount_rail_1:
@@ -132,22 +121,27 @@ trials:
               gripper_offset:
                 x: 0.0
                 y: 0.015385
-                z: 0.04245
+                z: 0.04045
               roll: 0.4432
               pitch: -0.4838
               yaw: 1.3303
-            attach_cable_to_gripper: True
-            cable_type: "sfp_sc_cable" # [sfp_sc_cable, sfp_sc_cable_reversed]
+            attach_cable_to_gripper: False
+            cable_type: "sfp_sc_cable_reversed"
     tasks:
       task_1:
         cable_type: "sfp_sc"
         cable_name: "cable_0"
-        plug_type: "sfp"
-        plug_name: "sfp_tip"
-        port_type: "sfp"
-        port_name: "sfp_port_0"
-        target_module_name: "nic_card_mount_0"
+        plug_type: "sc"
+        plug_name: "sc_tip"
+        port_type: "sc"
+        port_name: "sc_port_base"
+        target_module_name: "sc_port_0"
         time_limit: 180
+
+  # ── Trial 2: 3 SC ports (non-contiguous) ──────────────────────────────────
+  # SC_PORT_0 on SC_RAIL_0; SC_PORT_3 and SC_PORT_5 on SC_RAIL_1
+  # SC_PORT_1, SC_PORT_2, SC_PORT_4 absent
+  # SC_RAIL_1 gap: PORT_3 at -0.025, PORT_5 at 0.020 → gap = 45 mm (> 30 mm)
   trial_2:
     scene:
         task_board:
@@ -161,13 +155,7 @@ trials:
           nic_rail_0:
             entity_present: False
           nic_rail_1:
-            entity_present: True # True if a NIC card is present on this rail.
-            entity_name: "nic_card_1" # Name of the NIC card entity to spawn.
-            entity_pose:
-              translation: 0.036
-              roll: 0.0 # roll orientation for the NIC card.
-              pitch: 0.0 # pitch orientation for the NIC card.
-              yaw: 0.0 # yaw orientation for the NIC card.
+            entity_present: False
           nic_rail_2:
             entity_present: False
           nic_rail_3:
@@ -175,47 +163,45 @@ trials:
           nic_rail_4:
             entity_present: False
           sc_rail_0:
-            entity_present: True
-            entity_name: "sc_mount_0" # Name of the SC port entity to spawn.
-            entity_pose:
-              translation: 0.042
-              roll: 0.0 # roll orientation for the SC port.
-              pitch: 0.0 # pitch orientation for the SC port.
-              yaw: 0.1 # yaw orientation for the SC port.
+            sc_port_0:
+              entity_present: True
+              entity_name: "sc_port_0"
+              entity_pose:
+                translation: 0.0
+                roll: 0.0
+                pitch: 0.0
+                yaw: 0.0
+            sc_port_1:
+              entity_present: False
+            sc_port_2:
+              entity_present: False
           sc_rail_1:
-            entity_present: False
+            sc_port_3:
+              entity_present: True
+              entity_name: "sc_port_3"
+              entity_pose:
+                translation: -0.025
+                roll: 0.0
+                pitch: 0.0
+                yaw: 0.0
+            sc_port_4:
+              entity_present: False
+            sc_port_5:
+              entity_present: True
+              entity_name: "sc_port_5"
+              entity_pose:
+                translation: 0.020  # 45 mm from sc_port_3
+                roll: 0.0
+                pitch: 0.0
+                yaw: 0.0
           lc_mount_rail_0:
-            entity_present: True
-            entity_name: "lc_mount_0"  # Name of the LC mount entity
-            entity_pose:
-              translation: 0.02  # Translation along Y axis
-              roll: 0.0
-              pitch: 0.0
-              yaw: 0.0
+            entity_present: False
           sfp_mount_rail_0:
-            entity_present: True
-            entity_name: "sfp_mount_0"
-            entity_pose:
-              translation: 0.03
-              roll: 0.0
-              pitch: 0.0
-              yaw: 0.0
+            entity_present: False
           sc_mount_rail_0:
-            entity_present: True
-            entity_name: "sc_mount_0"
-            entity_pose:
-              translation: -0.02
-              roll: 0.0
-              pitch: 0.0
-              yaw: 0.0
+            entity_present: False
           lc_mount_rail_1:
-            entity_present: True
-            entity_name: "lc_mount_1"
-            entity_pose:
-              translation: -0.01
-              roll: 0.0
-              pitch: 0.0
-              yaw: 0.0
+            entity_present: False
           sfp_mount_rail_1:
             entity_present: False
           sc_mount_rail_1:
@@ -226,32 +212,37 @@ trials:
               gripper_offset:
                 x: 0.0
                 y: 0.015385
-                z: 0.04545
+                z: 0.04045
               roll: 0.4432
               pitch: -0.4838
               yaw: 1.3303
-            attach_cable_to_gripper: True
-            cable_type: "sfp_sc_cable" # [sfp_sc_cable, sfp_sc_cable_reversed]
+            attach_cable_to_gripper: False
+            cable_type: "sfp_sc_cable_reversed"
     tasks:
       task_1:
         cable_type: "sfp_sc"
         cable_name: "cable_0"
-        plug_type: "sfp"
-        plug_name: "sfp_tip"
-        port_type: "sfp"
-        port_name: "sfp_port_0"
-        target_module_name: "nic_card_mount_1"
+        plug_type: "sc"
+        plug_name: "sc_tip"
+        port_type: "sc"
+        port_name: "sc_port_base"
+        target_module_name: "sc_port_5"
         time_limit: 180
+
+  # ── Trial 3: 5 SC ports ────────────────────────────────────────────────────
+  # SC_PORT_0, SC_PORT_1, SC_PORT_2 on SC_RAIL_0 (gaps exactly 30 mm each)
+  # SC_PORT_3, SC_PORT_4 on SC_RAIL_1 (gap exactly 30 mm)
+  # SC_PORT_5 absent
   trial_3:
     scene:
         task_board:
           pose:
-            x: 0.17
-            y: 0.0
+            x: 0.15
+            y: -0.2
             z: 1.14
             roll: 0.0
             pitch: 0.0
-            yaw: 3.0
+            yaw: 3.1415
           nic_rail_0:
             entity_present: False
           nic_rail_1:
@@ -263,47 +254,63 @@ trials:
           nic_rail_4:
             entity_present: False
           sc_rail_0:
-            entity_present: False
+            sc_port_0:
+              entity_present: True
+              entity_name: "sc_port_0"
+              entity_pose:
+                translation: -0.050
+                roll: 0.0
+                pitch: 0.0
+                yaw: 0.0
+            sc_port_1:
+              entity_present: True
+              entity_name: "sc_port_1"
+              entity_pose:
+                translation: -0.020  # 30 mm from sc_port_0
+                roll: 0.0
+                pitch: 0.0
+                yaw: 0.0
+            sc_port_2:
+              entity_present: True
+              entity_name: "sc_port_2"
+              entity_pose:
+                translation: 0.010  # 30 mm from sc_port_1
+                roll: 0.0
+                pitch: 0.0
+                yaw: 0.0
           sc_rail_1:
-            entity_present: True
-            entity_name: "sc_mount_1"
-            entity_pose:
-              translation: -0.055
-              roll: 0.0
-              pitch: 0.0
-              yaw: 0.0
+            sc_port_3:
+              entity_present: True
+              entity_name: "sc_port_3"
+              entity_pose:
+                translation: -0.015
+                roll: 0.0
+                pitch: 0.0
+                yaw: 0.0
+            sc_port_4:
+              entity_present: True
+              entity_name: "sc_port_4"
+              entity_pose:
+                translation: 0.015  # 30 mm from sc_port_3
+                roll: 0.0
+                pitch: 0.0
+                yaw: 0.0
+            sc_port_5:
+              entity_present: False
           lc_mount_rail_0:
             entity_present: False
           sfp_mount_rail_0:
-            entity_present: True
-            entity_name: "sfp_mount_0"
-            entity_pose:
-              translation: 0.05
-              roll: 0.0
-              pitch: 0.0
-              yaw: 0.0
+            entity_present: False
           sc_mount_rail_0:
-            entity_present: True
-            entity_name: "sc_mount_2"
-            entity_pose:
-              translation: -0.03
-              roll: 0.0
-              pitch: 0.0
-              yaw: 0.0
+            entity_present: False
           lc_mount_rail_1:
-            entity_present: True
-            entity_name: "lc_mount_1"
-            entity_pose:
-              translation: 0.04
-              roll: 0.0
-              pitch: 0.0
-              yaw: 0.0
+            entity_present: False
           sfp_mount_rail_1:
             entity_present: False
           sc_mount_rail_1:
             entity_present: False
         cables:
-          cable_1:
+          cable_0:
             pose:
               gripper_offset:
                 x: 0.0
@@ -312,18 +319,19 @@ trials:
               roll: 0.4432
               pitch: -0.4838
               yaw: 1.3303
-            attach_cable_to_gripper: True
-            cable_type: "sfp_sc_cable_reversed" # [sfp_sc_cable, sfp_sc_cable_reversed]
+            attach_cable_to_gripper: False
+            cable_type: "sfp_sc_cable_reversed"
     tasks:
       task_1:
         cable_type: "sfp_sc"
-        cable_name: "cable_1"
+        cable_name: "cable_0"
         plug_type: "sc"
-        plug_name:  "sc_tip"
+        plug_name: "sc_tip"
         port_type: "sc"
         port_name: "sc_port_base"
-        target_module_name: "sc_port_1"
+        target_module_name: "sc_port_2"
         time_limit: 180
+
 robot:
   home_joint_positions:
     shoulder_pan_joint: -0.1597

--- a/aic_engine/config/sample_config.yaml
+++ b/aic_engine/config/sample_config.yaml
@@ -49,14 +49,11 @@ task_board_limits:
     max_translation: 0.0234   # Maximum translation from center along the rail (in meters)
   sc_rail:
     min_translation: -0.06  # Minimum translation from center along the rail (in meters)
-    max_translation: 0.055  # Maximum translation from center along the rail (in meters)
+    max_translation: 0.055   # Maximum translation from center along the rail (in meters)
   mount_rail:
     min_translation: -0.09425  # Minimum translation from center along the rail (in meters)
     max_translation: 0.09425   # Maximum translation from center along the rail (in meters)
-
 trials:
-  # ── Trial 1: 2 SC ports ────────────────────────────────────────────────────
-  # SC_PORT_0 and SC_PORT_1 both on SC_RAIL_0, gap = 40 mm (> 30 mm minimum)
   trial_1:
     scene:
         task_board:
@@ -68,7 +65,13 @@ trials:
             pitch: 0.0
             yaw: 3.1415
           nic_rail_0:
-            entity_present: False
+            entity_present: True # True if a NIC card is present on this rail.
+            entity_name: "nic_card_0" # Name of the NIC card entity to spawn.
+            entity_pose:
+              translation: 0.036
+              roll: 0.0 # roll orientation for the NIC card.
+              pitch: 0.0 # pitch orientation for the NIC card.
+              yaw: 0.0 # yaw orientation for the NIC card.
           nic_rail_1:
             entity_present: False
           nic_rail_2:
@@ -78,39 +81,47 @@ trials:
           nic_rail_4:
             entity_present: False
           sc_rail_0:
-            sc_port_0:
-              entity_present: True
-              entity_name: "sc_port_0"
-              entity_pose:
-                translation: -0.030
-                roll: 0.0
-                pitch: 0.0
-                yaw: 0.0
-            sc_port_1:
-              entity_present: True
-              entity_name: "sc_port_1"
-              entity_pose:
-                translation: 0.010  # 40 mm from sc_port_0
-                roll: 0.0
-                pitch: 0.0
-                yaw: 0.0
-            sc_port_2:
-              entity_present: False
+            entity_present: True
+            entity_name: "sc_mount_0" # Name of the SC port entity to spawn.
+            entity_pose:
+              translation: 0.042
+              roll: 0.0 # roll orientation for the SC port.
+              pitch: 0.0 # pitch orientation for the SC port.
+              yaw: 0.1 # yaw orientation for the SC port.
           sc_rail_1:
-            sc_port_3:
-              entity_present: False
-            sc_port_4:
-              entity_present: False
-            sc_port_5:
-              entity_present: False
+            entity_present: False
           lc_mount_rail_0:
-            entity_present: False
+            entity_present: True
+            entity_name: "lc_mount_0"  # Name of the LC mount entity
+            entity_pose:
+              translation: 0.02  # Translation along Y axis
+              roll: 0.0
+              pitch: 0.0
+              yaw: 0.0
           sfp_mount_rail_0:
-            entity_present: False
+            entity_present: True
+            entity_name: "sfp_mount_0"
+            entity_pose:
+              translation: 0.03
+              roll: 0.0
+              pitch: 0.0
+              yaw: 0.0
           sc_mount_rail_0:
-            entity_present: False
+            entity_present: True
+            entity_name: "sc_mount_0"
+            entity_pose:
+              translation: -0.02
+              roll: 0.0
+              pitch: 0.0
+              yaw: 0.0
           lc_mount_rail_1:
-            entity_present: False
+            entity_present: True
+            entity_name: "lc_mount_1"
+            entity_pose:
+              translation: -0.01
+              roll: 0.0
+              pitch: 0.0
+              yaw: 0.0
           sfp_mount_rail_1:
             entity_present: False
           sc_mount_rail_1:
@@ -121,27 +132,22 @@ trials:
               gripper_offset:
                 x: 0.0
                 y: 0.015385
-                z: 0.04045
+                z: 0.04245
               roll: 0.4432
               pitch: -0.4838
               yaw: 1.3303
-            attach_cable_to_gripper: False
-            cable_type: "sfp_sc_cable_reversed"
+            attach_cable_to_gripper: True
+            cable_type: "sfp_sc_cable" # [sfp_sc_cable, sfp_sc_cable_reversed]
     tasks:
       task_1:
         cable_type: "sfp_sc"
         cable_name: "cable_0"
-        plug_type: "sc"
-        plug_name: "sc_tip"
-        port_type: "sc"
-        port_name: "sc_port_base"
-        target_module_name: "sc_port_0"
+        plug_type: "sfp"
+        plug_name: "sfp_tip"
+        port_type: "sfp"
+        port_name: "sfp_port_0"
+        target_module_name: "nic_card_mount_0"
         time_limit: 180
-
-  # ── Trial 2: 3 SC ports (non-contiguous) ──────────────────────────────────
-  # SC_PORT_0 on SC_RAIL_0; SC_PORT_3 and SC_PORT_5 on SC_RAIL_1
-  # SC_PORT_1, SC_PORT_2, SC_PORT_4 absent
-  # SC_RAIL_1 gap: PORT_3 at -0.025, PORT_5 at 0.020 → gap = 45 mm (> 30 mm)
   trial_2:
     scene:
         task_board:
@@ -155,7 +161,13 @@ trials:
           nic_rail_0:
             entity_present: False
           nic_rail_1:
-            entity_present: False
+            entity_present: True # True if a NIC card is present on this rail.
+            entity_name: "nic_card_1" # Name of the NIC card entity to spawn.
+            entity_pose:
+              translation: 0.036
+              roll: 0.0 # roll orientation for the NIC card.
+              pitch: 0.0 # pitch orientation for the NIC card.
+              yaw: 0.0 # yaw orientation for the NIC card.
           nic_rail_2:
             entity_present: False
           nic_rail_3:
@@ -163,45 +175,47 @@ trials:
           nic_rail_4:
             entity_present: False
           sc_rail_0:
-            sc_port_0:
-              entity_present: True
-              entity_name: "sc_port_0"
-              entity_pose:
-                translation: 0.0
-                roll: 0.0
-                pitch: 0.0
-                yaw: 0.0
-            sc_port_1:
-              entity_present: False
-            sc_port_2:
-              entity_present: False
+            entity_present: True
+            entity_name: "sc_mount_0" # Name of the SC port entity to spawn.
+            entity_pose:
+              translation: 0.042
+              roll: 0.0 # roll orientation for the SC port.
+              pitch: 0.0 # pitch orientation for the SC port.
+              yaw: 0.1 # yaw orientation for the SC port.
           sc_rail_1:
-            sc_port_3:
-              entity_present: True
-              entity_name: "sc_port_3"
-              entity_pose:
-                translation: -0.025
-                roll: 0.0
-                pitch: 0.0
-                yaw: 0.0
-            sc_port_4:
-              entity_present: False
-            sc_port_5:
-              entity_present: True
-              entity_name: "sc_port_5"
-              entity_pose:
-                translation: 0.020  # 45 mm from sc_port_3
-                roll: 0.0
-                pitch: 0.0
-                yaw: 0.0
+            entity_present: False
           lc_mount_rail_0:
-            entity_present: False
+            entity_present: True
+            entity_name: "lc_mount_0"  # Name of the LC mount entity
+            entity_pose:
+              translation: 0.02  # Translation along Y axis
+              roll: 0.0
+              pitch: 0.0
+              yaw: 0.0
           sfp_mount_rail_0:
-            entity_present: False
+            entity_present: True
+            entity_name: "sfp_mount_0"
+            entity_pose:
+              translation: 0.03
+              roll: 0.0
+              pitch: 0.0
+              yaw: 0.0
           sc_mount_rail_0:
-            entity_present: False
+            entity_present: True
+            entity_name: "sc_mount_0"
+            entity_pose:
+              translation: -0.02
+              roll: 0.0
+              pitch: 0.0
+              yaw: 0.0
           lc_mount_rail_1:
-            entity_present: False
+            entity_present: True
+            entity_name: "lc_mount_1"
+            entity_pose:
+              translation: -0.01
+              roll: 0.0
+              pitch: 0.0
+              yaw: 0.0
           sfp_mount_rail_1:
             entity_present: False
           sc_mount_rail_1:
@@ -212,37 +226,32 @@ trials:
               gripper_offset:
                 x: 0.0
                 y: 0.015385
-                z: 0.04045
+                z: 0.04545
               roll: 0.4432
               pitch: -0.4838
               yaw: 1.3303
-            attach_cable_to_gripper: False
-            cable_type: "sfp_sc_cable_reversed"
+            attach_cable_to_gripper: True
+            cable_type: "sfp_sc_cable" # [sfp_sc_cable, sfp_sc_cable_reversed]
     tasks:
       task_1:
         cable_type: "sfp_sc"
         cable_name: "cable_0"
-        plug_type: "sc"
-        plug_name: "sc_tip"
-        port_type: "sc"
-        port_name: "sc_port_base"
-        target_module_name: "sc_port_5"
+        plug_type: "sfp"
+        plug_name: "sfp_tip"
+        port_type: "sfp"
+        port_name: "sfp_port_0"
+        target_module_name: "nic_card_mount_1"
         time_limit: 180
-
-  # ── Trial 3: 5 SC ports ────────────────────────────────────────────────────
-  # SC_PORT_0, SC_PORT_1, SC_PORT_2 on SC_RAIL_0 (gaps exactly 30 mm each)
-  # SC_PORT_3, SC_PORT_4 on SC_RAIL_1 (gap exactly 30 mm)
-  # SC_PORT_5 absent
   trial_3:
     scene:
         task_board:
           pose:
-            x: 0.15
-            y: -0.2
+            x: 0.17
+            y: 0.0
             z: 1.14
             roll: 0.0
             pitch: 0.0
-            yaw: 3.1415
+            yaw: 3.0
           nic_rail_0:
             entity_present: False
           nic_rail_1:
@@ -254,63 +263,47 @@ trials:
           nic_rail_4:
             entity_present: False
           sc_rail_0:
-            sc_port_0:
-              entity_present: True
-              entity_name: "sc_port_0"
-              entity_pose:
-                translation: -0.050
-                roll: 0.0
-                pitch: 0.0
-                yaw: 0.0
-            sc_port_1:
-              entity_present: True
-              entity_name: "sc_port_1"
-              entity_pose:
-                translation: -0.020  # 30 mm from sc_port_0
-                roll: 0.0
-                pitch: 0.0
-                yaw: 0.0
-            sc_port_2:
-              entity_present: True
-              entity_name: "sc_port_2"
-              entity_pose:
-                translation: 0.010  # 30 mm from sc_port_1
-                roll: 0.0
-                pitch: 0.0
-                yaw: 0.0
+            entity_present: False
           sc_rail_1:
-            sc_port_3:
-              entity_present: True
-              entity_name: "sc_port_3"
-              entity_pose:
-                translation: -0.015
-                roll: 0.0
-                pitch: 0.0
-                yaw: 0.0
-            sc_port_4:
-              entity_present: True
-              entity_name: "sc_port_4"
-              entity_pose:
-                translation: 0.015  # 30 mm from sc_port_3
-                roll: 0.0
-                pitch: 0.0
-                yaw: 0.0
-            sc_port_5:
-              entity_present: False
+            entity_present: True
+            entity_name: "sc_mount_1"
+            entity_pose:
+              translation: -0.055
+              roll: 0.0
+              pitch: 0.0
+              yaw: 0.0
           lc_mount_rail_0:
             entity_present: False
           sfp_mount_rail_0:
-            entity_present: False
+            entity_present: True
+            entity_name: "sfp_mount_0"
+            entity_pose:
+              translation: 0.05
+              roll: 0.0
+              pitch: 0.0
+              yaw: 0.0
           sc_mount_rail_0:
-            entity_present: False
+            entity_present: True
+            entity_name: "sc_mount_2"
+            entity_pose:
+              translation: -0.03
+              roll: 0.0
+              pitch: 0.0
+              yaw: 0.0
           lc_mount_rail_1:
-            entity_present: False
+            entity_present: True
+            entity_name: "lc_mount_1"
+            entity_pose:
+              translation: 0.04
+              roll: 0.0
+              pitch: 0.0
+              yaw: 0.0
           sfp_mount_rail_1:
             entity_present: False
           sc_mount_rail_1:
             entity_present: False
         cables:
-          cable_0:
+          cable_1:
             pose:
               gripper_offset:
                 x: 0.0
@@ -319,19 +312,18 @@ trials:
               roll: 0.4432
               pitch: -0.4838
               yaw: 1.3303
-            attach_cable_to_gripper: False
-            cable_type: "sfp_sc_cable_reversed"
+            attach_cable_to_gripper: True
+            cable_type: "sfp_sc_cable_reversed" # [sfp_sc_cable, sfp_sc_cable_reversed]
     tasks:
       task_1:
         cable_type: "sfp_sc"
-        cable_name: "cable_0"
+        cable_name: "cable_1"
         plug_type: "sc"
-        plug_name: "sc_tip"
+        plug_name:  "sc_tip"
         port_type: "sc"
         port_name: "sc_port_base"
-        target_module_name: "sc_port_2"
+        target_module_name: "sc_port_1"
         time_limit: 180
-
 robot:
   home_joint_positions:
     shoulder_pan_joint: -0.1597

--- a/aic_engine/config/sample_config_multiple_sc_ports.yaml
+++ b/aic_engine/config/sample_config_multiple_sc_ports.yaml
@@ -1,0 +1,350 @@
+# Sample config exercising multiple SC ports per rail.
+#
+# Naming convention:
+#   SC_RAIL_0 → sc_port_0, sc_port_1, sc_port_2  (Y = 0.0295 in task board frame)
+#   SC_RAIL_1 → sc_port_3, sc_port_4, sc_port_5  (Y = 0.0705 in task board frame)
+#
+# Port presence is independent — any subset may be present.
+# The engine enforces a 30 mm minimum center-to-center gap between ports on
+# the same rail, clamping translations to the rail limits [-0.06, 0.055] m.
+
+scoring:
+  topics:
+    # Joint states for the robot arm
+    - topic:
+        name: "/joint_states"
+        type: "sensor_msgs/msg/JointState"
+    - topic:
+    # TF that contains the robot and gripper poses
+        name: "/tf"
+        type: "tf2_msgs/msg/TFMessage"
+    - topic:
+    # TF that contains the robot and gripper static poses
+        name: "/tf_static"
+        type: "tf2_msgs/msg/TFMessage"
+        latched: true
+    - topic:
+    # TF that contains the cable link poses
+        name: "/scoring/tf"
+        type: "tf2_msgs/msg/TFMessage"
+    - topic:
+    # Contains the contacts with off limit items
+        name: "/aic/gazebo/contacts/off_limit"
+        type: "ros_gz_interfaces/msg/Contacts"
+    - topic:
+    # Insertion force sensed by the force torque sensor
+        name: "/fts_broadcaster/wrench"
+        type: "geometry_msgs/msg/WrenchStamped"
+    - topic:
+    # Joint commands sent from the model to the robot controller
+        name: "/aic_controller/joint_commands"
+        type: "aic_control_interfaces/msg/JointMotionUpdate"
+    - topic:
+    # Pose commands sent from the model to the robot controller
+        name: "/aic_controller/pose_commands"
+        type: "aic_control_interfaces/msg/MotionUpdate"
+    - topic:
+    # Cable plug-port insertion task completion event
+        name: "/scoring/insertion_event"
+        type: "std_msgs/msg/String"
+    - topic:
+    # Controller state for force torque tare
+        name: "/aic_controller/controller_state"
+        type: "aic_control_interfaces/msg/ControllerState"
+
+task_board_limits:
+  nic_rail:
+    min_translation: -0.0215
+    max_translation: 0.0234
+  sc_rail:
+    min_translation: -0.06
+    max_translation: 0.055
+  mount_rail:
+    min_translation: -0.09425
+    max_translation: 0.09425
+
+trials:
+  # ── Trial 1: 2 SC ports ────────────────────────────────────────────────────
+  # SC_PORT_0 and SC_PORT_1 both on SC_RAIL_0, gap = 40 mm (> 30 mm minimum)
+  trial_1:
+    scene:
+        task_board:
+          pose:
+            x: 0.15
+            y: -0.2
+            z: 1.14
+            roll: 0.0
+            pitch: 0.0
+            yaw: 3.1415
+          nic_rail_0:
+            entity_present: False
+          nic_rail_1:
+            entity_present: False
+          nic_rail_2:
+            entity_present: False
+          nic_rail_3:
+            entity_present: False
+          nic_rail_4:
+            entity_present: False
+          sc_rail_0:
+            sc_port_0:
+              entity_present: True
+              entity_name: "sc_port_0"
+              entity_pose:
+                translation: -0.030
+                roll: 0.0
+                pitch: 0.0
+                yaw: 0.0
+            sc_port_1:
+              entity_present: True
+              entity_name: "sc_port_1"
+              entity_pose:
+                translation: 0.010  # 40 mm from sc_port_0
+                roll: 0.0
+                pitch: 0.0
+                yaw: 0.0
+            sc_port_2:
+              entity_present: False
+          sc_rail_1:
+            sc_port_3:
+              entity_present: False
+            sc_port_4:
+              entity_present: False
+            sc_port_5:
+              entity_present: False
+          lc_mount_rail_0:
+            entity_present: False
+          sfp_mount_rail_0:
+            entity_present: False
+          sc_mount_rail_0:
+            entity_present: False
+          lc_mount_rail_1:
+            entity_present: False
+          sfp_mount_rail_1:
+            entity_present: False
+          sc_mount_rail_1:
+            entity_present: False
+        cables:
+          cable_0:
+            pose:
+              gripper_offset:
+                x: 0.0
+                y: 0.015385
+                z: 0.04045
+              roll: 0.4432
+              pitch: -0.4838
+              yaw: 1.3303
+            attach_cable_to_gripper: False
+            cable_type: "sfp_sc_cable_reversed"
+    tasks:
+      task_1:
+        cable_type: "sfp_sc"
+        cable_name: "cable_0"
+        plug_type: "sc"
+        plug_name: "sc_tip"
+        port_type: "sc"
+        port_name: "sc_port_base"
+        target_module_name: "sc_port_0"
+        time_limit: 180
+
+  # ── Trial 2: 3 SC ports (non-contiguous, across both rails) ───────────────
+  # SC_PORT_0 on SC_RAIL_0; SC_PORT_3 and SC_PORT_5 on SC_RAIL_1
+  # SC_RAIL_1 gap: PORT_3 at -0.025, PORT_5 at 0.020 → gap = 45 mm (> 30 mm)
+  trial_2:
+    scene:
+        task_board:
+          pose:
+            x: 0.15
+            y: -0.2
+            z: 1.14
+            roll: 0.0
+            pitch: 0.0
+            yaw: 3.1415
+          nic_rail_0:
+            entity_present: False
+          nic_rail_1:
+            entity_present: False
+          nic_rail_2:
+            entity_present: False
+          nic_rail_3:
+            entity_present: False
+          nic_rail_4:
+            entity_present: False
+          sc_rail_0:
+            sc_port_0:
+              entity_present: True
+              entity_name: "sc_port_0"
+              entity_pose:
+                translation: 0.0
+                roll: 0.0
+                pitch: 0.0
+                yaw: 0.0
+            sc_port_1:
+              entity_present: False
+            sc_port_2:
+              entity_present: False
+          sc_rail_1:
+            sc_port_3:
+              entity_present: True
+              entity_name: "sc_port_3"
+              entity_pose:
+                translation: -0.025
+                roll: 0.0
+                pitch: 0.0
+                yaw: 0.0
+            sc_port_4:
+              entity_present: False
+            sc_port_5:
+              entity_present: True
+              entity_name: "sc_port_5"
+              entity_pose:
+                translation: 0.020  # 45 mm from sc_port_3
+                roll: 0.0
+                pitch: 0.0
+                yaw: 0.0
+          lc_mount_rail_0:
+            entity_present: False
+          sfp_mount_rail_0:
+            entity_present: False
+          sc_mount_rail_0:
+            entity_present: False
+          lc_mount_rail_1:
+            entity_present: False
+          sfp_mount_rail_1:
+            entity_present: False
+          sc_mount_rail_1:
+            entity_present: False
+        cables:
+          cable_0:
+            pose:
+              gripper_offset:
+                x: 0.0
+                y: 0.015385
+                z: 0.04045
+              roll: 0.4432
+              pitch: -0.4838
+              yaw: 1.3303
+            attach_cable_to_gripper: False
+            cable_type: "sfp_sc_cable_reversed"
+    tasks:
+      task_1:
+        cable_type: "sfp_sc"
+        cable_name: "cable_0"
+        plug_type: "sc"
+        plug_name: "sc_tip"
+        port_type: "sc"
+        port_name: "sc_port_base"
+        target_module_name: "sc_port_5"
+        time_limit: 180
+
+  # ── Trial 3: 5 SC ports ────────────────────────────────────────────────────
+  # SC_PORT_0, SC_PORT_1, SC_PORT_2 on SC_RAIL_0 (gaps exactly 30 mm each)
+  # SC_PORT_3, SC_PORT_4 on SC_RAIL_1 (gap exactly 30 mm)
+  # SC_PORT_5 absent
+  trial_3:
+    scene:
+        task_board:
+          pose:
+            x: 0.15
+            y: -0.2
+            z: 1.14
+            roll: 0.0
+            pitch: 0.0
+            yaw: 3.1415
+          nic_rail_0:
+            entity_present: False
+          nic_rail_1:
+            entity_present: False
+          nic_rail_2:
+            entity_present: False
+          nic_rail_3:
+            entity_present: False
+          nic_rail_4:
+            entity_present: False
+          sc_rail_0:
+            sc_port_0:
+              entity_present: True
+              entity_name: "sc_port_0"
+              entity_pose:
+                translation: -0.050
+                roll: 0.0
+                pitch: 0.0
+                yaw: 0.0
+            sc_port_1:
+              entity_present: True
+              entity_name: "sc_port_1"
+              entity_pose:
+                translation: -0.020  # 30 mm from sc_port_0
+                roll: 0.0
+                pitch: 0.0
+                yaw: 0.0
+            sc_port_2:
+              entity_present: True
+              entity_name: "sc_port_2"
+              entity_pose:
+                translation: 0.010  # 30 mm from sc_port_1
+                roll: 0.0
+                pitch: 0.0
+                yaw: 0.0
+          sc_rail_1:
+            sc_port_3:
+              entity_present: True
+              entity_name: "sc_port_3"
+              entity_pose:
+                translation: -0.015
+                roll: 0.0
+                pitch: 0.0
+                yaw: 0.0
+            sc_port_4:
+              entity_present: True
+              entity_name: "sc_port_4"
+              entity_pose:
+                translation: 0.015  # 30 mm from sc_port_3
+                roll: 0.0
+                pitch: 0.0
+                yaw: 0.0
+            sc_port_5:
+              entity_present: False
+          lc_mount_rail_0:
+            entity_present: False
+          sfp_mount_rail_0:
+            entity_present: False
+          sc_mount_rail_0:
+            entity_present: False
+          lc_mount_rail_1:
+            entity_present: False
+          sfp_mount_rail_1:
+            entity_present: False
+          sc_mount_rail_1:
+            entity_present: False
+        cables:
+          cable_0:
+            pose:
+              gripper_offset:
+                x: 0.0
+                y: 0.015385
+                z: 0.04045
+              roll: 0.4432
+              pitch: -0.4838
+              yaw: 1.3303
+            attach_cable_to_gripper: False
+            cable_type: "sfp_sc_cable_reversed"
+    tasks:
+      task_1:
+        cable_type: "sfp_sc"
+        cable_name: "cable_0"
+        plug_type: "sc"
+        plug_name: "sc_tip"
+        port_type: "sc"
+        port_name: "sc_port_base"
+        target_module_name: "sc_port_2"
+        time_limit: 180
+
+robot:
+  home_joint_positions:
+    shoulder_pan_joint: -0.1597
+    shoulder_lift_joint: -1.3542
+    elbow_joint: -1.6648
+    wrist_1_joint: -1.6933
+    wrist_2_joint: 1.5710
+    wrist_3_joint: 1.4110

--- a/aic_engine/src/aic_engine.cpp
+++ b/aic_engine/src/aic_engine.cpp
@@ -41,9 +41,9 @@ enum class ScPortAdjustStatus { None, Adjusted, Overflow, Overpacked };
 
 // Enforces a minimum center-to-center buffer between sorted (by translation)
 // SC ports. Mutates translations in-place; returns the adjustment status.
-ScPortAdjustStatus enforce_sc_port_constraints(std::vector<std::pair<int, double>>& ports,
-                                          double rail_min, double rail_max,
-                                          double min_buffer) {
+ScPortAdjustStatus enforce_sc_port_constraints(
+    std::vector<std::pair<int, double>>& ports, double rail_min,
+    double rail_max, double min_buffer) {
   bool adjusted = false;
   for (size_t j = 1; j < ports.size(); ++j) {
     if (ports[j].second - ports[j - 1].second < min_buffer) {
@@ -136,7 +136,8 @@ Trial::Trial(const std::string& _id, YAML::Node _config) : id(std::move(_id)) {
     }
   }
 
-  // Validate SC rails (sc_rail_0 and sc_rail_1), each with up to MAX_SC_PORTS_PER_RAIL ports
+  // Validate SC rails (sc_rail_0 and sc_rail_1), each with up to
+  // MAX_SC_PORTS_PER_RAIL ports
   for (int rail_idx = 0; rail_idx < 2; ++rail_idx) {
     std::string rail_key = "sc_rail_" + std::to_string(rail_idx);
     if (!task_board[rail_key]) {
@@ -145,34 +146,36 @@ Trial::Trial(const std::string& _id, YAML::Node _config) : id(std::move(_id)) {
     }
     const auto& rail = task_board[rail_key];
     int port_start = rail_idx * MAX_SC_PORTS_PER_RAIL;
-    for (int port_idx = port_start; port_idx < port_start + MAX_SC_PORTS_PER_RAIL; ++port_idx) {
+    for (int port_idx = port_start;
+         port_idx < port_start + MAX_SC_PORTS_PER_RAIL; ++port_idx) {
       std::string port_key = "sc_port_" + std::to_string(port_idx);
       if (!rail[port_key]) {
         throw std::runtime_error(
-            "Config missing required key: 'scene.task_board." + rail_key + "." + port_key + "'");
+            "Config missing required key: 'scene.task_board." + rail_key + "." +
+            port_key + "'");
       }
       if (!rail[port_key]["entity_present"]) {
         throw std::runtime_error(
-            "Config missing required key: 'scene.task_board." + rail_key + "." + port_key +
-            ".entity_present'");
+            "Config missing required key: 'scene.task_board." + rail_key + "." +
+            port_key + ".entity_present'");
       }
       if (rail[port_key]["entity_present"].as<bool>()) {
         if (!rail[port_key]["entity_name"]) {
           throw std::runtime_error(
-              "Config missing required key: 'scene.task_board." + rail_key + "." + port_key +
-              ".entity_name'");
+              "Config missing required key: 'scene.task_board." + rail_key +
+              "." + port_key + ".entity_name'");
         }
         if (!rail[port_key]["entity_pose"]) {
           throw std::runtime_error(
-              "Config missing required key: 'scene.task_board." + rail_key + "." + port_key +
-              ".entity_pose'");
+              "Config missing required key: 'scene.task_board." + rail_key +
+              "." + port_key + ".entity_pose'");
         }
         const auto& entity_pose = rail[port_key]["entity_pose"];
         for (const auto& key : {"translation", "roll", "pitch", "yaw"}) {
           if (!entity_pose[key]) {
             throw std::runtime_error(
-                "Config missing required key: 'scene.task_board." + rail_key + "." + port_key +
-                ".entity_pose." + key + "'");
+                "Config missing required key: 'scene.task_board." + rail_key +
+                "." + port_key + ".entity_pose." + key + "'");
           }
         }
       }
@@ -1884,46 +1887,58 @@ bool Engine::spawn_entity(Trial& trial, std::string entity_name,
       }
     }
 
-    // Add SC rail parameters (sc_rail_0 and sc_rail_1, up to MAX_SC_PORTS_PER_RAIL ports each)
+    // Add SC rail parameters (sc_rail_0 and sc_rail_1, up to
+    // MAX_SC_PORTS_PER_RAIL ports each)
     constexpr double SC_PORT_MIN_BUFFER = 0.030;
     for (int rail_idx = 0; rail_idx < 2; ++rail_idx) {
       const std::string rail_key = "sc_rail_" + std::to_string(rail_idx);
       const int port_start = rail_idx * MAX_SC_PORTS_PER_RAIL;
 
       std::vector<std::pair<int, double>> present_ports;
-      for (int port_idx = port_start; port_idx < port_start + MAX_SC_PORTS_PER_RAIL; ++port_idx) {
+      for (int port_idx = port_start;
+           port_idx < port_start + MAX_SC_PORTS_PER_RAIL; ++port_idx) {
         const std::string port_key = "sc_port_" + std::to_string(port_idx);
         if (config[rail_key] && config[rail_key][port_key] &&
             config[rail_key][port_key]["entity_present"] &&
             config[rail_key][port_key]["entity_present"].as<bool>()) {
           present_ports.push_back(
               {port_idx,
-               std::clamp(config[rail_key][port_key]["entity_pose"]["translation"].as<double>(),
-                          sc_rail_min, sc_rail_max)});
+               std::clamp(
+                   config[rail_key][port_key]["entity_pose"]["translation"]
+                       .as<double>(),
+                   sc_rail_min, sc_rail_max)});
         }
       }
-      std::sort(present_ports.begin(), present_ports.end(),
-                [](const auto& a, const auto& b) { return a.second < b.second; });
+      std::sort(
+          present_ports.begin(), present_ports.end(),
+          [](const auto& a, const auto& b) { return a.second < b.second; });
 
-      switch (enforce_sc_port_constraints(present_ports, sc_rail_min, sc_rail_max, SC_PORT_MIN_BUFFER)) {
+      switch (enforce_sc_port_constraints(present_ports, sc_rail_min,
+                                          sc_rail_max, SC_PORT_MIN_BUFFER)) {
         case ScPortAdjustStatus::Overflow:
           RCLCPP_WARN(node_->get_logger(),
-                      "SC %s: port positions have been adjusted to fit within rail limits "
+                      "SC %s: port positions have been adjusted to fit within "
+                      "rail limits "
                       "[%.3f, %.3f] m with %.3f m minimum buffer.",
-                      rail_key.c_str(), sc_rail_min, sc_rail_max, SC_PORT_MIN_BUFFER);
+                      rail_key.c_str(), sc_rail_min, sc_rail_max,
+                      SC_PORT_MIN_BUFFER);
           break;
         case ScPortAdjustStatus::Overpacked:
-          RCLCPP_WARN(node_->get_logger(),
-                      "SC %s: %zu ports cannot all fit within rail limits [%.3f, %.3f] m with "
-                      "%.3f m minimum buffer; ports packed as tightly as possible.",
-                      rail_key.c_str(), present_ports.size(), sc_rail_min, sc_rail_max,
-                      SC_PORT_MIN_BUFFER);
+          RCLCPP_WARN(
+              node_->get_logger(),
+              "SC %s: %zu ports cannot all fit within rail limits [%.3f, %.3f] "
+              "m with "
+              "%.3f m minimum buffer; ports packed as tightly as possible.",
+              rail_key.c_str(), present_ports.size(), sc_rail_min, sc_rail_max,
+              SC_PORT_MIN_BUFFER);
           break;
         case ScPortAdjustStatus::Adjusted:
           RCLCPP_WARN(node_->get_logger(),
-                      "SC %s: port translations adjusted to enforce %.3f m minimum buffer and "
+                      "SC %s: port translations adjusted to enforce %.3f m "
+                      "minimum buffer and "
                       "stay within rail limits [%.3f, %.3f] m.",
-                      rail_key.c_str(), SC_PORT_MIN_BUFFER, sc_rail_min, sc_rail_max);
+                      rail_key.c_str(), SC_PORT_MIN_BUFFER, sc_rail_min,
+                      sc_rail_max);
           break;
         default:
           break;
@@ -1932,7 +1947,8 @@ bool Engine::spawn_entity(Trial& trial, std::string entity_name,
       std::map<int, double> adjusted;
       for (const auto& [idx, t] : present_ports) adjusted[idx] = t;
 
-      for (int port_idx = port_start; port_idx < port_start + MAX_SC_PORTS_PER_RAIL; ++port_idx) {
+      for (int port_idx = port_start;
+           port_idx < port_start + MAX_SC_PORTS_PER_RAIL; ++port_idx) {
         const std::string port_key = "sc_port_" + std::to_string(port_idx);
         if (adjusted.count(port_idx)) {
           const auto& pose = config[rail_key][port_key]["entity_pose"];

--- a/aic_engine/src/aic_engine.cpp
+++ b/aic_engine/src/aic_engine.cpp
@@ -102,36 +102,45 @@ Trial::Trial(const std::string& _id, YAML::Node _config) : id(std::move(_id)) {
     }
   }
 
-  // Validate SC rails (sc_rail_0 and sc_rail_1)
-  for (int i = 0; i < 2; ++i) {
-    std::string rail_key = "sc_rail_" + std::to_string(i);
+  // Validate SC rails (sc_rail_0 and sc_rail_1), each with up to MAX_SC_PORTS_PER_RAIL ports
+  constexpr int MAX_SC_PORTS_PER_RAIL = 3;
+  for (int rail_idx = 0; rail_idx < 2; ++rail_idx) {
+    std::string rail_key = "sc_rail_" + std::to_string(rail_idx);
     if (!task_board[rail_key]) {
       throw std::runtime_error(
           "Config missing required key: 'scene.task_board." + rail_key + "'");
     }
     const auto& rail = task_board[rail_key];
-    if (!rail["entity_present"]) {
-      throw std::runtime_error(
-          "Config missing required key: 'scene.task_board." + rail_key +
-          ".entity_present'");
-    }
-    if (rail["entity_present"].as<bool>()) {
-      if (!rail["entity_name"]) {
+    int port_start = rail_idx * MAX_SC_PORTS_PER_RAIL;
+    for (int port_idx = port_start; port_idx < port_start + MAX_SC_PORTS_PER_RAIL; ++port_idx) {
+      std::string port_key = "sc_port_" + std::to_string(port_idx);
+      if (!rail[port_key]) {
         throw std::runtime_error(
-            "Config missing required key: 'scene.task_board." + rail_key +
-            ".entity_name'");
+            "Config missing required key: 'scene.task_board." + rail_key + "." + port_key + "'");
       }
-      if (!rail["entity_pose"]) {
+      if (!rail[port_key]["entity_present"]) {
         throw std::runtime_error(
-            "Config missing required key: 'scene.task_board." + rail_key +
-            ".entity_pose'");
+            "Config missing required key: 'scene.task_board." + rail_key + "." + port_key +
+            ".entity_present'");
       }
-      const auto& entity_pose = rail["entity_pose"];
-      for (const auto& key : {"translation", "roll", "pitch", "yaw"}) {
-        if (!entity_pose[key]) {
+      if (rail[port_key]["entity_present"].as<bool>()) {
+        if (!rail[port_key]["entity_name"]) {
           throw std::runtime_error(
-              "Config missing required key: 'scene.task_board." + rail_key +
-              ".entity_pose." + key + "'");
+              "Config missing required key: 'scene.task_board." + rail_key + "." + port_key +
+              ".entity_name'");
+        }
+        if (!rail[port_key]["entity_pose"]) {
+          throw std::runtime_error(
+              "Config missing required key: 'scene.task_board." + rail_key + "." + port_key +
+              ".entity_pose'");
+        }
+        const auto& entity_pose = rail[port_key]["entity_pose"];
+        for (const auto& key : {"translation", "roll", "pitch", "yaw"}) {
+          if (!entity_pose[key]) {
+            throw std::runtime_error(
+                "Config missing required key: 'scene.task_board." + rail_key + "." + port_key +
+                ".entity_pose." + key + "'");
+          }
         }
       }
     }
@@ -1842,33 +1851,95 @@ bool Engine::spawn_entity(Trial& trial, std::string entity_name,
       }
     }
 
-    // Add SC rail parameters (sc_rail_0 and sc_rail_1)
-    for (int i = 0; i < 2; ++i) {
-      std::string rail_key = "sc_rail_" + std::to_string(i);
-      std::string port_prefix = "sc_port_" + std::to_string(i);
+    // Add SC rail parameters (sc_rail_0 and sc_rail_1, up to MAX_SC_PORTS_PER_RAIL ports each)
+    constexpr double SC_PORT_MIN_BUFFER = 0.030;
+    constexpr int MAX_SC_PORTS_PER_RAIL = 3;
+    for (int rail_idx = 0; rail_idx < 2; ++rail_idx) {
+      std::string rail_key = "sc_rail_" + std::to_string(rail_idx);
+      int port_start = rail_idx * MAX_SC_PORTS_PER_RAIL;
 
-      if (config[rail_key] && config[rail_key]["entity_present"] &&
-          config[rail_key]["entity_present"].as<bool>()) {
-        cmd << " " << port_prefix << "_present:=true";
-
-        if (config[rail_key]["entity_pose"]) {
-          const auto& pose = config[rail_key]["entity_pose"];
-
-          double translation = pose["translation"].as<double>();
-          // Clamp translation to SC rail limits
-          translation = std::clamp(translation, sc_rail_min, sc_rail_max);
-          cmd << " " << port_prefix << "_translation:=" << translation;
-
-          // Add orientation parameters
-          double roll = pose["roll"].as<double>();
-          double pitch = pose["pitch"].as<double>();
-          double yaw = pose["yaw"].as<double>();
-          cmd << " " << port_prefix << "_roll:=" << roll;
-          cmd << " " << port_prefix << "_pitch:=" << pitch;
-          cmd << " " << port_prefix << "_yaw:=" << yaw;
+      // Collect present ports and clamp translations to rail limits
+      std::vector<std::pair<int, double>> present_ports;
+      for (int port_idx = port_start; port_idx < port_start + MAX_SC_PORTS_PER_RAIL; ++port_idx) {
+        std::string port_key = "sc_port_" + std::to_string(port_idx);
+        if (config[rail_key] && config[rail_key][port_key] &&
+            config[rail_key][port_key]["entity_present"] &&
+            config[rail_key][port_key]["entity_present"].as<bool>()) {
+          double t = config[rail_key][port_key]["entity_pose"]["translation"].as<double>();
+          t = std::clamp(t, sc_rail_min, sc_rail_max);
+          present_ports.push_back({port_idx, t});
         }
-      } else {
-        cmd << " " << port_prefix << "_present:=false";
+      }
+
+      // Sort by translation so buffer enforcement is applied in order
+      std::sort(present_ports.begin(), present_ports.end(),
+                [](const auto& a, const auto& b) { return a.second < b.second; });
+
+      // Forward-pass: push ports forward to enforce minimum buffer
+      bool adjusted_positions = false;
+      for (size_t j = 1; j < present_ports.size(); ++j) {
+        if (present_ports[j].second - present_ports[j - 1].second < SC_PORT_MIN_BUFFER) {
+          present_ports[j].second = present_ports[j - 1].second + SC_PORT_MIN_BUFFER;
+          adjusted_positions = true;
+        }
+      }
+
+      // Backward-pass: if last port exceeds rail max, pull all back while maintaining gaps
+      if (!present_ports.empty() && present_ports.back().second > sc_rail_max) {
+        adjusted_positions = true;
+        RCLCPP_WARN(node_->get_logger(),
+                    "SC %s: port translations exceed rail max (%.3f m); port positions have been "
+                    "adjusted to fit within rail limits.",
+                    rail_key.c_str(), sc_rail_max);
+        present_ports.back().second = sc_rail_max;
+        for (int j = static_cast<int>(present_ports.size()) - 2; j >= 0; --j) {
+          double required = present_ports[j + 1].second - SC_PORT_MIN_BUFFER;
+          if (present_ports[j].second > required)
+            present_ports[j].second = required;
+        }
+      }
+
+      // Final validation: if first port fell below rail min, ports cannot all fit
+      if (!present_ports.empty() && present_ports.front().second < sc_rail_min) {
+        throw std::runtime_error(
+            rail_key + ": present ports cannot all fit within rail limits [" +
+            std::to_string(sc_rail_min) + ", " + std::to_string(sc_rail_max) +
+            "] with minimum buffer " + std::to_string(SC_PORT_MIN_BUFFER) + " m.");
+      }
+
+      // Defensive check: assert no overlap remains after adjustment
+      for (size_t j = 1; j < present_ports.size(); ++j) {
+        if (present_ports[j].second - present_ports[j - 1].second < SC_PORT_MIN_BUFFER - 1e-9) {
+          throw std::runtime_error(
+              rail_key + ": buffer enforcement failed — ports still overlap after adjustment.");
+        }
+      }
+
+      if (adjusted_positions) {
+        RCLCPP_WARN(node_->get_logger(),
+                    "SC %s: one or more port translations were adjusted to enforce %.3f m minimum "
+                    "buffer and stay within rail limits [%.3f, %.3f] m.",
+                    rail_key.c_str(), SC_PORT_MIN_BUFFER, sc_rail_min, sc_rail_max);
+      }
+
+      // Build port-index to adjusted translation map
+      std::map<int, double> adjusted;
+      for (const auto& [idx, t] : present_ports) adjusted[idx] = t;
+
+      // Emit xacro params for all ports on this rail
+      for (int port_idx = port_start; port_idx < port_start + MAX_SC_PORTS_PER_RAIL; ++port_idx) {
+        std::string port_key = "sc_port_" + std::to_string(port_idx);
+        std::string prefix = "sc_port_" + std::to_string(port_idx);
+        if (adjusted.count(port_idx)) {
+          cmd << " " << prefix << "_present:=true";
+          cmd << " " << prefix << "_translation:=" << adjusted[port_idx];
+          const auto& pose = config[rail_key][port_key]["entity_pose"];
+          cmd << " " << prefix << "_roll:=" << pose["roll"].as<double>();
+          cmd << " " << prefix << "_pitch:=" << pose["pitch"].as<double>();
+          cmd << " " << prefix << "_yaw:=" << pose["yaw"].as<double>();
+        } else {
+          cmd << " " << prefix << "_present:=false";
+        }
       }
     }
 

--- a/aic_engine/src/aic_engine.cpp
+++ b/aic_engine/src/aic_engine.cpp
@@ -1952,11 +1952,11 @@ bool Engine::spawn_entity(Trial& trial, std::string entity_name,
         const std::string port_key = "sc_port_" + std::to_string(port_idx);
         if (adjusted.count(port_idx)) {
           const auto& pose = config[rail_key][port_key]["entity_pose"];
-          cmd << " " << port_key << "_present:=true"
-              << " " << port_key << "_translation:=" << adjusted[port_idx]
-              << " " << port_key << "_roll:=" << pose["roll"].as<double>()
-              << " " << port_key << "_pitch:=" << pose["pitch"].as<double>()
-              << " " << port_key << "_yaw:=" << pose["yaw"].as<double>();
+          cmd << " " << port_key << "_present:=true" << " " << port_key
+              << "_translation:=" << adjusted[port_idx] << " " << port_key
+              << "_roll:=" << pose["roll"].as<double>() << " " << port_key
+              << "_pitch:=" << pose["pitch"].as<double>() << " " << port_key
+              << "_yaw:=" << pose["yaw"].as<double>();
         } else {
           cmd << " " << port_key << "_present:=false";
         }

--- a/aic_engine/src/aic_engine.cpp
+++ b/aic_engine/src/aic_engine.cpp
@@ -37,6 +37,40 @@
 
 namespace aic {
 
+enum class ScPortAdjustStatus { None, Adjusted, Overflow, Overpacked };
+
+// Enforces a minimum center-to-center buffer between sorted (by translation)
+// SC ports. Mutates translations in-place; returns the adjustment status.
+ScPortAdjustStatus enforce_sc_port_constraints(std::vector<std::pair<int, double>>& ports,
+                                          double rail_min, double rail_max,
+                                          double min_buffer) {
+  bool adjusted = false;
+  for (size_t j = 1; j < ports.size(); ++j) {
+    if (ports[j].second - ports[j - 1].second < min_buffer) {
+      ports[j].second = ports[j - 1].second + min_buffer;
+      adjusted = true;
+    }
+  }
+  if (!ports.empty() && ports.back().second > rail_max) {
+    ports.back().second = rail_max;
+    for (int j = static_cast<int>(ports.size()) - 2; j >= 0; --j) {
+      double req = ports[j + 1].second - min_buffer;
+      if (ports[j].second > req) ports[j].second = req;
+    }
+    if (ports.front().second < rail_min) {
+      ports.front().second = rail_min;
+      for (size_t j = 1; j < ports.size(); ++j)
+        ports[j].second = std::min(ports[j - 1].second + min_buffer, rail_max);
+      return ports.back().second >= rail_max ? ScPortAdjustStatus::Overpacked
+                                             : ScPortAdjustStatus::Overflow;
+    }
+    return ScPortAdjustStatus::Overflow;
+  }
+  return adjusted ? ScPortAdjustStatus::Adjusted : ScPortAdjustStatus::None;
+}
+
+constexpr int MAX_SC_PORTS_PER_RAIL = 3;
+
 //==============================================================================
 Trial::Trial(const std::string& _id, YAML::Node _config) : id(std::move(_id)) {
   // Validate config structure
@@ -103,7 +137,6 @@ Trial::Trial(const std::string& _id, YAML::Node _config) : id(std::move(_id)) {
   }
 
   // Validate SC rails (sc_rail_0 and sc_rail_1), each with up to MAX_SC_PORTS_PER_RAIL ports
-  constexpr int MAX_SC_PORTS_PER_RAIL = 3;
   for (int rail_idx = 0; rail_idx < 2; ++rail_idx) {
     std::string rail_key = "sc_rail_" + std::to_string(rail_idx);
     if (!task_board[rail_key]) {
@@ -1853,92 +1886,63 @@ bool Engine::spawn_entity(Trial& trial, std::string entity_name,
 
     // Add SC rail parameters (sc_rail_0 and sc_rail_1, up to MAX_SC_PORTS_PER_RAIL ports each)
     constexpr double SC_PORT_MIN_BUFFER = 0.030;
-    constexpr int MAX_SC_PORTS_PER_RAIL = 3;
     for (int rail_idx = 0; rail_idx < 2; ++rail_idx) {
-      std::string rail_key = "sc_rail_" + std::to_string(rail_idx);
-      int port_start = rail_idx * MAX_SC_PORTS_PER_RAIL;
+      const std::string rail_key = "sc_rail_" + std::to_string(rail_idx);
+      const int port_start = rail_idx * MAX_SC_PORTS_PER_RAIL;
 
-      // Collect present ports and clamp translations to rail limits
       std::vector<std::pair<int, double>> present_ports;
       for (int port_idx = port_start; port_idx < port_start + MAX_SC_PORTS_PER_RAIL; ++port_idx) {
-        std::string port_key = "sc_port_" + std::to_string(port_idx);
+        const std::string port_key = "sc_port_" + std::to_string(port_idx);
         if (config[rail_key] && config[rail_key][port_key] &&
             config[rail_key][port_key]["entity_present"] &&
             config[rail_key][port_key]["entity_present"].as<bool>()) {
-          double t = config[rail_key][port_key]["entity_pose"]["translation"].as<double>();
-          t = std::clamp(t, sc_rail_min, sc_rail_max);
-          present_ports.push_back({port_idx, t});
+          present_ports.push_back(
+              {port_idx,
+               std::clamp(config[rail_key][port_key]["entity_pose"]["translation"].as<double>(),
+                          sc_rail_min, sc_rail_max)});
         }
       }
-
-      // Sort by translation so buffer enforcement is applied in order
       std::sort(present_ports.begin(), present_ports.end(),
                 [](const auto& a, const auto& b) { return a.second < b.second; });
 
-      // Forward-pass: push ports forward to enforce minimum buffer
-      bool adjusted_positions = false;
-      for (size_t j = 1; j < present_ports.size(); ++j) {
-        if (present_ports[j].second - present_ports[j - 1].second < SC_PORT_MIN_BUFFER) {
-          present_ports[j].second = present_ports[j - 1].second + SC_PORT_MIN_BUFFER;
-          adjusted_positions = true;
-        }
+      switch (enforce_sc_port_constraints(present_ports, sc_rail_min, sc_rail_max, SC_PORT_MIN_BUFFER)) {
+        case ScPortAdjustStatus::Overflow:
+          RCLCPP_WARN(node_->get_logger(),
+                      "SC %s: port positions have been adjusted to fit within rail limits "
+                      "[%.3f, %.3f] m with %.3f m minimum buffer.",
+                      rail_key.c_str(), sc_rail_min, sc_rail_max, SC_PORT_MIN_BUFFER);
+          break;
+        case ScPortAdjustStatus::Overpacked:
+          RCLCPP_WARN(node_->get_logger(),
+                      "SC %s: %zu ports cannot all fit within rail limits [%.3f, %.3f] m with "
+                      "%.3f m minimum buffer; ports packed as tightly as possible.",
+                      rail_key.c_str(), present_ports.size(), sc_rail_min, sc_rail_max,
+                      SC_PORT_MIN_BUFFER);
+          break;
+        case ScPortAdjustStatus::Adjusted:
+          RCLCPP_WARN(node_->get_logger(),
+                      "SC %s: port translations adjusted to enforce %.3f m minimum buffer and "
+                      "stay within rail limits [%.3f, %.3f] m.",
+                      rail_key.c_str(), SC_PORT_MIN_BUFFER, sc_rail_min, sc_rail_max);
+          break;
+        default:
+          break;
       }
 
-      // Backward-pass: if last port exceeds rail max, pull all back while maintaining gaps
-      if (!present_ports.empty() && present_ports.back().second > sc_rail_max) {
-        adjusted_positions = true;
-        RCLCPP_WARN(node_->get_logger(),
-                    "SC %s: port translations exceed rail max (%.3f m); port positions have been "
-                    "adjusted to fit within rail limits.",
-                    rail_key.c_str(), sc_rail_max);
-        present_ports.back().second = sc_rail_max;
-        for (int j = static_cast<int>(present_ports.size()) - 2; j >= 0; --j) {
-          double required = present_ports[j + 1].second - SC_PORT_MIN_BUFFER;
-          if (present_ports[j].second > required)
-            present_ports[j].second = required;
-        }
-      }
-
-      // Final validation: if first port fell below rail min, ports cannot all fit
-      if (!present_ports.empty() && present_ports.front().second < sc_rail_min) {
-        throw std::runtime_error(
-            rail_key + ": present ports cannot all fit within rail limits [" +
-            std::to_string(sc_rail_min) + ", " + std::to_string(sc_rail_max) +
-            "] with minimum buffer " + std::to_string(SC_PORT_MIN_BUFFER) + " m.");
-      }
-
-      // Defensive check: assert no overlap remains after adjustment
-      for (size_t j = 1; j < present_ports.size(); ++j) {
-        if (present_ports[j].second - present_ports[j - 1].second < SC_PORT_MIN_BUFFER - 1e-9) {
-          throw std::runtime_error(
-              rail_key + ": buffer enforcement failed — ports still overlap after adjustment.");
-        }
-      }
-
-      if (adjusted_positions) {
-        RCLCPP_WARN(node_->get_logger(),
-                    "SC %s: one or more port translations were adjusted to enforce %.3f m minimum "
-                    "buffer and stay within rail limits [%.3f, %.3f] m.",
-                    rail_key.c_str(), SC_PORT_MIN_BUFFER, sc_rail_min, sc_rail_max);
-      }
-
-      // Build port-index to adjusted translation map
       std::map<int, double> adjusted;
       for (const auto& [idx, t] : present_ports) adjusted[idx] = t;
 
-      // Emit xacro params for all ports on this rail
       for (int port_idx = port_start; port_idx < port_start + MAX_SC_PORTS_PER_RAIL; ++port_idx) {
-        std::string port_key = "sc_port_" + std::to_string(port_idx);
-        std::string prefix = "sc_port_" + std::to_string(port_idx);
+        const std::string port_key = "sc_port_" + std::to_string(port_idx);
         if (adjusted.count(port_idx)) {
-          cmd << " " << prefix << "_present:=true";
-          cmd << " " << prefix << "_translation:=" << adjusted[port_idx];
           const auto& pose = config[rail_key][port_key]["entity_pose"];
-          cmd << " " << prefix << "_roll:=" << pose["roll"].as<double>();
-          cmd << " " << prefix << "_pitch:=" << pose["pitch"].as<double>();
-          cmd << " " << prefix << "_yaw:=" << pose["yaw"].as<double>();
+          cmd << " " << port_key << "_present:=true"
+              << " " << port_key << "_translation:=" << adjusted[port_idx]
+              << " " << port_key << "_roll:=" << pose["roll"].as<double>()
+              << " " << port_key << "_pitch:=" << pose["pitch"].as<double>()
+              << " " << port_key << "_yaw:=" << pose["yaw"].as<double>();
         } else {
-          cmd << " " << prefix << "_present:=false";
+          cmd << " " << port_key << "_present:=false";
         }
       }
     }


### PR DESCRIPTION
# Support up to 3 SC ports per rail

## Summary

- Expanded SC port support from 2 ports (one per rail) to 6 total (3 per rail)
- Added automatic 30 mm minimum gap enforcement between ports on the same rail
- Fixed `sc_port_1` placement: was incorrectly positioned on RAIL_1, now correctly on RAIL_0
- Added test config demonstrating 2-port, 3-port (non-contiguous), and 5-port scenarios

## Port naming convention

| Rail | Ports |
|------|-------|
| `sc_rail_0` | `sc_port_0`, `sc_port_1`, `sc_port_2` |
| `sc_rail_1` | `sc_port_3`, `sc_port_4`, `sc_port_5` |

Port presence is independent: any subset across both rails is valid (e.g. `[sc_port_0, sc_port_3, sc_port_5]`).

## Changes

### `aic_description/urdf/task_board.urdf.xacro`
- Added xacro args and instantiation blocks for `sc_port_2` through `sc_port_5`
- Fixed `sc_port_1` Y offset: `0.0705` → `0.0295` (moves it from RAIL_1 to RAIL_0)

### `aic_engine/src/aic_engine.cpp`
- Redesigned SC rail YAML structure: each rail now holds named port keys (`sc_port_N`) instead of a single flat `entity_present` flag, allowing independent presence per port
- Added `enforce_sc_port_constraints()`: enforces a 30 mm minimum center-to-center gap via a forward pass (push conflicting ports forward) followed by a backward pass (pull back if the last port exceeds the rail max). Logs a warning if positions are adjusted; errors if ports cannot physically fit within rail limits.
- Added `ScPortAdjustStatus` enum (`None`, `Adjusted`, `Overflow`, `Overpacked`) for structured status reporting from the constraint function
- Added `MAX_SC_PORTS_PER_RAIL = 3` as a namespace-level constant

### `aic_engine/config/sample_config_multiple_sc_ports.yaml` *(new)*
Test config covering three scenarios:
- **Trial 1:** `sc_port_0` + `sc_port_1` on RAIL_0, gap = 40 mm
- **Trial 2:** `sc_port_0` on RAIL_0; `sc_port_3` + `sc_port_5` on RAIL_1, gap = 45 mm
- **Trial 3:** `sc_port_0/1/2` on RAIL_0 (30 mm gaps); `sc_port_3/4` on RAIL_1 (30 mm gap)

## Testing Instructions

**Build:**
```bash
colcon build --packages-select aic_engine aic_description
source install/setup.bash
```

**Run with the multi-port test config:**
```bash
ros2 launch aic_bringup aic_gz_bringup.launch.py \
  config_file:=<path_to_ws>/src/aic/aic_engine/config/sample_config_multiple_sc_ports.yaml
```

**Trial 1: 2 ports on RAIL_0:**
- Verify `sc_port_0` and `sc_port_1` spawn on RAIL_0, nothing on RAIL_1

**Trial 2: 3 ports, non-contiguous:**
- Verify `sc_port_0` on RAIL_0, `sc_port_3` and `sc_port_5` on RAIL_1
- `sc_port_1`, `sc_port_2`, `sc_port_4` should not be present
- Confirm trial 1 ports are fully removed before trial 2 spawns

**Trial 3: 5 ports:**
- Verify 3 ports on RAIL_0 (`sc_port_0`, `sc_port_1`, `sc_port_2`) and 2 on RAIL_1 (`sc_port_3`, `sc_port_4`)
- All gaps should be exactly 30 mm

**Buffer enforcement:**
- Edit `sample_config_multiple_sc_ports.yaml` to place two ports on the same rail with translations only 10 mm apart
- Confirm the engine logs a `WARN` and adjusts them to 30 mm apart at spawn time
