### PR TITLE
place sdk-ros in top level of workspace

### DIFF
--- a/flowstate/flowstate.repos
+++ b/flowstate/flowstate.repos
@@ -1,5 +1,5 @@
 repositories:
-  intrinsic-ai/sdk-ros:
+  sdk-ros:
     type: git
     url: https://github.com/intrinsic-ai/sdk-ros.git
     version: df4abd6fdb9edf6e7af4a4b85f85e7f7f4d2c614


### PR DESCRIPTION
Adjust the location of `sdk-ros` to the top level of the workspace, to align the assumptions of its scripts and Dockerfiles.