### PR TITLE
Tweak SC mount and SFP mount collisions

### DIFF
--- a/aic_assets/models/SC Mount/model.sdf
+++ b/aic_assets/models/SC Mount/model.sdf
@@ -61,7 +61,7 @@
         <pose>0.017774 -0.0 0.008656 0.0 0.785398 -0.0</pose>
         <geometry>
           <box>
-            <size>0.025812 0.014 0.001239</size>
+            <size>0.009 0.014 0.001239</size>
           </box>
         </geometry>
       </collision>

--- a/aic_assets/models/SFP Mount/model.sdf
+++ b/aic_assets/models/SFP Mount/model.sdf
@@ -34,18 +34,18 @@
         </geometry>
       </collision>
       <collision name="iso 4762 - m2 x 8072_collider_box.003">
-        <pose>0.021242 0.007723 0.013979 0.0 -0.785398 0.0</pose>
+        <pose>0.021242 0.0080 0.013979 0.0 -0.785398 0.0</pose>
         <geometry>
           <box>
-            <size>0.036111 0.002305 0.010956</size>
+            <size>0.036111 0.0018 0.010956</size>
           </box>
         </geometry>
       </collision>
       <collision name="iso 4762 - m2 x 8072_collider_box.004">
-        <pose>0.021003 -0.007938 0.014217 0.0 -0.785398 0.0</pose>
+        <pose>0.021003 -0.008 0.014217 0.0 -0.785398 0.0</pose>
         <geometry>
           <box>
-            <size>0.036111 0.001875 0.01163</size>
+            <size>0.036111 0.0018 0.01163</size>
           </box>
         </geometry>
       </collision>


### PR DESCRIPTION
Tweak these two mount collisions so the SFP module and SC plug can be inserted into them

Changes
* SFP Mount: the opening was too small and the SFP module could not fit in so reduced collision size and increased opening
* SC Mount: The SC plug wasn't not able to be inserted all the way in so adjusted the collision at the bottom of the mount.

After the changes, both plugs can be inserted all the way into the mount

<img width="514" height="505" alt="Screenshot from 2026-04-21 13-56-43" src="https://github.com/user-attachments/assets/669e02d4-76eb-4a14-92a8-2dd3d68114c0" />

<img width="550" height="497" alt="Screenshot from 2026-04-21 14-46-16" src="https://github.com/user-attachments/assets/46afaae7-8ce1-4e3b-9f03-f202e0b0f4d6" />


I was able to push these plugs out of the mount with around ~5N of force