### PR TITLE
Update CableModeratorPlugin to monitor grasp events

### DIFF
--- a/aic_description/world/aic.sdf
+++ b/aic_description/world/aic.sdf
@@ -151,7 +151,7 @@
         <cable_connection_0_link>lc_plug_link</cable_connection_0_link>
         <cable_connection_0_port>nic_card_mount</cable_connection_0_port>
         <cable_connection_1_link>sc_plug_link</cable_connection_1_link>
-        <cable_connection_1_port>sc_port</cable_connection_1_port>
+        <cable_connection_1_port>sc_port_base</cable_connection_1_port>
       </cable>
       <end_effector_model>ur5e</end_effector_model>
       <end_effector_link>ati/tool_link</end_effector_link>

--- a/aic_description/world/aic.sdf
+++ b/aic_description/world/aic.sdf
@@ -151,7 +151,7 @@
         <cable_connection_0_link>lc_plug_link</cable_connection_0_link>
         <cable_connection_0_port>nic_card_mount</cable_connection_0_port>
         <cable_connection_1_link>sc_plug_link</cable_connection_1_link>
-        <cable_connection_1_port>sc_port_base</cable_connection_1_port>
+        <cable_connection_1_port>sc_port</cable_connection_1_port>
       </cable>
       <end_effector_model>ur5e</end_effector_model>
       <end_effector_link>ati/tool_link</end_effector_link>

--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -164,6 +164,46 @@ void CableModeratorPlugin::Configure(
 }
 
 //////////////////////////////////////////////////
+void CableModeratorPlugin::ProcessManualGraspRequests(
+    gz::sim::EntityComponentManager& _ecm) {
+  if (this->attachEnd0Requested.exchange(false)) {
+    if (this->FindGripperJoint(this->cableConnection0LinkEntity, _ecm) == kNullEntity) {
+      Entity jointEntity = _ecm.CreateEntity();
+      _ecm.CreateComponent(
+          jointEntity,
+          components::DetachableJoint(
+              {this->endEffectorLinkEntity, this->cableConnection0LinkEntity, "fixed"}));
+      gzdbg << "Manually attached end 0" << std::endl;
+    }
+  }
+  if (this->detachEnd0Requested.exchange(false)) {
+    Entity gripperJoint = this->FindGripperJoint(this->cableConnection0LinkEntity, _ecm);
+    if (gripperJoint != kNullEntity) {
+      _ecm.RequestRemoveEntity(gripperJoint);
+      gzdbg << "Manually detached end 0" << std::endl;
+    }
+  }
+
+  if (this->attachEnd1Requested.exchange(false)) {
+    if (this->FindGripperJoint(this->cableConnection1LinkEntity, _ecm) == kNullEntity) {
+      Entity jointEntity = _ecm.CreateEntity();
+      _ecm.CreateComponent(
+          jointEntity,
+          components::DetachableJoint(
+              {this->endEffectorLinkEntity, this->cableConnection1LinkEntity, "fixed"}));
+      gzdbg << "Manually attached end 1" << std::endl;
+    }
+  }
+  if (this->detachEnd1Requested.exchange(false)) {
+    Entity gripperJoint = this->FindGripperJoint(this->cableConnection1LinkEntity, _ecm);
+    if (gripperJoint != kNullEntity) {
+      _ecm.RequestRemoveEntity(gripperJoint);
+      gzdbg << "Manually detached end 1" << std::endl;
+    }
+  }
+}
+
+//////////////////////////////////////////////////
 void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
                                      gz::sim::EntityComponentManager& _ecm) {
   if (this->cableState == CableState::COMPLETED) return;
@@ -177,6 +217,8 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
         findLinkInModel(this->endEffectorModelName, endEffectorLinkName, _ecm);
   }
   if (this->endEffectorLinkEntity == kNullEntity) return;
+
+  this->ProcessManualGraspRequests(_ecm);
 
   if (this->cableState == CableState::HARNESS) {
     // Hold both connections of the cable in place
@@ -211,6 +253,10 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
     }
 
     if (this->attachCableConnectionToPort) {
+      this->cableConnectionPortSubs.clear();
+      this->attachCableConnectionToPort = false;
+      this->touchEventCallbackNamespace = std::nullopt;
+
       gzmsg << "Cable transitioning to ATTACH_TO_PORT_CONN_0 state."
             << std::endl;
       this->cableState = CableState::ATTACH_TO_PORT_CONN_0;
@@ -218,22 +264,16 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
   }
 
   if (this->cableState == CableState::ATTACH_TO_PORT_CONN_0) {
-    this->cableConnectionPortSubs.clear();
-    this->attachCableConnectionToPort = false;
-    this->touchEventCallbackNamespace = std::nullopt;
-
-    // Find and remove the externally-created gripper joint
     Entity gripperJoint =
         this->FindGripperJoint(this->cableConnection0LinkEntity, _ecm);
-    if (gripperJoint != kNullEntity) {
-      _ecm.RequestRemoveEntity(gripperJoint);
+
+    if (gripperJoint == kNullEntity) {
+      this->detachableJointStatic0Entity =
+          this->MakeStatic(this->cableConnection0LinkEntity, true, _ecm);
+
+      gzmsg << "Cable transitioning to WAITING_CONN_1 state." << std::endl;
+      this->cableState = CableState::WAITING_CONN_1;
     }
-
-    this->detachableJointStatic0Entity =
-        this->MakeStatic(this->cableConnection0LinkEntity, true, _ecm);
-
-    gzmsg << "Cable transitioning to WAITING_CONN_1 state." << std::endl;
-    this->cableState = CableState::WAITING_CONN_1;
   }
 
   if (this->cableState == CableState::WAITING_CONN_1) {
@@ -258,6 +298,10 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
     }
 
     if (this->attachCableConnectionToPort) {
+      this->cableConnectionPortSubs.clear();
+      this->attachCableConnectionToPort = false;
+      this->touchEventCallbackNamespace = std::nullopt;
+
       gzmsg << "Cable transitioning to ATTACH_TO_PORT_CONN_1 state."
             << std::endl;
       this->cableState = CableState::ATTACH_TO_PORT_CONN_1;
@@ -265,18 +309,16 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
   }
 
   if (this->cableState == CableState::ATTACH_TO_PORT_CONN_1) {
-    // Find and remove the externally-created gripper joint
     Entity gripperJoint =
         this->FindGripperJoint(this->cableConnection1LinkEntity, _ecm);
-    if (gripperJoint != kNullEntity) {
-      _ecm.RequestRemoveEntity(gripperJoint);
+
+    if (gripperJoint == kNullEntity) {
+      this->detachableJointStatic1Entity =
+          this->MakeStatic(this->cableConnection1LinkEntity, true, _ecm);
+
+      gzmsg << "Cable transitioning to NEXT_CABLE state." << std::endl;
+      this->cableState = CableState::NEXT_CABLE;
     }
-
-    this->detachableJointStatic1Entity =
-        this->MakeStatic(this->cableConnection1LinkEntity, true, _ecm);
-
-    gzmsg << "Cable transitioning to NEXT_CABLE state." << std::endl;
-    this->cableState = CableState::NEXT_CABLE;
   }
 
   if (this->cableState == CableState::NEXT_CABLE) {
@@ -409,9 +451,9 @@ Entity CableModeratorPlugin::FindGripperJoint(
             (info.parentLink == _connectionLinkEntity &&
              info.childLink == this->endEffectorLinkEntity)) {
           result = _entity;
-          return false;  // stop iteration
+          return false;
         }
-        return true;  // continue
+        return true;
       });
   return result;
 }
