### PR TITLE
Update sdk-ros repo hash 

### DIFF
--- a/flowstate/flowstate.repos
+++ b/flowstate/flowstate.repos
@@ -2,4 +2,4 @@ repositories:
   sdk-ros:
     type: git
     url: https://github.com/intrinsic-ai/sdk-ros.git
-    version: df4abd6fdb9edf6e7af4a4b85f85e7f7f4d2c614
+    version: 4e6c8ae2a51c5d36e2fe4f7f6fa0a5db8b008581


### PR DESCRIPTION
Update sdk-ros repo hash to [4e6c8ae](https://github.com/intrinsic-ai/sdk-ros/commit/4e6c8ae2a51c5d36e2fe4f7f6fa0a5db8b008581). This does not bump up the SDK version which should stay at `v1.28.20260223 `

This change is required in order to:
- support required features for the `robot_control_plugin` within Flowstate-ROS Bridge (#449)
- The bundle generation script in #449 depends on the new bundle generation in SDK-ROS commit [72c663c](https://github.com/intrinsic-ai/sdk-ros/commit/72c663c0b85691032c9bd8b2e6c57aa72384b8dd).