@@ -489,6 +531,18 @@ bool CableModeratorPlugin::ToggleActiveCable(
   if (this->cableConnection0LinkEntity == kNullEntity ||
       this->cableConnection1LinkEntity == kNullEntity)
     return false;
+
+  this->manualGraspSubs.clear();
+
+  auto cbAttach0 = std::function<void(const gz::msgs::Empty&)>([this](const gz::msgs::Empty&) { this->attachEnd0Requested = true; });
+  auto cbDetach0 = std::function<void(const gz::msgs::Empty&)>([this](const gz::msgs::Empty&) { this->detachEnd0Requested = true; });
+  auto cbAttach1 = std::function<void(const gz::msgs::Empty&)>([this](const gz::msgs::Empty&) { this->attachEnd1Requested = true; });
+  auto cbDetach1 = std::function<void(const gz::msgs::Empty&)>([this](const gz::msgs::Empty&) { this->detachEnd1Requested = true; });
+
+  this->manualGraspSubs.emplace_back(this->node.CreateSubscriber("/" + cableModelName + "/attach_end_0", cbAttach0));
+  this->manualGraspSubs.emplace_back(this->node.CreateSubscriber("/" + cableModelName + "/detach_end_0", cbDetach0));
+  this->manualGraspSubs.emplace_back(this->node.CreateSubscriber("/" + cableModelName + "/attach_end_1", cbAttach1));
+  this->manualGraspSubs.emplace_back(this->node.CreateSubscriber("/" + cableModelName + "/detach_end_1", cbDetach1));
 
   this->cableIndex++;
 

--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -30,7 +30,6 @@
 #include <gz/sim/components/Model.hh>
 #include <gz/sim/components/Name.hh>
 #include <gz/sim/components/ParentEntity.hh>
-
 #include <gz/sim/components/World.hh>
 
 using namespace gz;
@@ -167,17 +166,19 @@ void CableModeratorPlugin::Configure(
 void CableModeratorPlugin::ProcessManualGraspRequests(
     gz::sim::EntityComponentManager& _ecm) {
   if (this->attachEnd0Requested.exchange(false)) {
-    if (this->FindGripperJoint(this->cableConnection0LinkEntity, _ecm) == kNullEntity) {
+    if (this->FindGripperJoint(this->cableConnection0LinkEntity, _ecm) ==
+        kNullEntity) {
       Entity jointEntity = _ecm.CreateEntity();
-      _ecm.CreateComponent(
-          jointEntity,
-          components::DetachableJoint(
-              {this->endEffectorLinkEntity, this->cableConnection0LinkEntity, "fixed"}));
+      _ecm.CreateComponent(jointEntity,
+                           components::DetachableJoint(
+                               {this->endEffectorLinkEntity,
+                                this->cableConnection0LinkEntity, "fixed"}));
       gzdbg << "Manually attached end 0" << std::endl;
     }
   }
   if (this->detachEnd0Requested.exchange(false)) {
-    Entity gripperJoint = this->FindGripperJoint(this->cableConnection0LinkEntity, _ecm);
+    Entity gripperJoint =
+        this->FindGripperJoint(this->cableConnection0LinkEntity, _ecm);
     if (gripperJoint != kNullEntity) {
       _ecm.RequestRemoveEntity(gripperJoint);
       gzdbg << "Manually detached end 0" << std::endl;
@@ -185,17 +186,19 @@ void CableModeratorPlugin::ProcessManualGraspRequests(
   }
 
   if (this->attachEnd1Requested.exchange(false)) {
-    if (this->FindGripperJoint(this->cableConnection1LinkEntity, _ecm) == kNullEntity) {
+    if (this->FindGripperJoint(this->cableConnection1LinkEntity, _ecm) ==
+        kNullEntity) {
       Entity jointEntity = _ecm.CreateEntity();
-      _ecm.CreateComponent(
-          jointEntity,
-          components::DetachableJoint(
-              {this->endEffectorLinkEntity, this->cableConnection1LinkEntity, "fixed"}));
+      _ecm.CreateComponent(jointEntity,
+                           components::DetachableJoint(
+                               {this->endEffectorLinkEntity,
+                                this->cableConnection1LinkEntity, "fixed"}));
       gzdbg << "Manually attached end 1" << std::endl;
     }
   }
   if (this->detachEnd1Requested.exchange(false)) {
-    Entity gripperJoint = this->FindGripperJoint(this->cableConnection1LinkEntity, _ecm);
+    Entity gripperJoint =
+        this->FindGripperJoint(this->cableConnection1LinkEntity, _ecm);
     if (gripperJoint != kNullEntity) {
       _ecm.RequestRemoveEntity(gripperJoint);
       gzdbg << "Manually detached end 1" << std::endl;
@@ -235,7 +238,7 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
     Entity gripperJoint =
         this->FindGripperJoint(this->cableConnection0LinkEntity, _ecm);
     if (gripperJoint != kNullEntity) {
-      // External plugin has grasped connection 0 - remove the static hold
+      // External skill has grasped connection 0 - remove the static hold
       if (this->detachableJointStatic0Entity != kNullEntity) {
         _ecm.RequestRemoveEntity(this->detachableJointStatic0Entity);
         this->detachableJointStatic0Entity = kNullEntity;
@@ -280,7 +283,7 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
     Entity gripperJoint =
         this->FindGripperJoint(this->cableConnection1LinkEntity, _ecm);
     if (gripperJoint != kNullEntity) {
-      // External plugin has grasped connection 1 - remove the static hold
+      // External skill has grasped connection 1 - remove the static hold
       if (this->detachableJointStatic1Entity != kNullEntity) {
         _ecm.RequestRemoveEntity(this->detachableJointStatic1Entity);
         this->detachableJointStatic1Entity = kNullEntity;
@@ -534,15 +537,23 @@ bool CableModeratorPlugin::ToggleActiveCable(
 
   this->manualGraspSubs.clear();
 
-  auto cbAttach0 = std::function<void(const gz::msgs::Empty&)>([this](const gz::msgs::Empty&) { this->attachEnd0Requested = true; });
-  auto cbDetach0 = std::function<void(const gz::msgs::Empty&)>([this](const gz::msgs::Empty&) { this->detachEnd0Requested = true; });
-  auto cbAttach1 = std::function<void(const gz::msgs::Empty&)>([this](const gz::msgs::Empty&) { this->attachEnd1Requested = true; });
-  auto cbDetach1 = std::function<void(const gz::msgs::Empty&)>([this](const gz::msgs::Empty&) { this->detachEnd1Requested = true; });
+  auto cbAttach0 = std::function<void(const gz::msgs::Empty&)>(
+      [this](const gz::msgs::Empty&) { this->attachEnd0Requested = true; });
+  auto cbDetach0 = std::function<void(const gz::msgs::Empty&)>(
+      [this](const gz::msgs::Empty&) { this->detachEnd0Requested = true; });
+  auto cbAttach1 = std::function<void(const gz::msgs::Empty&)>(
+      [this](const gz::msgs::Empty&) { this->attachEnd1Requested = true; });
+  auto cbDetach1 = std::function<void(const gz::msgs::Empty&)>(
+      [this](const gz::msgs::Empty&) { this->detachEnd1Requested = true; });
 
-  this->manualGraspSubs.emplace_back(this->node.CreateSubscriber("/" + cableModelName + "/attach_end_0", cbAttach0));
-  this->manualGraspSubs.emplace_back(this->node.CreateSubscriber("/" + cableModelName + "/detach_end_0", cbDetach0));
-  this->manualGraspSubs.emplace_back(this->node.CreateSubscriber("/" + cableModelName + "/attach_end_1", cbAttach1));
-  this->manualGraspSubs.emplace_back(this->node.CreateSubscriber("/" + cableModelName + "/detach_end_1", cbDetach1));
+  this->manualGraspSubs.emplace_back(this->node.CreateSubscriber(
+      "/" + cableModelName + "/attach_end_0", cbAttach0));
+  this->manualGraspSubs.emplace_back(this->node.CreateSubscriber(
+      "/" + cableModelName + "/detach_end_0", cbDetach0));
+  this->manualGraspSubs.emplace_back(this->node.CreateSubscriber(
+      "/" + cableModelName + "/attach_end_1", cbAttach1));
+  this->manualGraspSubs.emplace_back(this->node.CreateSubscriber(
+      "/" + cableModelName + "/detach_end_1", cbDetach1));
 
   this->cableIndex++;
 

--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -134,6 +134,8 @@ void CableModeratorPlugin::Configure(
     cableElem = cableElem->GetNextElement("cable");
   }
 
+  this->cableTrackers.resize(this->cableConfigs.size());
+
   if (this->cableConfigs.empty()) {
     gzerr << "Missing valid <cable> parameters." << std::endl;
     return;
@@ -207,12 +209,101 @@ void CableModeratorPlugin::ProcessManualGraspRequests(
 }
 
 //////////////////////////////////////////////////
-void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
+void CableModeratorPlugin::MakeCableStatic(
+    size_t _cableIndex, gz::sim::EntityComponentManager& _ecm) {
+  // Skip if this is the cable that was just completed, as its connectors
+  // are already frozen.
+  if (this->nextCableIndex > 0 && (this->nextCableIndex - 1) == _cableIndex) {
+    return;
+  }
+
+  const auto& config = this->cableConfigs[_cableIndex];
+  const auto cableModelName =
+      Model(this->cableTrackers[_cableIndex].modelEntity).Name(_ecm);
+
+  Entity connection0 =
+      findLinkInModel(cableModelName, config.connection0LinkName, _ecm);
+  Entity connection1 =
+      findLinkInModel(cableModelName, config.connection1LinkName, _ecm);
+
+  if (connection0 != kNullEntity) {
+    Entity jointEntity = this->MakeStatic(connection0, true, _ecm);
+    if (jointEntity != kNullEntity) {
+      this->cableTrackers[_cableIndex].frozenJoints.push_back(jointEntity);
+    }
+  }
+
+  if (connection1 != kNullEntity) {
+    Entity jointEntity = this->MakeStatic(connection1, true, _ecm);
+    if (jointEntity != kNullEntity) {
+      this->cableTrackers[_cableIndex].frozenJoints.push_back(jointEntity);
+    }
+  }
+}
+
+//////////////////////////////////////////////////
+void CableModeratorPlugin::MakeCableDynamic(
+    size_t _cableIndex, gz::sim::EntityComponentManager& _ecm) {
+  // Remove the joints
+  for (const Entity& jointEntity :
+       this->cableTrackers[_cableIndex].frozenJoints) {
+    if (jointEntity != kNullEntity) {
+      _ecm.RequestRemoveEntity(jointEntity);
+    }
+  }
+  this->cableTrackers[_cableIndex].frozenJoints.clear();
+
+  // Remove the static models
+  const auto& config = this->cableConfigs[_cableIndex];
+  const auto cableModelName =
+      Model(this->cableTrackers[_cableIndex].modelEntity).Name(_ecm);
+
+  Entity connection0 =
+      findLinkInModel(cableModelName, config.connection0LinkName, _ecm);
+  Entity connection1 =
+      findLinkInModel(cableModelName, config.connection1LinkName, _ecm);
+
+  auto removeStaticModel = [&](Entity _link) {
+    if (_link != kNullEntity) {
+      auto nameComp = _ecm.Component<components::Name>(_link);
+      auto parentComp = _ecm.Component<components::ParentEntity>(_link);
+      auto parentNameComp =
+          _ecm.Component<components::Name>(parentComp->Data());
+      std::string staticEntName =
+          nameComp->Data() + "_" + parentNameComp->Data() + "__static__";
+      Entity staticEntity =
+          _ecm.EntityByComponents(components::Name(staticEntName));
+      if (staticEntity != kNullEntity) {
+        _ecm.RequestRemoveEntity(staticEntity);
+      }
+    }
+  };
+
+  removeStaticModel(connection0);
+  removeStaticModel(connection1);
+}
+
+//////////////////////////////////////////////////
+void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& _info,
                                      gz::sim::EntityComponentManager& _ecm) {
   if (this->cableState == CableState::COMPLETED) return;
 
-  if (this->cableModels.empty()) {
-    if (!this->FindCableModels(_ecm)) return;
+  if (!this->foundAllCables) {
+    this->foundAllCables = this->FindCableModels(_info, _ecm);
+  }
+
+  for (size_t i = 1; i < this->cableTrackers.size(); ++i) {
+    auto& tracker = this->cableTrackers[i];
+    // Skip the active cable (which has index this->nextCableIndex - 1)
+    if (tracker.found && !tracker.frozen && i + 1 != this->nextCableIndex) {
+      auto timeSinceFound = std::chrono::duration_cast<std::chrono::seconds>(
+          _info.simTime - tracker.foundTime);
+      if (timeSinceFound.count() >= 0.0) {
+        this->MakeCableStatic(i, _ecm);
+        tracker.frozen = true;
+        gzmsg << "Froze cable " << this->cableConfigs[i].modelName << std::endl;
+      }
+    }
   }
 
   if (this->endEffectorLinkEntity == kNullEntity) {
@@ -235,10 +326,9 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
   }
 
   if (this->cableState == CableState::WAITING_CONN_0) {
-    Entity gripperJoint =
-        this->FindGripperJoint(this->cableConnection0LinkEntity, _ecm);
-    if (gripperJoint != kNullEntity) {
-      // External skill has grasped connection 0 - remove the static hold
+    this->activeGraspJoint = this->FindExternalGraspJoint(_ecm);
+    if (this->activeGraspJoint != kNullEntity) {
+      // External skill has grasped the cable - remove the static hold
       if (this->detachableJointStatic0Entity != kNullEntity) {
         _ecm.RequestRemoveEntity(this->detachableJointStatic0Entity);
         this->detachableJointStatic0Entity = kNullEntity;
@@ -252,7 +342,7 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
   if (this->cableState == CableState::ATTACHED_TO_GRIPPER_CONN_0) {
     if (this->cableConnectionPortSubs.empty()) {
       this->CreatePortSubscribers(
-          this->cableConfigs[this->cableIndex - 1].connection0PortName);
+          this->cableConfigs[this->nextCableIndex - 1].connection0PortName);
     }
 
     if (this->attachCableConnectionToPort) {
@@ -267,23 +357,21 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
   }
 
   if (this->cableState == CableState::ATTACH_TO_PORT_CONN_0) {
-    Entity gripperJoint =
-        this->FindGripperJoint(this->cableConnection0LinkEntity, _ecm);
-
-    if (gripperJoint == kNullEntity) {
+    if (this->activeGraspJoint == kNullEntity ||
+        !_ecm.HasEntity(this->activeGraspJoint)) {
       this->detachableJointStatic0Entity =
           this->MakeStatic(this->cableConnection0LinkEntity, true, _ecm);
 
+      this->activeGraspJoint = kNullEntity;
       gzmsg << "Cable transitioning to WAITING_CONN_1 state." << std::endl;
       this->cableState = CableState::WAITING_CONN_1;
     }
   }
 
   if (this->cableState == CableState::WAITING_CONN_1) {
-    Entity gripperJoint =
-        this->FindGripperJoint(this->cableConnection1LinkEntity, _ecm);
-    if (gripperJoint != kNullEntity) {
-      // External skill has grasped connection 1 - remove the static hold
+    this->activeGraspJoint = this->FindExternalGraspJoint(_ecm);
+    if (this->activeGraspJoint != kNullEntity) {
+      // External skill has grasped the cable - remove the static hold
       if (this->detachableJointStatic1Entity != kNullEntity) {
         _ecm.RequestRemoveEntity(this->detachableJointStatic1Entity);
         this->detachableJointStatic1Entity = kNullEntity;
@@ -297,7 +385,7 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
   if (this->cableState == CableState::ATTACHED_TO_GRIPPER_CONN_1) {
     if (this->cableConnectionPortSubs.empty()) {
       this->CreatePortSubscribers(
-          this->cableConfigs[this->cableIndex - 1].connection1PortName);
+          this->cableConfigs[this->nextCableIndex - 1].connection1PortName);
     }
 
     if (this->attachCableConnectionToPort) {
@@ -312,13 +400,12 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
   }
 
   if (this->cableState == CableState::ATTACH_TO_PORT_CONN_1) {
-    Entity gripperJoint =
-        this->FindGripperJoint(this->cableConnection1LinkEntity, _ecm);
-
-    if (gripperJoint == kNullEntity) {
+    if (this->activeGraspJoint == kNullEntity ||
+        !_ecm.HasEntity(this->activeGraspJoint)) {
       this->detachableJointStatic1Entity =
           this->MakeStatic(this->cableConnection1LinkEntity, true, _ecm);
 
+      this->activeGraspJoint = kNullEntity;
       gzmsg << "Cable transitioning to NEXT_CABLE state." << std::endl;
       this->cableState = CableState::NEXT_CABLE;
     }
@@ -329,7 +416,12 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
     this->attachCableConnectionToPort = false;
     this->touchEventCallbackNamespace = std::nullopt;
 
-    if (this->cableIndex < this->cableModels.size()) {
+    // Freeze all links in the completed cable before proceeding
+    if (this->nextCableIndex > 0) {
+      this->MakeCableStatic(this->nextCableIndex - 1, _ecm);
+    }
+
+    if (this->nextCableIndex < this->cableTrackers.size()) {
       if (this->ToggleActiveCable(_ecm)) {
         gzmsg << "Cable transitioning to HARNESS state for next cable."
               << std::endl;
@@ -400,8 +492,11 @@ Entity CableModeratorPlugin::MakeStatic(Entity _entity,
     staticModelToSpawn.Load(staticModelSDF);
   }
 
+  auto parentComp = _ecm.Component<components::ParentEntity>(_entity);
+  auto parentNameComp = _ecm.Component<components::Name>(parentComp->Data());
   auto nameComp = _ecm.Component<components::Name>(_entity);
-  std::string staticEntName = nameComp->Data() + "__static__";
+  std::string staticEntName =
+      nameComp->Data() + "_" + parentNameComp->Data() + "__static__";
   Entity staticEntity =
       _ecm.EntityByComponents(components::Name(staticEntName));
   if (staticEntity == kNullEntity) {
@@ -462,24 +557,73 @@ Entity CableModeratorPlugin::FindGripperJoint(
 }
 
 //////////////////////////////////////////////////
+Entity CableModeratorPlugin::FindExternalGraspJoint(
+    const gz::sim::EntityComponentManager& _ecm) const {
+  if (this->cableModel.Entity() == kNullEntity) return kNullEntity;
+
+  auto cableLinks = this->cableModel.Links(_ecm);
+  std::unordered_set<Entity> cableLinkSet(cableLinks.begin(), cableLinks.end());
+
+  Entity result = kNullEntity;
+  _ecm.Each<components::DetachableJoint>(
+      [&](const Entity& _entity,
+          const components::DetachableJoint* _joint) -> bool {
+        const auto& info = _joint->Data();
+
+        bool parentInCable = cableLinkSet.count(info.parentLink) > 0;
+        bool childInCable = cableLinkSet.count(info.childLink) > 0;
+
+        // We are looking for a joint between a cable link and a non-cable link
+        if (parentInCable != childInCable) {
+          Entity externalLink =
+              parentInCable ? info.childLink : info.parentLink;
+
+          // Check if this is a plugin-created static hold
+          // These connect to a model containing "__static__"
+          auto parentEnt =
+              _ecm.Component<components::ParentEntity>(externalLink);
+          if (parentEnt) {
+            auto modelName =
+                _ecm.Component<components::Name>(parentEnt->Data());
+            if (modelName &&
+                modelName->Data().find("__static__") != std::string::npos) {
+              return true;  // Skip plugin-created static holds
+            }
+          }
+
+          // If we are here, it's an external joint
+          result = _entity;
+          return false;  // Found it
+        }
+        return true;
+      });
+  return result;
+}
+
+//////////////////////////////////////////////////
 bool CableModeratorPlugin::FindCableModels(
+    const gz::sim::UpdateInfo& _info,
     const gz::sim::EntityComponentManager& _ecm) {
-  for (const auto& config : this->cableConfigs) {
-    auto entitiesMatchingName = entitiesFromScopedName(config.modelName, _ecm);
-    Entity modelEntity{kNullEntity};
-    if (entitiesMatchingName.size() == 1) {
-      modelEntity = *entitiesMatchingName.begin();
-      this->cableModels.push_back(modelEntity);
-    } else {
-      gzwarn << "Cable model " << config.modelName << " could not be found.\n";
+  bool allFound = true;
+  for (size_t i = 0; i < this->cableConfigs.size(); ++i) {
+    if (!this->cableTrackers[i].found) {
+      auto entitiesMatchingName =
+          entitiesFromScopedName(this->cableConfigs[i].modelName, _ecm);
+      if (entitiesMatchingName.size() == 1) {
+        this->cableTrackers[i].modelEntity = *entitiesMatchingName.begin();
+        this->cableTrackers[i].found = true;
+        this->cableTrackers[i].foundTime = _info.simTime;
+        gzdbg << "Found cable model " << this->cableConfigs[i].modelName
+              << std::endl;
+      } else {
+        // gzwarn << "Cable model " << this->cableConfigs[i].modelName << "
+        // could not be found.\n";
+        allFound = false;
+      }
     }
   }
 
-  if (this->cableModels.size() != this->cableConfigs.size()) {
-    this->cableModels.clear();
-    return false;
-  }
-  return true;
+  return allFound;
 }
 
 //////////////////////////////////////////////////
@@ -516,14 +660,19 @@ void CableModeratorPlugin::CreatePortSubscribers(const std::string& _portName) {
 
 //////////////////////////////////////////////////
 bool CableModeratorPlugin::ToggleActiveCable(
-    const gz::sim::EntityComponentManager& _ecm) {
-  // TODO(anyone) make previous cable (including all links) static?
-  this->cableModel = Model(this->cableModels[this->cableIndex]);
+    gz::sim::EntityComponentManager& _ecm) {
+  // Make sure we unfreeze the newly active cable
+  this->MakeCableDynamic(this->nextCableIndex, _ecm);
+  // this->cableTrackers[this->nextCableIndex].frozen = false;
+
+  this->cableModel =
+      Model(this->cableTrackers[this->nextCableIndex].modelEntity);
+  this->activeGraspJoint = kNullEntity;
   const auto cableModelName = this->cableModel.Name(_ecm);
 
   if (!this->cableModel.Valid(_ecm)) return false;
 
-  const auto& config = this->cableConfigs[this->cableIndex];
+  const auto& config = this->cableConfigs[this->nextCableIndex];
 
   this->cableConnection0LinkEntity =
       findLinkInModel(cableModelName, config.connection0LinkName, _ecm);
@@ -555,7 +704,7 @@ bool CableModeratorPlugin::ToggleActiveCable(
   this->manualGraspSubs.emplace_back(this->node.CreateSubscriber(
       "/" + cableModelName + "/detach_end_1", cbDetach1));
 
-  this->cableIndex++;
+  this->nextCableIndex++;
 
   return true;
 }

--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -30,8 +30,7 @@
 #include <gz/sim/components/Model.hh>
 #include <gz/sim/components/Name.hh>
 #include <gz/sim/components/ParentEntity.hh>
-#include <gz/sim/components/Pose.hh>
-#include <gz/sim/components/PoseCmd.hh>
+
 #include <gz/sim/components/World.hh>
 
 using namespace gz;
@@ -45,10 +44,6 @@ GZ_ADD_PLUGIN(aic_gazebo::CableModeratorPlugin, gz::sim::System,
               aic_gazebo::CableModeratorPlugin::ISystemReset)
 
 namespace {
-
-/// \brief Default offset of gripper grasping point w.r.t. the end effector.
-const gz::math::Pose3d kEndEffectorOffset =
-    gz::math::Pose3d(0, 0.0, 0.165, 0, 0, 0);
 
 /// \brief Find link in a model
 /// \param[in] _modelName Name of model
@@ -159,16 +154,6 @@ void CableModeratorPlugin::Configure(
     return;
   }
 
-  this->endEffectorOffset =
-      _sdf->Get<math::Pose3d>("end_effector_offset", kEndEffectorOffset).first;
-
-  if (_sdf->HasElement("grasp_distance_threshold")) {
-    this->graspDistanceThreshold =
-        _sdf->Get<double>("grasp_distance_threshold",
-                          this->graspDistanceThreshold)
-            .first;
-  }
-
   this->creator = std::make_unique<SdfEntityCreator>(_ecm, _eventManager);
 
   this->taskCompletionPub = this->node.Advertise<gz::msgs::StringMsg>(
@@ -205,8 +190,14 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
   }
 
   if (this->cableState == CableState::WAITING_CONN_0) {
-    if (this->HandleGrasping(this->cableConnection0LinkEntity,
-                             this->detachableJointStatic0Entity, _ecm)) {
+    Entity gripperJoint =
+        this->FindGripperJoint(this->cableConnection0LinkEntity, _ecm);
+    if (gripperJoint != kNullEntity) {
+      // External plugin has grasped connection 0 - remove the static hold
+      if (this->detachableJointStatic0Entity != kNullEntity) {
+        _ecm.RequestRemoveEntity(this->detachableJointStatic0Entity);
+        this->detachableJointStatic0Entity = kNullEntity;
+      }
       gzmsg << "Cable transitioning to ATTACHED_TO_GRIPPER_CONN_0 state."
             << std::endl;
       this->cableState = CableState::ATTACHED_TO_GRIPPER_CONN_0;
@@ -230,9 +221,12 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
     this->cableConnectionPortSubs.clear();
     this->attachCableConnectionToPort = false;
     this->touchEventCallbackNamespace = std::nullopt;
-    if (this->detachableJointGripperConnEntity != kNullEntity) {
-      _ecm.RequestRemoveEntity(this->detachableJointGripperConnEntity);
-      this->detachableJointGripperConnEntity = kNullEntity;
+
+    // Find and remove the externally-created gripper joint
+    Entity gripperJoint =
+        this->FindGripperJoint(this->cableConnection0LinkEntity, _ecm);
+    if (gripperJoint != kNullEntity) {
+      _ecm.RequestRemoveEntity(gripperJoint);
     }
 
     this->detachableJointStatic0Entity =
@@ -243,8 +237,14 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
   }
 
   if (this->cableState == CableState::WAITING_CONN_1) {
-    if (this->HandleGrasping(this->cableConnection1LinkEntity,
-                             this->detachableJointStatic1Entity, _ecm)) {
+    Entity gripperJoint =
+        this->FindGripperJoint(this->cableConnection1LinkEntity, _ecm);
+    if (gripperJoint != kNullEntity) {
+      // External plugin has grasped connection 1 - remove the static hold
+      if (this->detachableJointStatic1Entity != kNullEntity) {
+        _ecm.RequestRemoveEntity(this->detachableJointStatic1Entity);
+        this->detachableJointStatic1Entity = kNullEntity;
+      }
       gzmsg << "Cable transitioning to ATTACHED_TO_GRIPPER_CONN_1 state."
             << std::endl;
       this->cableState = CableState::ATTACHED_TO_GRIPPER_CONN_1;
@@ -265,9 +265,11 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
   }
 
   if (this->cableState == CableState::ATTACH_TO_PORT_CONN_1) {
-    if (this->detachableJointGripperConnEntity != kNullEntity) {
-      _ecm.RequestRemoveEntity(this->detachableJointGripperConnEntity);
-      this->detachableJointGripperConnEntity = kNullEntity;
+    // Find and remove the externally-created gripper joint
+    Entity gripperJoint =
+        this->FindGripperJoint(this->cableConnection1LinkEntity, _ecm);
+    if (gripperJoint != kNullEntity) {
+      _ecm.RequestRemoveEntity(gripperJoint);
     }
 
     this->detachableJointStatic1Entity =
@@ -326,8 +328,6 @@ void CableModeratorPlugin::Cleanup(gz::sim::EntityComponentManager& _ecm) {
     _ecm.RequestRemoveEntity(this->detachableJointStatic0Entity);
   if (this->detachableJointStatic1Entity != kNullEntity)
     _ecm.RequestRemoveEntity(this->detachableJointStatic1Entity);
-  if (this->detachableJointGripperConnEntity != kNullEntity)
-    _ecm.RequestRemoveEntity(this->detachableJointGripperConnEntity);
 
   for (const auto& ent : this->staticEntities) {
     if (ent != kNullEntity) {
@@ -394,30 +394,26 @@ Entity CableModeratorPlugin::MakeStatic(Entity _entity,
 }
 
 //////////////////////////////////////////////////
-bool CableModeratorPlugin::HandleGrasping(
+Entity CableModeratorPlugin::FindGripperJoint(
     gz::sim::Entity _connectionLinkEntity,
-    gz::sim::Entity& _detachableJointStaticEntity,
-    gz::sim::EntityComponentManager& _ecm) {
-  auto eeLinkWorldPose = gz::sim::worldPose(this->endEffectorLinkEntity, _ecm);
-  auto eeLinkOffsetWorldPose = eeLinkWorldPose * this->endEffectorOffset;
-  auto connPose = gz::sim::worldPose(_connectionLinkEntity, _ecm);
-
-  if (eeLinkOffsetWorldPose.Pos().Distance(connPose.Pos()) <
-      this->graspDistanceThreshold) {
-    // TODO(anyone) Add check for gripper joint state to make sure it is closed.
-    if (_detachableJointStaticEntity != kNullEntity) {
-      _ecm.RequestRemoveEntity(_detachableJointStaticEntity);
-      _detachableJointStaticEntity = kNullEntity;
-    }
-
-    this->detachableJointGripperConnEntity = _ecm.CreateEntity();
-    _ecm.CreateComponent(
-        this->detachableJointGripperConnEntity,
-        components::DetachableJoint(
-            {this->endEffectorLinkEntity, _connectionLinkEntity, "fixed"}));
-    return true;
-  }
-  return false;
+    const gz::sim::EntityComponentManager& _ecm) const {
+  Entity result = kNullEntity;
+  _ecm.Each<components::DetachableJoint>(
+      [&](const Entity& _entity,
+          const components::DetachableJoint* _joint) -> bool {
+        const auto& info = _joint->Data();
+        // Check if this joint connects the end-effector to the connection link
+        // (in either parent/child order)
+        if ((info.parentLink == this->endEffectorLinkEntity &&
+             info.childLink == _connectionLinkEntity) ||
+            (info.parentLink == _connectionLinkEntity &&
+             info.childLink == this->endEffectorLinkEntity)) {
+          result = _entity;
+          return false;  // stop iteration
+        }
+        return true;  // continue
+      });
+  return result;
 }
 
 //////////////////////////////////////////////////

--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -167,20 +167,23 @@ void CableModeratorPlugin::Configure(
 //////////////////////////////////////////////////
 void CableModeratorPlugin::ProcessManualGraspRequests(
     gz::sim::EntityComponentManager& _ecm) {
+  if (this->cableIndex < 0) return;
+
+  const auto& tracker = this->cableTrackers[this->cableIndex];
   if (this->attachEnd0Requested.exchange(false)) {
-    if (this->FindGripperJoint(this->cableConnection0LinkEntity, _ecm) ==
+    if (this->FindGripperJoint(tracker.connection0LinkEntity, _ecm) ==
         kNullEntity) {
       Entity jointEntity = _ecm.CreateEntity();
       _ecm.CreateComponent(jointEntity,
                            components::DetachableJoint(
                                {this->endEffectorLinkEntity,
-                                this->cableConnection0LinkEntity, "fixed"}));
+                                tracker.connection0LinkEntity, "fixed"}));
       gzdbg << "Manually attached end 0" << std::endl;
     }
   }
   if (this->detachEnd0Requested.exchange(false)) {
     Entity gripperJoint =
-        this->FindGripperJoint(this->cableConnection0LinkEntity, _ecm);
+        this->FindGripperJoint(tracker.connection0LinkEntity, _ecm);
     if (gripperJoint != kNullEntity) {
       _ecm.RequestRemoveEntity(gripperJoint);
       gzdbg << "Manually detached end 0" << std::endl;
@@ -188,19 +191,19 @@ void CableModeratorPlugin::ProcessManualGraspRequests(
   }
 
   if (this->attachEnd1Requested.exchange(false)) {
-    if (this->FindGripperJoint(this->cableConnection1LinkEntity, _ecm) ==
+    if (this->FindGripperJoint(tracker.connection1LinkEntity, _ecm) ==
         kNullEntity) {
       Entity jointEntity = _ecm.CreateEntity();
       _ecm.CreateComponent(jointEntity,
                            components::DetachableJoint(
                                {this->endEffectorLinkEntity,
-                                this->cableConnection1LinkEntity, "fixed"}));
+                                tracker.connection1LinkEntity, "fixed"}));
       gzdbg << "Manually attached end 1" << std::endl;
     }
   }
   if (this->detachEnd1Requested.exchange(false)) {
     Entity gripperJoint =
-        this->FindGripperJoint(this->cableConnection1LinkEntity, _ecm);
+        this->FindGripperJoint(tracker.connection1LinkEntity, _ecm);
     if (gripperJoint != kNullEntity) {
       _ecm.RequestRemoveEntity(gripperJoint);
       gzdbg << "Manually detached end 1" << std::endl;
@@ -210,13 +213,7 @@ void CableModeratorPlugin::ProcessManualGraspRequests(
 
 //////////////////////////////////////////////////
 void CableModeratorPlugin::MakeCableStatic(
-    size_t _cableIndex, gz::sim::EntityComponentManager& _ecm) {
-  // Skip if this is the cable that was just completed, as its connectors
-  // are already frozen.
-  if (this->nextCableIndex > 0 && (this->nextCableIndex - 1) == _cableIndex) {
-    return;
-  }
-
+    int _cableIndex, gz::sim::EntityComponentManager& _ecm) {
   const auto& config = this->cableConfigs[_cableIndex];
   const auto cableModelName =
       Model(this->cableTrackers[_cableIndex].modelEntity).Name(_ecm);
@@ -227,80 +224,34 @@ void CableModeratorPlugin::MakeCableStatic(
       findLinkInModel(cableModelName, config.connection1LinkName, _ecm);
 
   if (connection0 != kNullEntity) {
-    Entity jointEntity = this->MakeStatic(connection0, true, _ecm);
-    if (jointEntity != kNullEntity) {
-      this->cableTrackers[_cableIndex].frozenJoints.push_back(jointEntity);
-    }
+    this->cableTrackers[_cableIndex].detachableJointStatic0Entity =
+        this->MakeStatic(connection0, true, _ecm);
   }
 
   if (connection1 != kNullEntity) {
-    Entity jointEntity = this->MakeStatic(connection1, true, _ecm);
-    if (jointEntity != kNullEntity) {
-      this->cableTrackers[_cableIndex].frozenJoints.push_back(jointEntity);
-    }
+    this->cableTrackers[_cableIndex].detachableJointStatic1Entity =
+        this->MakeStatic(connection1, true, _ecm);
   }
 }
 
 //////////////////////////////////////////////////
 void CableModeratorPlugin::MakeCableDynamic(
-    size_t _cableIndex, gz::sim::EntityComponentManager& _ecm) {
-  // Remove the joints
-  for (const Entity& jointEntity :
-       this->cableTrackers[_cableIndex].frozenJoints) {
-    if (jointEntity != kNullEntity) {
-      _ecm.RequestRemoveEntity(jointEntity);
-    }
-  }
-  this->cableTrackers[_cableIndex].frozenJoints.clear();
-
-  // Remove the static models
-  const auto& config = this->cableConfigs[_cableIndex];
-  const auto cableModelName =
-      Model(this->cableTrackers[_cableIndex].modelEntity).Name(_ecm);
-
-  Entity connection0 =
-      findLinkInModel(cableModelName, config.connection0LinkName, _ecm);
-  Entity connection1 =
-      findLinkInModel(cableModelName, config.connection1LinkName, _ecm);
-
-  auto removeStaticModel = [&](Entity _link) {
-    if (_link != kNullEntity) {
-      auto nameComp = _ecm.Component<components::Name>(_link);
-      auto parentComp = _ecm.Component<components::ParentEntity>(_link);
-      auto parentNameComp =
-          _ecm.Component<components::Name>(parentComp->Data());
-      std::string staticEntName =
-          nameComp->Data() + "_" + parentNameComp->Data() + "__static__";
-      Entity staticEntity =
-          _ecm.EntityByComponents(components::Name(staticEntName));
-      if (staticEntity != kNullEntity) {
-        _ecm.RequestRemoveEntity(staticEntity);
-      }
-    }
-  };
-
-  removeStaticModel(connection0);
-  removeStaticModel(connection1);
+    size_t /*_cableIndex*/, gz::sim::EntityComponentManager& /*_ecm*/) {
+  // For now noop
+  // TODO(anyone) Consider making the links dynamic if they are made
+  // static in MakeCableStatic
 }
 
 //////////////////////////////////////////////////
-void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& _info,
+void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
                                      gz::sim::EntityComponentManager& _ecm) {
   if (this->cableState == CableState::COMPLETED) return;
 
   if (!this->foundAllCables) {
-    this->foundAllCables = this->FindCableModels(_info, _ecm);
-  }
-
-  for (size_t i = 1; i < this->cableTrackers.size(); ++i) {
-    auto& tracker = this->cableTrackers[i];
-    // Skip the active cable (which has index this->nextCableIndex - 1)
-    if (tracker.found && !tracker.frozen && i + 1 != this->nextCableIndex) {
-      auto timeSinceFound = std::chrono::duration_cast<std::chrono::seconds>(
-          _info.simTime - tracker.foundTime);
-      if (timeSinceFound.count() >= 0.0) {
+    this->foundAllCables = this->FindCableModels(_ecm);
+    if (this->foundAllCables) {
+      for (std::size_t i = 0; i < this->cableTrackers.size(); ++i) {
         this->MakeCableStatic(i, _ecm);
-        tracker.frozen = true;
         gzmsg << "Froze cable " << this->cableConfigs[i].modelName << std::endl;
       }
     }
@@ -314,24 +265,15 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& _info,
 
   this->ProcessManualGraspRequests(_ecm);
 
-  if (this->cableState == CableState::HARNESS) {
-    // Hold both connections of the cable in place
-    this->detachableJointStatic0Entity =
-        this->MakeStatic(this->cableConnection0LinkEntity, true, _ecm);
-    this->detachableJointStatic1Entity =
-        this->MakeStatic(this->cableConnection1LinkEntity, true, _ecm);
-
-    gzmsg << "Cable transitioning to WAITING_CONN_0 state." << std::endl;
-    this->cableState = CableState::WAITING_CONN_0;
-  }
-
   if (this->cableState == CableState::WAITING_CONN_0) {
     this->activeGraspJoint = this->FindExternalGraspJoint(_ecm);
     if (this->activeGraspJoint != kNullEntity) {
       // External skill has grasped the cable - remove the static hold
-      if (this->detachableJointStatic0Entity != kNullEntity) {
-        _ecm.RequestRemoveEntity(this->detachableJointStatic0Entity);
-        this->detachableJointStatic0Entity = kNullEntity;
+      auto& joint0 =
+          this->cableTrackers[this->cableIndex].detachableJointStatic0Entity;
+      if (joint0 != kNullEntity) {
+        _ecm.RequestRemoveEntity(joint0);
+        joint0 = kNullEntity;
       }
       gzmsg << "Cable transitioning to ATTACHED_TO_GRIPPER_CONN_0 state."
             << std::endl;
@@ -342,7 +284,7 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& _info,
   if (this->cableState == CableState::ATTACHED_TO_GRIPPER_CONN_0) {
     if (this->cableConnectionPortSubs.empty()) {
       this->CreatePortSubscribers(
-          this->cableConfigs[this->nextCableIndex - 1].connection0PortName);
+          this->cableConfigs[this->cableIndex].connection0PortName);
     }
 
     if (this->attachCableConnectionToPort) {
@@ -357,10 +299,11 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& _info,
   }
 
   if (this->cableState == CableState::ATTACH_TO_PORT_CONN_0) {
+    auto& tracker = this->cableTrackers[this->cableIndex];
     if (this->activeGraspJoint == kNullEntity ||
         !_ecm.HasEntity(this->activeGraspJoint)) {
-      this->detachableJointStatic0Entity =
-          this->MakeStatic(this->cableConnection0LinkEntity, true, _ecm);
+      tracker.detachableJointStatic0Entity =
+          this->MakeStatic(tracker.connection0LinkEntity, true, _ecm);
 
       this->activeGraspJoint = kNullEntity;
       gzmsg << "Cable transitioning to WAITING_CONN_1 state." << std::endl;
@@ -372,9 +315,11 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& _info,
     this->activeGraspJoint = this->FindExternalGraspJoint(_ecm);
     if (this->activeGraspJoint != kNullEntity) {
       // External skill has grasped the cable - remove the static hold
-      if (this->detachableJointStatic1Entity != kNullEntity) {
-        _ecm.RequestRemoveEntity(this->detachableJointStatic1Entity);
-        this->detachableJointStatic1Entity = kNullEntity;
+      auto& joint1 =
+          this->cableTrackers[this->cableIndex].detachableJointStatic1Entity;
+      if (joint1 != kNullEntity) {
+        _ecm.RequestRemoveEntity(joint1);
+        joint1 = kNullEntity;
       }
       gzmsg << "Cable transitioning to ATTACHED_TO_GRIPPER_CONN_1 state."
             << std::endl;
@@ -385,7 +330,7 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& _info,
   if (this->cableState == CableState::ATTACHED_TO_GRIPPER_CONN_1) {
     if (this->cableConnectionPortSubs.empty()) {
       this->CreatePortSubscribers(
-          this->cableConfigs[this->nextCableIndex - 1].connection1PortName);
+          this->cableConfigs[this->cableIndex].connection1PortName);
     }
 
     if (this->attachCableConnectionToPort) {
@@ -400,10 +345,11 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& _info,
   }
 
   if (this->cableState == CableState::ATTACH_TO_PORT_CONN_1) {
+    auto& tracker = this->cableTrackers[this->cableIndex];
     if (this->activeGraspJoint == kNullEntity ||
         !_ecm.HasEntity(this->activeGraspJoint)) {
-      this->detachableJointStatic1Entity =
-          this->MakeStatic(this->cableConnection1LinkEntity, true, _ecm);
+      tracker.detachableJointStatic1Entity =
+          this->MakeStatic(tracker.connection1LinkEntity, true, _ecm);
 
       this->activeGraspJoint = kNullEntity;
       gzmsg << "Cable transitioning to NEXT_CABLE state." << std::endl;
@@ -416,16 +362,12 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& _info,
     this->attachCableConnectionToPort = false;
     this->touchEventCallbackNamespace = std::nullopt;
 
-    // Freeze all links in the completed cable before proceeding
-    if (this->nextCableIndex > 0) {
-      this->MakeCableStatic(this->nextCableIndex - 1, _ecm);
-    }
-
-    if (this->nextCableIndex < this->cableTrackers.size()) {
+    if (this->cableIndex + 1 < static_cast<int>(this->cableTrackers.size())) {
+      // There are more cables to be processed
       if (this->ToggleActiveCable(_ecm)) {
-        gzmsg << "Cable transitioning to HARNESS state for next cable."
+        gzmsg << "Cable transitioning to WAITING_CONN_0 state for next cable."
               << std::endl;
-        this->cableState = CableState::HARNESS;
+        this->cableState = CableState::WAITING_CONN_0;
       } else {
         gzmsg << "Failed to toggle active cable. Transitioning to COMPLETED "
                  "state."
@@ -461,10 +403,13 @@ void CableModeratorPlugin::Reset(const gz::sim::UpdateInfo& /*_info*/,
 
 //////////////////////////////////////////////////
 void CableModeratorPlugin::Cleanup(gz::sim::EntityComponentManager& _ecm) {
+  // TODO(luca) reinstate, should probably iterate over all cables
+  /*
   if (this->detachableJointStatic0Entity != kNullEntity)
     _ecm.RequestRemoveEntity(this->detachableJointStatic0Entity);
   if (this->detachableJointStatic1Entity != kNullEntity)
     _ecm.RequestRemoveEntity(this->detachableJointStatic1Entity);
+  */
 
   for (const auto& ent : this->staticEntities) {
     if (ent != kNullEntity) {
@@ -602,7 +547,6 @@ Entity CableModeratorPlugin::FindExternalGraspJoint(
 
 //////////////////////////////////////////////////
 bool CableModeratorPlugin::FindCableModels(
-    const gz::sim::UpdateInfo& _info,
     const gz::sim::EntityComponentManager& _ecm) {
   bool allFound = true;
   for (size_t i = 0; i < this->cableConfigs.size(); ++i) {
@@ -612,7 +556,6 @@ bool CableModeratorPlugin::FindCableModels(
       if (entitiesMatchingName.size() == 1) {
         this->cableTrackers[i].modelEntity = *entitiesMatchingName.begin();
         this->cableTrackers[i].found = true;
-        this->cableTrackers[i].foundTime = _info.simTime;
         gzdbg << "Found cable model " << this->cableConfigs[i].modelName
               << std::endl;
       } else {
@@ -661,27 +604,27 @@ void CableModeratorPlugin::CreatePortSubscribers(const std::string& _portName) {
 //////////////////////////////////////////////////
 bool CableModeratorPlugin::ToggleActiveCable(
     gz::sim::EntityComponentManager& _ecm) {
+  this->cableIndex++;
+  auto& tracker = this->cableTrackers[this->cableIndex];
   // Make sure we unfreeze the newly active cable
-  this->MakeCableDynamic(this->nextCableIndex, _ecm);
-  // this->cableTrackers[this->nextCableIndex].frozen = false;
+  this->MakeCableDynamic(this->cableIndex, _ecm);
 
-  this->cableModel =
-      Model(this->cableTrackers[this->nextCableIndex].modelEntity);
+  this->cableModel = Model(tracker.modelEntity);
   this->activeGraspJoint = kNullEntity;
-  const auto cableModelName = this->cableModel.Name(_ecm);
+  const auto& cableModelName = this->cableModel.Name(_ecm);
 
   if (!this->cableModel.Valid(_ecm)) return false;
 
-  const auto& config = this->cableConfigs[this->nextCableIndex];
+  const auto& config = this->cableConfigs[this->cableIndex];
 
-  this->cableConnection0LinkEntity =
+  tracker.connection0LinkEntity =
       findLinkInModel(cableModelName, config.connection0LinkName, _ecm);
 
-  this->cableConnection1LinkEntity =
+  tracker.connection1LinkEntity =
       findLinkInModel(cableModelName, config.connection1LinkName, _ecm);
 
-  if (this->cableConnection0LinkEntity == kNullEntity ||
-      this->cableConnection1LinkEntity == kNullEntity)
+  if (tracker.connection0LinkEntity == kNullEntity ||
+      tracker.connection1LinkEntity == kNullEntity)
     return false;
 
   this->manualGraspSubs.clear();
@@ -703,8 +646,6 @@ bool CableModeratorPlugin::ToggleActiveCable(
       "/" + cableModelName + "/attach_end_1", cbAttach1));
   this->manualGraspSubs.emplace_back(this->node.CreateSubscriber(
       "/" + cableModelName + "/detach_end_1", cbDetach1));
-
-  this->nextCableIndex++;
 
   return true;
 }

--- a/aic_gazebo/src/CableModeratorPlugin.hh
+++ b/aic_gazebo/src/CableModeratorPlugin.hh
@@ -142,6 +142,10 @@ namespace aic_gazebo
         gz::sim::Entity _connectionLinkEntity,
         const gz::sim::EntityComponentManager& _ecm) const;
 
+    /// \brief Process any pending manual attach/detach requests
+    /// \param[in] _ecm Entity Component Manager
+    private: void ProcessManualGraspRequests(gz::sim::EntityComponentManager& _ecm);
+
     /// \brief Toggle active cable. Done by setting internal vairables to keep
     /// track of the connection link entities of the next cable in the queue
     /// \param[in] _ecm Entity Component Manager
@@ -218,6 +222,17 @@ namespace aic_gazebo
 
     /// \brief Static entities created by this plugin
     private: std::unordered_set<gz::sim::Entity> staticEntities;
+
+    /// \brief Flags for manual attach/detach of connection 0
+    private: std::atomic<bool> attachEnd0Requested{false};
+    private: std::atomic<bool> detachEnd0Requested{false};
+
+    /// \brief Flags for manual attach/detach of connection 1
+    private: std::atomic<bool> attachEnd1Requested{false};
+    private: std::atomic<bool> detachEnd1Requested{false};
+
+    /// \brief Manual grasp subscribers
+    private: std::vector<gz::transport::Node::Subscriber> manualGraspSubs;
 };
 }
 #endif

--- a/aic_gazebo/src/CableModeratorPlugin.hh
+++ b/aic_gazebo/src/CableModeratorPlugin.hh
@@ -133,15 +133,14 @@ namespace aic_gazebo
                              bool _attachEntityAsParentOfJoint,
                              gz::sim::EntityComponentManager& _ecm);
 
-    /// \brief Check end effector distance to connection and handle grasping
-    /// \param[in] _connectionLinkEntity The connection link to check
-    /// \param[in, out] _detachableJointStaticEntity The static joint holding
-    ///  it (removed if grasped)
+    /// \brief Find a detachable joint created by an external plugin that
+    /// connects the end-effector link to the given connection link.
+    /// \param[in] _connectionLinkEntity The cable connection link to check
     /// \param[in] _ecm Entity Component Manager
-    /// \return True if grasped, false otherwise
-    private: bool HandleGrasping(gz::sim::Entity _connectionLinkEntity,
-                                 gz::sim::Entity& _detachableJointStaticEntity,
-                                 gz::sim::EntityComponentManager& _ecm);
+    /// \return Entity of the gripper joint if found, kNullEntity otherwise
+    private: gz::sim::Entity FindGripperJoint(
+        gz::sim::Entity _connectionLinkEntity,
+        const gz::sim::EntityComponentManager& _ecm) const;
 
     /// \brief Toggle active cable. Done by setting internal vairables to keep
     /// track of the connection link entities of the next cable in the queue
@@ -166,9 +165,7 @@ namespace aic_gazebo
     /// \brief Connection 1 link entity in the cable model
     private: gz::sim::Entity cableConnection1LinkEntity{gz::sim::kNullEntity};
 
-    /// \brief Detachable joint entity for gripper connection
-    private: gz::sim::Entity detachableJointGripperConnEntity{
-        gz::sim::kNullEntity};
+
 
     /// \brief Detachable joint entity for making cable connection 0 static
     private: gz::sim::Entity detachableJointStatic0Entity{gz::sim::kNullEntity};
@@ -185,9 +182,6 @@ namespace aic_gazebo
     /// \brief Index of cable model that is currently active.
     private: std::size_t cableIndex{0u};
 
-    /// \brief Entity offset for end effector
-    private: gz::math::Pose3d endEffectorOffset;
-
     /// \brief Entities of the cable models
     private: std::vector<gz::sim::Entity> cableModels;
 
@@ -196,9 +190,6 @@ namespace aic_gazebo
 
     /// \brief Name of the end effector link
     private: std::string endEffectorLinkName;
-
-    /// \brief Distance threshold for grasping the cable connection
-    private: double graspDistanceThreshold{0.05};
 
     /// \brief Sdf entity creator for spawning static entities
     /// Used for holding cable connections in place

--- a/aic_gazebo/src/CableModeratorPlugin.hh
+++ b/aic_gazebo/src/CableModeratorPlugin.hh
@@ -83,6 +83,20 @@ namespace aic_gazebo
     std::string connection1PortName;
   };
 
+  /// \brief Tracker for each cable model state
+  struct CableTracker {
+    /// \brief Entity of the cable model
+    gz::sim::Entity modelEntity{gz::sim::kNullEntity};
+    /// \brief Whether the cable has been found in simulation
+    bool found{false};
+    /// \brief Simulation time when the cable was found
+    std::chrono::steady_clock::duration foundTime{0};
+    /// \brief Whether the cable has been frozen
+    bool frozen{false};
+    /// \brief Entities of the static joints used to freeze this cable
+    std::vector<gz::sim::Entity> frozenJoints;
+  };
+
   /// \brief Plugin for initializing the cable
   /// It waits for end-effector / port to be ready before creating connections
   /// with them using detachable joints.
@@ -142,19 +156,41 @@ namespace aic_gazebo
         gz::sim::Entity _connectionLinkEntity,
         const gz::sim::EntityComponentManager& _ecm) const;
 
+    /// \brief Find a detachable joint created by an external plugin that
+    /// connects any link in the current cable model to an external link.
+    /// \param[in] _ecm Entity Component Manager
+    /// \return Entity of the grasp joint if found, kNullEntity otherwise
+    private: gz::sim::Entity FindExternalGraspJoint(
+        const gz::sim::EntityComponentManager& _ecm) const;
+
     /// \brief Process any pending manual attach/detach requests
     /// \param[in] _ecm Entity Component Manager
-    private: void ProcessManualGraspRequests(gz::sim::EntityComponentManager& _ecm);
+    private: void ProcessManualGraspRequests(
+        gz::sim::EntityComponentManager& _ecm);
+
+    /// \brief Freezes all links in the given cable in place by making them static
+    /// \param[in] _cableIndex The index of the cable to freeze
+    /// \param[in] _ecm Entity Component Manager
+    private: void MakeCableStatic(size_t _cableIndex,
+        gz::sim::EntityComponentManager& _ecm);
+
+    /// \brief Unfreezes all links in the given cable by removing static joints
+    /// \param[in] _cableIndex The index of the cable to unfreeze
+    /// \param[in] _ecm Entity Component Manager
+    private: void MakeCableDynamic(size_t _cableIndex,
+        gz::sim::EntityComponentManager& _ecm);
 
     /// \brief Toggle active cable. Done by setting internal vairables to keep
     /// track of the connection link entities of the next cable in the queue
     /// \param[in] _ecm Entity Component Manager
     private: bool ToggleActiveCable(
-        const gz::sim::EntityComponentManager& _ecm);
+        gz::sim::EntityComponentManager& _ecm);
 
     /// \brief Find Cable model entities based on their names
+    /// \param[in] _info Simulation update info
     /// \param[in] _ecm Entity Component Manager
-    private: bool FindCableModels(const gz::sim::EntityComponentManager& _ecm);
+    private: bool FindCableModels(const gz::sim::UpdateInfo &_info,
+        const gz::sim::EntityComponentManager& _ecm);
 
     /// \brief Initialize port contact subscribers for the given port
     /// \param[in] _portName The name of the port to subscribe to for contacts
@@ -169,7 +205,8 @@ namespace aic_gazebo
     /// \brief Connection 1 link entity in the cable model
     private: gz::sim::Entity cableConnection1LinkEntity{gz::sim::kNullEntity};
 
-
+    /// \brief Entity of the detachable joint found while waiting for grasp
+    private: gz::sim::Entity activeGraspJoint{gz::sim::kNullEntity};
 
     /// \brief Detachable joint entity for making cable connection 0 static
     private: gz::sim::Entity detachableJointStatic0Entity{gz::sim::kNullEntity};
@@ -183,11 +220,11 @@ namespace aic_gazebo
     /// \brief The current active cable model.
     private: gz::sim::Model cableModel;
 
-    /// \brief Index of cable model that is currently active.
-    private: std::size_t cableIndex{0u};
+    /// \brief Index of the active cable model to be activated.
+    private: std::size_t nextCableIndex{0u};
 
-    /// \brief Entities of the cable models
-    private: std::vector<gz::sim::Entity> cableModels;
+    /// \brief State trackers for the cable models
+    private: std::vector<CableTracker> cableTrackers;
 
     /// \brief Name of the end effector model
     private: std::string endEffectorModelName;
@@ -233,6 +270,9 @@ namespace aic_gazebo
 
     /// \brief Manual grasp subscribers
     private: std::vector<gz::transport::Node::Subscriber> manualGraspSubs;
+
+    /// \brief Flag to indicate if all cable model entities are found.
+    private: bool foundAllCables = false;
 };
 }
 #endif

--- a/aic_gazebo/src/CableModeratorPlugin.hh
+++ b/aic_gazebo/src/CableModeratorPlugin.hh
@@ -32,13 +32,8 @@ namespace aic_gazebo
 {
   /// \brief State of the cable
   enum class CableState {
-    /// \brief Harnessed to the world, i.e. made static
-    /// before creating connections
+    /// \brief Being initialized
     INITIALIZATION,
-
-    /// \brief Harnessed to the world, i.e. made static
-    /// before creating connections
-    HARNESS,
 
     /// \brief Waiting for end effector to approach connection 0
     WAITING_CONN_0,
@@ -89,12 +84,14 @@ namespace aic_gazebo
     gz::sim::Entity modelEntity{gz::sim::kNullEntity};
     /// \brief Whether the cable has been found in simulation
     bool found{false};
-    /// \brief Simulation time when the cable was found
-    std::chrono::steady_clock::duration foundTime{0};
-    /// \brief Whether the cable has been frozen
-    bool frozen{false};
-    /// \brief Entities of the static joints used to freeze this cable
-    std::vector<gz::sim::Entity> frozenJoints;
+    /// \brief Detachable joint entity for making cable connection 0 static
+    gz::sim::Entity detachableJointStatic0Entity{gz::sim::kNullEntity};
+    /// \brief Detachable joint entity for making cable connection 1 static
+    gz::sim::Entity detachableJointStatic1Entity{gz::sim::kNullEntity};
+    /// \brief Connection 0 link entity in the cable model
+    gz::sim::Entity connection0LinkEntity{gz::sim::kNullEntity};
+    /// \brief Connection 1 link entity in the cable model
+    gz::sim::Entity connection1LinkEntity{gz::sim::kNullEntity};
   };
 
   /// \brief Plugin for initializing the cable
@@ -171,7 +168,7 @@ namespace aic_gazebo
     /// \brief Freezes all links in the given cable in place by making them static
     /// \param[in] _cableIndex The index of the cable to freeze
     /// \param[in] _ecm Entity Component Manager
-    private: void MakeCableStatic(size_t _cableIndex,
+    private: void MakeCableStatic(int _cableIndex,
         gz::sim::EntityComponentManager& _ecm);
 
     /// \brief Unfreezes all links in the given cable by removing static joints
@@ -187,10 +184,8 @@ namespace aic_gazebo
         gz::sim::EntityComponentManager& _ecm);
 
     /// \brief Find Cable model entities based on their names
-    /// \param[in] _info Simulation update info
     /// \param[in] _ecm Entity Component Manager
-    private: bool FindCableModels(const gz::sim::UpdateInfo &_info,
-        const gz::sim::EntityComponentManager& _ecm);
+    private: bool FindCableModels(const gz::sim::EntityComponentManager& _ecm);
 
     /// \brief Initialize port contact subscribers for the given port
     /// \param[in] _portName The name of the port to subscribe to for contacts
@@ -199,20 +194,8 @@ namespace aic_gazebo
     /// \brief Entity of attachment link in the end effector model
     private: gz::sim::Entity endEffectorLinkEntity{gz::sim::kNullEntity};
 
-    /// \brief Connection 0 link entity in the cable model
-    private: gz::sim::Entity cableConnection0LinkEntity{gz::sim::kNullEntity};
-
-    /// \brief Connection 1 link entity in the cable model
-    private: gz::sim::Entity cableConnection1LinkEntity{gz::sim::kNullEntity};
-
     /// \brief Entity of the detachable joint found while waiting for grasp
     private: gz::sim::Entity activeGraspJoint{gz::sim::kNullEntity};
-
-    /// \brief Detachable joint entity for making cable connection 0 static
-    private: gz::sim::Entity detachableJointStatic0Entity{gz::sim::kNullEntity};
-
-    /// \brief Detachable joint entity for making cable connection 1 static
-    private: gz::sim::Entity detachableJointStatic1Entity{gz::sim::kNullEntity};
 
     /// \brief A list of cable configurations
     private: std::vector<CableConfig> cableConfigs;
@@ -220,8 +203,8 @@ namespace aic_gazebo
     /// \brief The current active cable model.
     private: gz::sim::Model cableModel;
 
-    /// \brief Index of the active cable model to be activated.
-    private: std::size_t nextCableIndex{0u};
+    /// \brief Index of the active cable model.
+    private: int cableIndex{-1};
 
     /// \brief State trackers for the cable models
     private: std::vector<CableTracker> cableTrackers;


### PR DESCRIPTION
Flowstate handles attaching / detaching the cable ends to the gripper so the CableModeratorPlugin should no longer be handling this.

Updated the CableModeratorPlugin to remove logic for creating and deleting detachable joints between the gripper and the cable connectors. Instead it will monitor the Gazebo ECM to check for detachable joints between any links in the cable and an external link (i.e. gripper) to determine when attach object / detach object events have occurred.

Other changes:
* 'Harness' all cables in the world on startup (with new `MakeCableStatic` function)
  * So that all cables stay seated in their mounts. Previously the state machine only harnesses the active cable. 
  *  A cable is detached via (`MakeCableDynamic`) once it becomes active, i.e. the previous cable plugs have been inserted.
* Added test topics and a `ProcessManualGraspRequests` function for testing grasp / release events.
    *  The steps in **To Test** section below publishes to these topics to mock a grasp / release event

## To Test:

Launch sim with cable, NIC card mount, and SC port
```
ros2 launch aic_bringup aic_gz_bringup.launch.py ground_truth:=false  spawn_cable:=true attach_cable_to_gripper:=false spawn_task_board:=true nic_card_mount_0_present:=true sc_port_0_present:=true launch_rviz:=false
```

The plugin should be in `WAITING_CONN_0` state. This indicates it's waiting for the gripper to grasp cable connection 0, i.e. SFP module. Scroll up the sim console to find this log:

```
[info] [CableModeratorPlugin.cc:233] Cable transitioning to WAITING_CONN_0 state
```

Fake a attach object event between gripper and the SFP module by publishing to a test topic:

```
gz topic -t "/cable_0/attach_end_0" -m gz.msgs.Empty -p " "
```

You should see the plugin transitions to the next state:

```
[info] [CableModeratorPlugin.cc:246] Cable transitioning to ATTACHED_TO_GRIPPER_CONN_0 state
```

In this state, the cable should be attached to the gripper. Now, fake an insertion event of the SFP module into one of the ports in the NIC card:

```
gz topic -t "/nic_card_mount_0/sfp_port_0/touched" -m gz.msgs.Boolean -p "data: true"
```

You should see the plugin transitions to the next state:

```
[info] [CableModeratorPlugin.cc:263] Cable transitioning to ATTACH_TO_PORT_CONN_0 state.
```

Insertion is done but cable should still attached because the users are expected to release the cable themselves. Fake a detach object skill execution between gripper and the SFP module by publishing:

```
gz topic -t "/cable_0/detach_end_0" -m gz.msgs.Empty -p " "
```

You should see the plugin transitions to the next state:

```
[info] [CableModeratorPlugin.cc:277] Cable transitioning to WAITING_CONN_1 state.
```

Now do the same for the other end of the cable. Fake an attach object event between gripper and the SC Plug by publishing to the test topic:

```
gz topic -t "/cable_0/attach_end_1" -m gz.msgs.Empty -p " "
```

You should see the plugin transitions to the next state:

```
[info] [CableModeratorPlugin.cc:291] Cable transitioning to ATTACHED_TO_GRIPPER_CONN_1 state.
```

Fake an insertion event of the SC Plug into the SC port:

```
gz topic -t "/sc_port_0/sc_port_base/touched" -m gz.msgs.Boolean -p "data: true"
```

You should see the plugin transitions to the next state:

```
[info] [CableModeratorPlugin.cc:263] Cable transitioning to ATTACH_TO_PORT_CONN_1 state.
```

Fake a detach object skill execution between gripper and the SC plug by publishing:

```
gz topic -t "/cable_0/detach_end_1" -m gz.msgs.Empty -p " "
```

You should see the plugin transitions to the final completion state:

```
[info] [CableModeratorPlugin.cc:348] All cables processed. Transitioning to COMPLETED state
```

