### PR TITLE
add tare force torque sensor service and skill

### DIFF
--- a/flowstate/README.md
+++ b/flowstate/README.md
@@ -112,7 +112,7 @@ cd ~/ws_aic_phase1
   --ros_distro kilted
 
 # This command bundles the skill into a deployable tarball
-inbuild skill bundle \
+./inbuild skill bundle \
   --file_descriptor_set images/insert_cable_skill/insert_cable_skill_protos.desc \
   --manifest src/aic/flowstate/aic_flowstate_skills/insert_cable_skill/src/insert_cable_skill.manifest.textproto \
   --oci_image images/insert_cable_skill/insert_cable_skill.tar \

--- a/flowstate/README.md
+++ b/flowstate/README.md
@@ -104,16 +104,19 @@ We can use the `build_container.sh` and `build_bundle.sh` script from the intrin
 cd ~/ws_aic_phase1
 
 # This command builds the insert_cable_skill, the Intrinsic SDK, and the necessary ROS dependencies into a tar image.
-./src/sdk-ros/scripts/build_container.sh \
-  --ros_distro "kilted" \
+./src/aic/flowstate/scripts/build_container.sh \
+  --skill_name insert_cable_skill \
   --skill_package aic_flowstate_skills \
-  --skill_name insert_cable_skill
+  --manifest_path src/aic/flowstate/aic_flowstate_skills/insert_cable_skill/src/insert_cable_skill.manifest.textproto \
+  --dockerfile ./src/aic/flowstate/resources/Dockerfile.skill \
+  --ros_distro kilted
 
 # This command bundles the skill into a deployable tarball
-./src/sdk-ros/scripts/build_bundle.sh \
-  --skill_package aic_flowstate_skills \
-  --skill_name insert_cable_skill \
-  --manifest_path src/aic/flowstate/aic_flowstate_skills/insert_cable_skill/src/insert_cable_skill.manifest.textproto
+inbuild skill bundle \
+  --file_descriptor_set images/insert_cable_skill/insert_cable_skill.desc \
+  --manifest src/aic/flowstate/aic_flowstate_skills/insert_cable_skill/src/insert_cable_skill.manifest.textproto \
+  --oci_image images/insert_cable_skill/insert_cable_skill.tar \
+  --output images/insert_cable_skill/insert_cable_skill.bundle.tar
 ```
 
 ---

--- a/flowstate/README.md
+++ b/flowstate/README.md
@@ -113,7 +113,7 @@ cd ~/ws_aic_phase1
 
 # This command bundles the skill into a deployable tarball
 inbuild skill bundle \
-  --file_descriptor_set images/insert_cable_skill/insert_cable_skill.desc \
+  --file_descriptor_set images/insert_cable_skill/insert_cable_skill_protos.desc \
   --manifest src/aic/flowstate/aic_flowstate_skills/insert_cable_skill/src/insert_cable_skill.manifest.textproto \
   --oci_image images/insert_cable_skill/insert_cable_skill.tar \
   --output images/insert_cable_skill/insert_cable_skill.bundle.tar

--- a/flowstate/README.md
+++ b/flowstate/README.md
@@ -91,3 +91,55 @@ export INTRINSIC_CLUSTER="vmp-xxxx-xxxxxxx"
 
 > [!NOTE]
 > It is possible that first time you run `inctl asset install` it fails with error. In that case, please try again.
+
+---
+
+## 🛠️ Building the Skill
+
+We can use the `build_container.sh` and `build_bundle.sh` script from the intrinsic-ai/sdk-ros repository to build and package the skill bundle. The instructions below build and bundle the `insert_cable_skill`.
+
+---
+
+```bash
+cd ~/ws_aic_phase1
+
+# This command builds the insert_cable_skill, the Intrinsic SDK, and the necessary ROS dependencies into a tar image.
+./src/sdk-ros/scripts/build_container.sh \
+  --ros_distro "kilted" \
+  --skill_package aic_flowstate_skills \
+  --skill_name insert_cable_skill
+
+# This command bundles the skill into a deployable tarball
+./src/sdk-ros/scripts/build_bundle.sh \
+  --skill_package aic_flowstate_skills \
+  --skill_name insert_cable_skill \
+  --manifest_path src/aic/flowstate/aic_flowstate_skills/insert_cable_skill/src/insert_cable_skill.manifest.textproto
+```
+
+---
+
+## 📥 Installing skills to Flowstate
+
+After building, upload and install the skill into your solution context.
+
+---
+
+```bash
+
+# 1. Export path to side-loaded service bundle
+export SKILL_BUNDLE=~/ws_aic_phase1/images/insert_cable_skill/insert_cable_skill.bundle.tar
+
+# 2. Add Organization
+export INTRINSIC_ORGANIZATION="<ORG_NAME>"
+
+# 3. Add Cluster Endpoint
+export INTRINSIC_CLUSTER="vmp-xxxx-xxxxxxx"
+
+./inctl asset install \
+  --org $INTRINSIC_ORGANIZATION \
+  --cluster $INTRINSIC_CLUSTER \
+  $SKILL_BUNDLE
+
+```
+
+---

--- a/flowstate/README.md
+++ b/flowstate/README.md
@@ -94,9 +94,9 @@ export INTRINSIC_CLUSTER="vmp-xxxx-xxxxxxx"
 
 ---
 
-## 🛠️ Building the Skill
+## 🛠️ Building the insert_cable_skill
 
-We can use the `build_container.sh` and `build_bundle.sh` script from the intrinsic-ai/sdk-ros repository to build and package the skill bundle. The instructions below build and bundle the `insert_cable_skill`.
+We can use the `build_container.sh` script to build and package the skill bundle using the following instructions.
 
 ---
 
@@ -108,8 +108,7 @@ cd ~/ws_aic_phase1
   --skill_name insert_cable_skill \
   --skill_package aic_flowstate_skills \
   --manifest_path src/aic/flowstate/aic_flowstate_skills/insert_cable_skill/src/insert_cable_skill.manifest.textproto \
-  --dockerfile ./src/aic/flowstate/resources/Dockerfile.skill \
-  --ros_distro kilted
+  --dockerfile ./src/aic/flowstate/resources/Dockerfile.skill
 
 # This command bundles the skill into a deployable tarball
 ./inbuild skill bundle \
@@ -121,7 +120,7 @@ cd ~/ws_aic_phase1
 
 ---
 
-## 📥 Installing skills to Flowstate
+## 📥 Installing insert_cable_skill to Flowstate
 
 After building, upload and install the skill into your solution context.
 
@@ -146,3 +145,53 @@ export INTRINSIC_CLUSTER="vmp-xxxx-xxxxxxx"
 ```
 
 ---
+
+## 🛠️ Building the tare_force_torque_sensor_skill
+
+We can use the `build_container.sh` script to build and package the skill bundle using the following instructions.
+
+---
+
+```bash
+cd ~/ws_aic_phase1
+
+# This command builds the insert_cable_skill, the Intrinsic SDK, and the necessary ROS dependencies into a tar image.
+./src/aic/flowstate/scripts/build_container.sh \
+  --skill_name tare_force_torque_sensor_skill \
+  --skill_package aic_flowstate_skills \
+  --manifest_path src/aic/flowstate/aic_flowstate_skills/tare_force_torque_sensor_skill/src/tare_force_torque_sensor_skill.manifest.textproto \
+  --dockerfile ./src/aic/flowstate/resources/Dockerfile.skill
+
+# This command bundles the skill into a deployable tarball
+./inbuild skill bundle \
+  --file_descriptor_set images/tare_force_torque_sensor_skill/tare_force_torque_sensor_skill_protos.desc \
+  --manifest src/aic/flowstate/aic_flowstate_skills/tare_force_torque_sensor_skill/src/tare_force_torque_sensor_skill.manifest.textproto \
+  --oci_image images/tare_force_torque_sensor_skill/tare_force_torque_sensor_skill.tar \
+  --output images/tare_force_torque_sensor_skill/tare_force_torque_sensor_skill.bundle.tar
+```
+
+---
+
+## 📥 Installing tare_force_torque_sensor_skill to Flowstate
+
+After building, upload and install the skill into your solution context.
+
+---
+
+```bash
+
+# 1. Export path to side-loaded service bundle
+export SKILL_BUNDLE=~/ws_aic_phase1/images/tare_force_torque_sensor_skill/tare_force_torque_sensor_skill.bundle.tar
+
+# 2. Add Organization
+export INTRINSIC_ORGANIZATION="<ORG_NAME>"
+
+# 3. Add Cluster Endpoint
+export INTRINSIC_CLUSTER="vmp-xxxx-xxxxxxx"
+
+./inctl asset install \
+  --org $INTRINSIC_ORGANIZATION \
+  --cluster $INTRINSIC_CLUSTER \
+  $SKILL_BUNDLE
+
+```

--- a/flowstate/aic_flowstate_ros_bridge/README.md
+++ b/flowstate/aic_flowstate_ros_bridge/README.md
@@ -9,14 +9,14 @@ A Flowstate-ROS bridge plugin that bridges the real-time controller service to R
 Set up the Docker engine:
 
 ```bash
-cd ~/ws_aic
+cd ~/ws_aic_phase1
 ./src/sdk-ros/scripts/setup_docker.sh
 ```
 
 Then, create the service bundle using the `build_service_bundle.sh` script.
 
 ```bash
-cd ~/ws_aic
+cd ~/ws_aic_phase1
 ./src/aic/flowstate/scripts/build_flowstate_ros_bridge.sh --ros_distro kilted
 ```
 
@@ -24,7 +24,7 @@ cd ~/ws_aic
 
 ```bash
 # 1. Export path to side-loaded service bundle
-export SERVICE_BUNDLE=~/ws_aic/images/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge.bundle.tar
+export SERVICE_BUNDLE=~/ws_aic_phase1/images/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge.bundle.tar
 
 # 2. Add Organization
 export INTRINSIC_ORGANIZATION="<ORG_NAME>"

--- a/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge.proto
+++ b/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge.proto
@@ -7,8 +7,9 @@ message RobotControlBridgeConfig {
   string server_address = 1;
   string instance = 2;
   string part_name = 3;
-  string task_settings_file = 4;
-  string joint_task_settings_file = 5;
+  string ft_sensor_part_name = 4;
+  string task_settings_file = 5;
+  string joint_task_settings_file = 6;
 }
 
 // Configuration to control which sensors are enabled to publish ROS 2 messages.

--- a/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge_default_config.pbtxt
+++ b/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge_default_config.pbtxt
@@ -39,6 +39,7 @@
     server_address: "istio-ingressgateway.app-ingress.svc.cluster.local:80"
     instance: "robot_controller"
     part_name: "arm"
+    ft_sensor_part_name: "ft_sensor"
     task_settings_file: "config/default_task_settings.pbtxt"
     joint_task_settings_file: "config/default_joint_task_settings.pbtxt"
   },

--- a/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge_default_config.pbtxt
+++ b/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge_default_config.pbtxt
@@ -40,7 +40,7 @@
     server_address: "istio-ingressgateway.app-ingress.svc.cluster.local:80"
     instance: "robot_controller"
     part_name: "arm"
-    ft_sensor_part_name: "ft_sensor"
+    ft_sensor_part_name: "ati_ft_sensor"
     task_settings_file: "config/default_task_settings.pbtxt"
     joint_task_settings_file: "config/default_joint_task_settings.pbtxt"
   },

--- a/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge_default_config.pbtxt
+++ b/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge_default_config.pbtxt
@@ -40,6 +40,7 @@
     server_address: "istio-ingressgateway.app-ingress.svc.cluster.local:80"
     instance: "robot_controller"
     part_name: "arm"
+    ft_sensor_part_name: "ft_sensor"
     task_settings_file: "config/default_task_settings.pbtxt"
     joint_task_settings_file: "config/default_joint_task_settings.pbtxt"
   },

--- a/flowstate/aic_flowstate_ros_bridge/launch/aic_flowstate_ros_bridge_launch.py
+++ b/flowstate/aic_flowstate_ros_bridge/launch/aic_flowstate_ros_bridge_launch.py
@@ -71,11 +71,11 @@ def generate_launch_description():
                 default_value="force_torque_sensor/force_torque_sensor/AtiForceTorqueSensor",
                 description="Frame ID of F/T sensor to be used in force_torque_topic",
             ),
-            # DeclareLaunchArgument(
-            #     "override_joint_names",
-            #     default_value="",
-            #     description="",
-            # ),
+            DeclareLaunchArgument(
+                "ft_sensor_part_name",
+                default_value="ft_sensor",
+                description="F/T sensor part name",
+            ),
             LifecycleNode(
                 package="flowstate_ros_bridge",
                 executable="flowstate_ros_bridge",
@@ -97,6 +97,9 @@ def generate_launch_description():
                         "server_address": LaunchConfiguration("server_address"),
                         "instance": LaunchConfiguration("instance"),
                         "part_name": LaunchConfiguration("part_name"),
+                        "ft_sensor_part_name": LaunchConfiguration(
+                            "ft_sensor_part_name"
+                        ),
                         "robot_joint_state_topic": LaunchConfiguration(
                             "robot_joint_state_topic"
                         ),

--- a/flowstate/aic_flowstate_ros_bridge/launch/aic_flowstate_ros_bridge_launch.py
+++ b/flowstate/aic_flowstate_ros_bridge/launch/aic_flowstate_ros_bridge_launch.py
@@ -73,7 +73,7 @@ def generate_launch_description():
             ),
             DeclareLaunchArgument(
                 "ft_sensor_part_name",
-                default_value="ft_sensor",
+                default_value="ati_ft_sensor",
                 description="F/T sensor part name",
             ),
             LifecycleNode(

--- a/flowstate/aic_flowstate_ros_bridge/launch/aic_flowstate_ros_bridge_launch.py
+++ b/flowstate/aic_flowstate_ros_bridge/launch/aic_flowstate_ros_bridge_launch.py
@@ -71,11 +71,11 @@ def generate_launch_description():
                 default_value="force_torque_sensor/force_torque_sensor/AtiForceTorqueSensor",
                 description="Frame ID of F/T sensor to be used in force_torque_topic",
             ),
-            # DeclareLaunchArgument(
-            #     "override_joint_names",
-            #     default_value="",
-            #     description="",
-            # ),
+            DeclareLaunchArgument(
+                "ft_sensor_part_name",
+                default_value="ft_sensor",
+                description="F/T sensor part name",
+            ),
             LifecycleNode(
                 package="flowstate_ros_bridge",
                 executable="flowstate_ros_bridge",
@@ -98,6 +98,9 @@ def generate_launch_description():
                         "server_address": LaunchConfiguration("server_address"),
                         "instance": LaunchConfiguration("instance"),
                         "part_name": LaunchConfiguration("part_name"),
+                        "ft_sensor_part_name": LaunchConfiguration(
+                            "ft_sensor_part_name"
+                        ),
                         "robot_joint_state_topic": LaunchConfiguration(
                             "robot_joint_state_topic"
                         ),

--- a/flowstate/aic_flowstate_ros_bridge/src/aic_flowstate_ros_bridge_main.cpp
+++ b/flowstate/aic_flowstate_ros_bridge/src/aic_flowstate_ros_bridge_main.cpp
@@ -112,6 +112,8 @@ int main(int argc, char* argv[]) {
                       robot_control_bridge_config.server_address());
   params.emplace_back("instance", robot_control_bridge_config.instance());
   params.emplace_back("part_name", robot_control_bridge_config.part_name());
+  params.emplace_back("ft_sensor_part_name",
+                      robot_control_bridge_config.ft_sensor_part_name());
   params.emplace_back("task_settings_file",
                       robot_control_bridge_config.task_settings_file());
   params.emplace_back("joint_task_settings_file",

--- a/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.cpp
+++ b/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.cpp
@@ -320,7 +320,8 @@ bool RobotControlBridge::initialize(
             << ", instance: " << data_->instance_
             << ", part: " << data_->part_name_;
 
-  if (!restartControllerBridge()) {
+  data_->connected_to_controller_ = restartControllerBridge();
+  if (!data_->connected_to_controller_) {
     LOG(ERROR) << "Failed to connect to controller bridge.";
     // todo(johntgz) add retry mechanism
   }
@@ -542,9 +543,16 @@ void RobotControlBridge::TareForceTorqueSensorCallback(
     std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
   LOG(INFO) << "Received request to tare force torque sensor";
 
-  if (!data_->session_ || !data_->tare_action_.has_value()) {
+  if (!data_->connected_to_controller_) {
+    LOG(INFO) << "Restarting connection to controller server";
+    data_->connected_to_controller_ = restartControllerBridge();
+  }
+
+  if (!data_->connected_to_controller_ || !data_->session_ ||
+      !data_->tare_action_.has_value()) {
     response->success = false;
-    response->message = "No active session or tare action not initialized";
+    response->message =
+        "No active controller session or tare action not initialized";
     return;
   }
 

--- a/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.cpp
+++ b/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.cpp
@@ -46,6 +46,7 @@ namespace flowstate_ros_bridge {
 constexpr const char* kServerAddressParamName = "server_address";
 constexpr const char* kInstanceParamName = "instance";
 constexpr const char* kPartNameParamName = "part_name";
+constexpr const char* kFTPartNameParamName = "ft_sensor_part_name";
 constexpr const char* kAgentBridgeTaskSettingsFileParamName =
     "task_settings_file";
 constexpr const char* kAgentBridgeJointTaskSettingsFileParamName =
@@ -66,6 +67,8 @@ void RobotControlBridge::declare_ros_parameters(
       kInstanceParamName, rclcpp::ParameterValue{"robot_controller"});
   param_interface->declare_parameter(kPartNameParamName,
                                      rclcpp::ParameterValue{"arm"});
+  param_interface->declare_parameter(kFTPartNameParamName,
+                                     rclcpp::ParameterValue{"ft_sensor"});
   param_interface->declare_parameter(kAgentBridgeTaskSettingsFileParamName,
                                      rclcpp::ParameterValue{""});
   param_interface->declare_parameter(kAgentBridgeJointTaskSettingsFileParamName,
@@ -92,6 +95,9 @@ bool RobotControlBridge::initialize(
                          .get_value<std::string>();
   data_->part_name_ = param_interface->get_parameter(kPartNameParamName)
                           .get_value<std::string>();
+  data_->ft_sensor_part_name_ =
+      param_interface->get_parameter(kFTPartNameParamName)
+          .get_value<std::string>();
   std::filesystem::path task_settings_file =
       param_interface->get_parameter(kAgentBridgeTaskSettingsFileParamName)
           .get_value<std::string>();
@@ -153,6 +159,9 @@ bool RobotControlBridge::initialize(
            "filepath for loading default task_settings.";
     throw std::runtime_error("'joint_task_settings_file' parameter is empty.");
   }
+  // Set default taring cycle of 100
+  // todo(johntgz) set this as a ros parameter
+  data_->tare_ft_sensor_fixed_params_.set_num_taring_cycles(100);
 
   // Create Zenoh subscriptions to the action output streams from the robot
   // controller server
@@ -267,6 +276,18 @@ bool RobotControlBridge::initialize(
       [this](const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
              std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
         this->RestartBridgeCallback(request, response);
+      },
+      rclcpp::ServicesQoS(), nullptr);
+
+  // ROS Service server for TareForceTorqueSensor
+  data_->tare_ft_sensor_srv_ = rclcpp::create_service<std_srvs::srv::Trigger>(
+      base_interface,
+      data_->node_interfaces_
+          .get<rclcpp::node_interfaces::NodeServicesInterface>(),
+      "aic_controller/tare_force_torque_sensor",
+      [this](const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+             std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
+        this->TareForceTorqueSensorCallback(request, response);
       },
       rclcpp::ServicesQoS(), nullptr);
 
@@ -516,6 +537,35 @@ void RobotControlBridge::RestartBridgeCallback(
 }
 
 ///=============================================================================
+void RobotControlBridge::TareForceTorqueSensorCallback(
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
+  LOG(INFO) << "Received request to tare force torque sensor";
+
+  if (!data_->session_ || !data_->tare_action_.has_value()) {
+    response->success = false;
+    response->message = "No active session or tare action not initialized";
+    return;
+  }
+
+  // todo(johntgz) should we Start the tare action in parallel with existing
+  // motion plans, we by setting stop_active_actions = false
+  auto status =
+      data_->session_->StartAction(data_->tare_action_.value(), false);
+  if (!status.ok()) {
+    LOG(ERROR) << "Failed to start TareForceTorqueSensor Action: "
+               << status.message().data();
+    response->success = false;
+    response->message = "Failed to start TareForceTorqueSensor Action";
+    return;
+  }
+
+  LOG(INFO) << "Successfully started TareForceTorqueSensor Action";
+  response->success = true;
+  response->message = "Successfully started TareForceTorqueSensor Action";
+}
+
+///=============================================================================
 bool RobotControlBridge::restartControllerBridge() {
   // Stop all currently running actions
   if (data_->session_) {
@@ -530,6 +580,7 @@ bool RobotControlBridge::restartControllerBridge() {
   data_->session_.reset();
   data_->agent_bridge_action_ = std::nullopt;
   data_->agent_bridge_joint_action_ = std::nullopt;
+  data_->tare_action_ = std::nullopt;
   data_->agent_bridge_writer_.reset();
   data_->agent_bridge_joint_writer_.reset();
 
@@ -576,6 +627,15 @@ bool RobotControlBridge::startControllerAction() {
                          data_->part_name_}})
           .WithFixedParams(data_->agent_bridge_joint_fixed_params_);
 
+  ActionDescriptor tare_ft_sensor_descriptor =
+      ActionDescriptor(
+          intrinsic::icon::TareForceTorqueSensorInfo::kActionTypeName,
+          kTareForceTorqueSensorId,
+          {{intrinsic::icon::TareForceTorqueSensorInfo::
+                kForceTorqueSensorSlotName,
+            data_->ft_sensor_part_name_}})
+          .WithFixedParams(data_->tare_ft_sensor_fixed_params_);
+
   // Add the AgentBridge and AgentBridgeJoint actions to the session, then
   // create StreamWriters for each of the actions.
 
@@ -598,6 +658,15 @@ bool RobotControlBridge::startControllerAction() {
     return false;
   }
   data_->agent_bridge_joint_action_ = agent_bridge_joint_action_or.value();
+
+  // Add the TareForceTorqueSensor action to the current session
+  auto tare_action_or = data_->session_->AddAction(tare_ft_sensor_descriptor);
+  if (!tare_action_or.ok()) {
+    LOG(ERROR) << "Failed to add TareForceTorqueSensor Action: "
+               << tare_action_or.status().message().data();
+    return false;
+  }
+  data_->tare_action_ = tare_action_or.value();
 
   // Create StreamWriter for the AgentBridge action
   auto agent_bridge_writer_or =
@@ -692,8 +761,13 @@ bool RobotControlBridge::startControllerSession() {
   data_->num_joints_ = part_status.value().joint_states_size();
 
   // Start ICON Session
-  auto session_or =
-      Session::Start(icon_channel_or.value(), {data_->part_name_});
+  std::vector<std::string> parts = {data_->part_name_};
+  if (data_->ft_sensor_part_name_ != data_->part_name_) {
+    parts.push_back(data_->ft_sensor_part_name_);
+  }
+  // todo(johntgz) test if starting a session with multiple parts would cause an
+  // issue
+  auto session_or = Session::Start(icon_channel_or.value(), parts);
   if (!session_or.ok()) {
     LOG(ERROR) << "Failed to start ICON session: "
                << session_or.status().message().data();
@@ -1104,6 +1178,7 @@ RobotControlBridge::Data::~Data() {
   session_.reset();
   agent_bridge_action_ = std::nullopt;
   agent_bridge_joint_action_ = std::nullopt;
+  tare_action_ = std::nullopt;
   agent_bridge_writer_.reset();
   agent_bridge_joint_writer_.reset();
 
@@ -1116,6 +1191,7 @@ RobotControlBridge::Data::~Data() {
   joint_motion_update_sub_.reset();
   change_target_mode_srv_.reset();
   restart_bridge_srv_.reset();
+  tare_ft_sensor_srv_.reset();
   controller_state_pub_.reset();
   controller_state_timer_.reset();
 

--- a/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.cpp
+++ b/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.cpp
@@ -559,6 +559,8 @@ void RobotControlBridge::TareForceTorqueSensorCallback(
       if (i < data_->restart_connection_retries_ - 1) {
         LOG(INFO)
             << "Failed to restart controller bridge. Retrying in 250ms...";
+        // todo(johntgz): This sleep currently blocks the bridge. Investigate
+        // the use of threads for non-blocking behaviour.
         rclcpp::sleep_for(std::chrono::milliseconds(250));
       }
     }

--- a/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.cpp
+++ b/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.cpp
@@ -76,7 +76,7 @@ void RobotControlBridge::declare_ros_parameters(
   param_interface->declare_parameter(kAgentBridgeJointTaskSettingsFileParamName,
                                      rclcpp::ParameterValue{""});
   param_interface->declare_parameter(kRestartConnectionRetriesParamName,
-                                     rclcpp::ParameterValue{3});
+                                     rclcpp::ParameterValue{6});
 }
 
 ///=============================================================================
@@ -558,8 +558,8 @@ void RobotControlBridge::TareForceTorqueSensorCallback(
       }
       if (i < data_->restart_connection_retries_ - 1) {
         LOG(INFO)
-            << "Failed to restart controller bridge. Retrying in 500ms...";
-        rclcpp::sleep_for(std::chrono::milliseconds(500));
+            << "Failed to restart controller bridge. Retrying in 250ms...";
+        rclcpp::sleep_for(std::chrono::milliseconds(250));
       }
     }
   }
@@ -787,8 +787,7 @@ bool RobotControlBridge::startControllerSession() {
   if (data_->ft_sensor_part_name_ != data_->part_name_) {
     parts.push_back(data_->ft_sensor_part_name_);
   }
-  // todo(johntgz) test if starting a session with multiple parts would cause an
-  // issue
+
   auto session_or = Session::Start(icon_channel_or.value(), parts);
   if (!session_or.ok()) {
     LOG(ERROR) << "Failed to start ICON session: "

--- a/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.cpp
+++ b/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.cpp
@@ -53,6 +53,8 @@ constexpr const char* kAgentBridgeJointTaskSettingsFileParamName =
     "joint_task_settings_file";
 constexpr const char* kFlowstateZenohRouterParamName =
     "flowstate_zenoh_router_address";
+constexpr const char* kRestartConnectionRetriesParamName =
+    "restart_connection_retries";
 
 ///=============================================================================
 void RobotControlBridge::declare_ros_parameters(
@@ -73,6 +75,8 @@ void RobotControlBridge::declare_ros_parameters(
                                      rclcpp::ParameterValue{""});
   param_interface->declare_parameter(kAgentBridgeJointTaskSettingsFileParamName,
                                      rclcpp::ParameterValue{""});
+  param_interface->declare_parameter(kRestartConnectionRetriesParamName,
+                                     rclcpp::ParameterValue{3});
 }
 
 ///=============================================================================
@@ -98,6 +102,9 @@ bool RobotControlBridge::initialize(
   data_->ft_sensor_part_name_ =
       param_interface->get_parameter(kFTPartNameParamName)
           .get_value<std::string>();
+  data_->restart_connection_retries_ =
+      param_interface->get_parameter(kRestartConnectionRetriesParamName)
+          .get_value<int>();
   std::filesystem::path task_settings_file =
       param_interface->get_parameter(kAgentBridgeTaskSettingsFileParamName)
           .get_value<std::string>();
@@ -544,8 +551,17 @@ void RobotControlBridge::TareForceTorqueSensorCallback(
   LOG(INFO) << "Received request to tare force torque sensor";
 
   if (!data_->connected_to_controller_) {
-    LOG(INFO) << "Restarting connection to controller server";
-    data_->connected_to_controller_ = restartControllerBridge();
+    for (int i = 0; i < data_->restart_connection_retries_; ++i) {
+      data_->connected_to_controller_ = restartControllerBridge();
+      if (data_->connected_to_controller_) {
+        break;
+      }
+      if (i < data_->restart_connection_retries_ - 1) {
+        LOG(INFO)
+            << "Failed to restart controller bridge. Retrying in 500ms...";
+        rclcpp::sleep_for(std::chrono::milliseconds(500));
+      }
+    }
   }
 
   if (!data_->connected_to_controller_ || !data_->session_ ||
@@ -556,8 +572,6 @@ void RobotControlBridge::TareForceTorqueSensorCallback(
     return;
   }
 
-  // todo(johntgz) should we Start the tare action in parallel with existing
-  // motion plans, we by setting stop_active_actions = false
   auto status =
       data_->session_->StartAction(data_->tare_action_.value(), false);
   if (!status.ok()) {

--- a/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.hpp
+++ b/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.hpp
@@ -22,6 +22,7 @@
 #include <mutex>
 
 #include "flowstate_ros_bridge/bridge_interface.hpp"
+#include "intrinsic/icon/actions/tare_force_torque_sensor_info.h"
 #include "intrinsic/icon/cc_client/client.h"
 #include "intrinsic/icon/cc_client/session.h"
 #include "intrinsic/icon/cc_client/stream.h"
@@ -52,6 +53,7 @@ using ::intrinsic::icon::Session;
 //==============================================================================
 constexpr intrinsic::icon::ActionInstanceId kAgentBridgeId(1);
 constexpr intrinsic::icon::ActionInstanceId kAgentBridgeJointId(2);
+constexpr intrinsic::icon::ActionInstanceId kTareForceTorqueSensorId(3);
 
 ///=============================================================================
 class RobotControlBridge : public BridgeInterface {
@@ -79,6 +81,10 @@ class RobotControlBridge : public BridgeInterface {
           response);
 
   void RestartBridgeCallback(
+      const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+      std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+
+  void TareForceTorqueSensorCallback(
       const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
       std::shared_ptr<std_srvs::srv::Trigger::Response> response);
 
@@ -156,8 +162,11 @@ class RobotControlBridge : public BridgeInterface {
     intrinsic::icon::AgentBridgeInfo::FixedParams agent_bridge_fixed_params_;
     intrinsic::icon::AgentBridgeJointInfo::FixedParams
         agent_bridge_joint_fixed_params_;
+    intrinsic::icon::TareForceTorqueSensorInfo::FixedParams
+        tare_ft_sensor_fixed_params_;
     std::optional<Action> agent_bridge_action_;
     std::optional<Action> agent_bridge_joint_action_;
+    std::optional<Action> tare_action_;
     std::unique_ptr<intrinsic::icon::StreamWriterInterface<
         intrinsic_proto::icon::actions::proto::MotionUpdate>>
         agent_bridge_writer_;
@@ -183,11 +192,13 @@ class RobotControlBridge : public BridgeInterface {
     rclcpp::Service<aic_control_interfaces::srv::ChangeTargetMode>::SharedPtr
         change_target_mode_srv_;
     rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr restart_bridge_srv_;
+    rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr tare_ft_sensor_srv_;
 
     rclcpp::TimerBase::SharedPtr controller_state_timer_;
 
     bool connected_to_controller_;
     std::string part_name_;
+    std::string ft_sensor_part_name_;
     std::string instance_;
     std::string server_address_;
     std::size_t num_joints_;

--- a/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.hpp
+++ b/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.hpp
@@ -202,6 +202,7 @@ class RobotControlBridge : public BridgeInterface {
     std::string instance_;
     std::string server_address_;
     std::size_t num_joints_;
+    int restart_connection_retries_;
     uint8_t target_mode_value_;
     std::optional<int64_t> last_part_status_timestamp_ns_;
 

--- a/flowstate/aic_flowstate_skills/CMakeLists.txt
+++ b/flowstate/aic_flowstate_skills/CMakeLists.txt
@@ -15,8 +15,10 @@ find_package(ament_cmake REQUIRED)
 find_package(intrinsic_sdk_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
+find_package(std_srvs REQUIRED)
 
 
 add_subdirectory(insert_cable_skill)
+add_subdirectory(tare_force_torque_sensor_skill)
 
 ament_package()

--- a/flowstate/aic_flowstate_skills/insert_cable_skill/CMakeLists.txt
+++ b/flowstate/aic_flowstate_skills/insert_cable_skill/CMakeLists.txt
@@ -3,7 +3,7 @@ intrinsic_sdk_protobuf_generate(
   NAME insert_cable_skill
   SOURCES src/insert_cable_skill.proto
   TARGET insert_cable_skill_protos
-  DESCRIPTOR_SET_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_protos.desc"
+  DESCRIPTOR_SET_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill.desc"
 )
 
 # Generate the skill config file.
@@ -11,7 +11,7 @@ intrinsic_sdk_generate_skill_config(
   TARGET insert_cable_skill_config
   SKILL_NAME insert_cable_skill
   MANIFEST src/insert_cable_skill.manifest.textproto
-  PROTO_DESCRIPTOR_FILE "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_protos.desc"
+  PROTO_DESCRIPTOR_FILE "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill.desc"
   SKILL_CONFIG_FILE_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_config.pbbin"
 )
 
@@ -19,7 +19,6 @@ install(
   FILES
     src/insert_cable_skill.manifest.textproto
     "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_config.pbbin"
-    "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_protos.desc"
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/flowstate/aic_flowstate_skills/insert_cable_skill/CMakeLists.txt
+++ b/flowstate/aic_flowstate_skills/insert_cable_skill/CMakeLists.txt
@@ -3,7 +3,7 @@ intrinsic_sdk_protobuf_generate(
   NAME insert_cable_skill
   SOURCES src/insert_cable_skill.proto
   TARGET insert_cable_skill_protos
-  DESCRIPTOR_SET_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill.desc"
+  DESCRIPTOR_SET_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_protos.desc"
 )
 
 # Generate the skill config file.
@@ -11,7 +11,7 @@ intrinsic_sdk_generate_skill_config(
   TARGET insert_cable_skill_config
   SKILL_NAME insert_cable_skill
   MANIFEST src/insert_cable_skill.manifest.textproto
-  PROTO_DESCRIPTOR_FILE "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill.desc"
+  PROTO_DESCRIPTOR_FILE "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_protos.desc"
   SKILL_CONFIG_FILE_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_config.pbbin"
 )
 
@@ -19,6 +19,7 @@ install(
   FILES
     src/insert_cable_skill.manifest.textproto
     "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_config.pbbin"
+    "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_protos.desc"
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/flowstate/aic_flowstate_skills/insert_cable_skill/CMakeLists.txt
+++ b/flowstate/aic_flowstate_skills/insert_cable_skill/CMakeLists.txt
@@ -19,6 +19,7 @@ install(
   FILES
     src/insert_cable_skill.manifest.textproto
     "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_config.pbbin"
+    "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_protos.desc"
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/flowstate/aic_flowstate_skills/insert_cable_skill/CMakeLists.txt
+++ b/flowstate/aic_flowstate_skills/insert_cable_skill/CMakeLists.txt
@@ -3,7 +3,7 @@ intrinsic_sdk_protobuf_generate(
   NAME insert_cable_skill
   SOURCES src/insert_cable_skill.proto
   TARGET insert_cable_skill_protos
-  DESCRIPTOR_SET_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill.desc"
+  DESCRIPTOR_SET_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_protos.desc"
 )
 
 # Generate the skill config file.
@@ -11,7 +11,7 @@ intrinsic_sdk_generate_skill_config(
   TARGET insert_cable_skill_config
   SKILL_NAME insert_cable_skill
   MANIFEST src/insert_cable_skill.manifest.textproto
-  PROTO_DESCRIPTOR_FILE "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill.desc"
+  PROTO_DESCRIPTOR_FILE "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_protos.desc"
   SKILL_CONFIG_FILE_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_config.pbbin"
 )
 

--- a/flowstate/aic_flowstate_skills/package.xml
+++ b/flowstate/aic_flowstate_skills/package.xml
@@ -13,6 +13,7 @@
   <depend>intrinsic_sdk_cmake</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
+  <depend>std_srvs</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/flowstate/aic_flowstate_skills/tare_force_torque_sensor_skill/CMakeLists.txt
+++ b/flowstate/aic_flowstate_skills/tare_force_torque_sensor_skill/CMakeLists.txt
@@ -1,0 +1,58 @@
+# Generate the skill's protobuf files, protobuf library, and descriptor set file.
+intrinsic_sdk_protobuf_generate(
+  NAME tare_force_torque_sensor_skill
+  SOURCES src/tare_force_torque_sensor_skill.proto
+  TARGET tare_force_torque_sensor_skill_protos
+  DESCRIPTOR_SET_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/tare_force_torque_sensor_skill_protos.desc"
+)
+
+# Generate the skill config file.
+intrinsic_sdk_generate_skill_config(
+  TARGET tare_force_torque_sensor_skill_config
+  SKILL_NAME tare_force_torque_sensor_skill
+  MANIFEST src/tare_force_torque_sensor_skill.manifest.textproto
+  PROTO_DESCRIPTOR_FILE "${CMAKE_CURRENT_BINARY_DIR}/tare_force_torque_sensor_skill_protos.desc"
+  SKILL_CONFIG_FILE_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/tare_force_torque_sensor_skill_config.pbbin"
+)
+
+install(
+  FILES
+    src/tare_force_torque_sensor_skill.manifest.textproto
+    "${CMAKE_CURRENT_BINARY_DIR}/tare_force_torque_sensor_skill_config.pbbin"
+    "${CMAKE_CURRENT_BINARY_DIR}/tare_force_torque_sensor_skill_protos.desc"
+  DESTINATION share/${PROJECT_NAME}
+)
+
+# Generate the c++ main file for the skill.
+intrinsic_sdk_generate_skill_main_cc(
+  MANIFEST src/tare_force_torque_sensor_skill.manifest.textproto
+  HEADER_FILES src/tare_force_torque_sensor_skill.h
+  MAIN_FILE_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/tare_force_torque_sensor_skill_main.cc"
+)
+
+add_executable(tare_force_torque_sensor_skill_main
+  src/tare_force_torque_sensor_skill.cc
+  ${CMAKE_CURRENT_BINARY_DIR}/tare_force_torque_sensor_skill_main.cc
+)
+
+target_include_directories(tare_force_torque_sensor_skill_main
+  PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_BINARY_DIR}
+  ${CMAKE_CURRENT_BINARY_DIR}/src
+)
+
+target_link_libraries(tare_force_torque_sensor_skill_main
+  intrinsic_sdk_cmake::intrinsic_sdk_cmake
+  tare_force_torque_sensor_skill_protos
+  rclcpp::rclcpp
+  ${std_srvs_TARGETS}
+)
+
+add_dependencies(tare_force_torque_sensor_skill_main tare_force_torque_sensor_skill_config)
+add_dependencies(tare_force_torque_sensor_skill_main tare_force_torque_sensor_skill_protos)
+
+install(
+  TARGETS tare_force_torque_sensor_skill_main
+  DESTINATION lib/${PROJECT_NAME}
+)

--- a/flowstate/aic_flowstate_skills/tare_force_torque_sensor_skill/CMakeLists.txt
+++ b/flowstate/aic_flowstate_skills/tare_force_torque_sensor_skill/CMakeLists.txt
@@ -19,7 +19,6 @@ install(
   FILES
     src/tare_force_torque_sensor_skill.manifest.textproto
     "${CMAKE_CURRENT_BINARY_DIR}/tare_force_torque_sensor_skill_config.pbbin"
-    "${CMAKE_CURRENT_BINARY_DIR}/tare_force_torque_sensor_skill_protos.desc"
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/flowstate/aic_flowstate_skills/tare_force_torque_sensor_skill/CMakeLists.txt
+++ b/flowstate/aic_flowstate_skills/tare_force_torque_sensor_skill/CMakeLists.txt
@@ -19,6 +19,7 @@ install(
   FILES
     src/tare_force_torque_sensor_skill.manifest.textproto
     "${CMAKE_CURRENT_BINARY_DIR}/tare_force_torque_sensor_skill_config.pbbin"
+    "${CMAKE_CURRENT_BINARY_DIR}/tare_force_torque_sensor_skill_protos.desc"
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/flowstate/aic_flowstate_skills/tare_force_torque_sensor_skill/src/tare_force_torque_sensor_skill.cc
+++ b/flowstate/aic_flowstate_skills/tare_force_torque_sensor_skill/src/tare_force_torque_sensor_skill.cc
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2026 Intrinsic Innovation LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "tare_force_torque_sensor_skill.h"
+
+#include <chrono>
+
+#include "absl/status/statusor.h"
+#include "rclcpp/rclcpp.hpp"
+#include "std_srvs/srv/trigger.hpp"
+#include "tare_force_torque_sensor_skill.pb.h"
+
+//==============================================================================
+// ROS initialization.
+//==============================================================================
+
+namespace {
+class InitRos {
+ public:
+  InitRos() { rclcpp::init(0, nullptr); }
+  ~InitRos() { rclcpp::shutdown(); }
+};
+
+class TareFTClientNode : public rclcpp::Node {
+ public:
+  TareFTClientNode() : Node("tare_force_torque_sensor_skill_node") {
+    client_ = this->create_client<std_srvs::srv::Trigger>(
+        "aic_controller/tare_force_torque_sensor");
+  }
+
+  absl::StatusOr<std_srvs::srv::Trigger::Response::SharedPtr> CallService(
+      double timeout_ms) {
+    if (!client_->wait_for_service(std::chrono::seconds(10))) {
+      return absl::UnavailableError(
+          "Service 'aic_controller/tare_force_torque_sensor' not available");
+    }
+
+    auto request = std::make_shared<std_srvs::srv::Trigger::Request>();
+    auto result_future = client_->async_send_request(request);
+
+    if (rclcpp::spin_until_future_complete(
+            this->get_node_base_interface(), result_future,
+            std::chrono::milliseconds(static_cast<int>(timeout_ms))) !=
+        rclcpp::FutureReturnCode::SUCCESS) {
+      return absl::DeadlineExceededError(
+          "Timed out waiting for service response.");
+    }
+
+    return result_future.get();
+  }
+
+  rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr client_;
+};
+
+InitRos init;
+TareFTClientNode client_node_;
+
+}  // namespace
+
+#include "intrinsic/skills/cc/skill_interface.h"
+#include "intrinsic/skills/proto/skill_service.pb.h"
+
+//==============================================================================
+// Skill signature.
+//==============================================================================
+
+std::unique_ptr<intrinsic::skills::SkillInterface>
+TareForceTorqueSensorSkill::CreateSkill() {
+  return std::make_unique<TareForceTorqueSensorSkill>();
+}
+
+absl::StatusOr<std::unique_ptr<google::protobuf::Message>>
+TareForceTorqueSensorSkill::Preview(
+    const intrinsic::skills::PreviewRequest& /*request*/,
+    intrinsic::skills::PreviewContext& /*context*/) {
+  return absl::UnimplementedError("Skill has not implemented `Preview`.");
+}
+
+//==============================================================================
+// Skill execution.
+//==============================================================================
+
+absl::StatusOr<std::unique_ptr<google::protobuf::Message>>
+TareForceTorqueSensorSkill::Execute(
+    const intrinsic::skills::ExecuteRequest& request,
+    intrinsic::skills::ExecuteContext& /*context*/) {
+  RCLCPP_INFO(client_node_.get_logger(), "TareForceTorqueSensorSkill::Execute");
+
+  INTR_ASSIGN_OR_RETURN(
+      auto params,
+      request.params<ai::flowstate::TareForceTorqueSensorSkillParams>());
+
+  auto timeout_ms =
+      params.time_limit() > 0 ? params.time_limit() * 1000.0 : 10000.0;
+
+  auto status_or_result = client_node_.CallService(timeout_ms);
+
+  if (!status_or_result.ok()) {
+    return status_or_result.status();
+  }
+
+  auto service_result = status_or_result.value();
+
+  auto result =
+      std::make_unique<ai::flowstate::TareForceTorqueSensorSkillResult>();
+  result->set_success(service_result->success);
+  result->set_message(service_result->message);
+
+  return result;
+}

--- a/flowstate/aic_flowstate_skills/tare_force_torque_sensor_skill/src/tare_force_torque_sensor_skill.h
+++ b/flowstate/aic_flowstate_skills/tare_force_torque_sensor_skill/src/tare_force_torque_sensor_skill.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Intrinsic Innovation LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef TARE_FORCE_TORQUE_SENSOR_SKILL_H_
+#define TARE_FORCE_TORQUE_SENSOR_SKILL_H_
+
+#include <memory>
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "intrinsic/skills/cc/skill_interface.h"
+#include "intrinsic/skills/proto/skill_service.pb.h"
+
+class TareForceTorqueSensorSkill final : public intrinsic::skills::SkillInterface {
+ public:
+  /**
+   * @copydoc intrinsic::skills::SkillInterface:: CreateSkill
+   */
+  static std::unique_ptr<intrinsic::skills::SkillInterface> CreateSkill();
+
+  /**
+   * @copydoc intrinsic::skills::SkillInterface:: Preview
+   */
+  absl::StatusOr<std::unique_ptr<google::protobuf::Message>> Preview(
+      const intrinsic::skills::PreviewRequest& request,
+      intrinsic::skills::PreviewContext& context) override;
+
+  /**
+   * @copydoc intrinsic::skills::SkillInterface:: Execute
+   */
+  absl::StatusOr<std::unique_ptr<google::protobuf::Message>> Execute(
+      const intrinsic::skills::ExecuteRequest& request,
+      intrinsic::skills::ExecuteContext& context) override;
+};
+
+#endif  // TARE_FORCE_TORQUE_SENSOR_SKILL_H_

--- a/flowstate/aic_flowstate_skills/tare_force_torque_sensor_skill/src/tare_force_torque_sensor_skill.h
+++ b/flowstate/aic_flowstate_skills/tare_force_torque_sensor_skill/src/tare_force_torque_sensor_skill.h
@@ -25,7 +25,8 @@
 #include "intrinsic/skills/cc/skill_interface.h"
 #include "intrinsic/skills/proto/skill_service.pb.h"
 
-class TareForceTorqueSensorSkill final : public intrinsic::skills::SkillInterface {
+class TareForceTorqueSensorSkill final
+    : public intrinsic::skills::SkillInterface {
  public:
   /**
    * @copydoc intrinsic::skills::SkillInterface:: CreateSkill

--- a/flowstate/aic_flowstate_skills/tare_force_torque_sensor_skill/src/tare_force_torque_sensor_skill.manifest.textproto
+++ b/flowstate/aic_flowstate_skills/tare_force_torque_sensor_skill/src/tare_force_torque_sensor_skill.manifest.textproto
@@ -1,0 +1,30 @@
+# proto-file: https://github.com/intrinsic-ai/sdk/blob/main/intrinsic/skills/proto/skill_manifest.proto
+# proto-message: intrinsic_proto.skill.SkillManifest
+id {
+  package: "ai.flowstate"
+  name: "tare_force_torque_sensor_skill"
+}
+display_name: "Tare Force Torque Sensor Skill"
+vendor {
+  display_name: "Intrinsic"
+}
+documentation {
+  description: "Skill that tares the force torque sensor."
+}
+options {
+  supports_cancellation: false
+  cc_config {
+    create_skill: "::TareForceTorqueSensorSkill::CreateSkill"
+  }
+}
+dependencies {
+}
+parameter {
+  message_full_name: "ai.flowstate.TareForceTorqueSensorSkillParams"
+  default_value: {
+    type_url: "type.googleapis.com/ai.flowstate.TareForceTorqueSensorSkillParams"
+  }
+}
+return_type {
+  message_full_name: "ai.flowstate.TareForceTorqueSensorSkillResult"
+}

--- a/flowstate/aic_flowstate_skills/tare_force_torque_sensor_skill/src/tare_force_torque_sensor_skill.proto
+++ b/flowstate/aic_flowstate_skills/tare_force_torque_sensor_skill/src/tare_force_torque_sensor_skill.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package ai.flowstate;
+
+message TareForceTorqueSensorSkillParams {
+  // The number of seconds from the moment this request is received by when the task must complete.
+  uint64 time_limit = 1;
+}
+
+message TareForceTorqueSensorSkillResult {
+  // True if the task succeeded.
+  bool success = 1;
+  
+  // A message if the task succeeded or failed.
+  string message = 2;
+}

--- a/flowstate/aic_flowstate_skills/tare_force_torque_sensor_skill/src/tare_force_torque_sensor_skill.proto
+++ b/flowstate/aic_flowstate_skills/tare_force_torque_sensor_skill/src/tare_force_torque_sensor_skill.proto
@@ -10,7 +10,7 @@ message TareForceTorqueSensorSkillParams {
 message TareForceTorqueSensorSkillResult {
   // True if the task succeeded.
   bool success = 1;
-  
+
   // A message if the task succeeded or failed.
   string message = 2;
 }

--- a/flowstate/resources/Dockerfile.skill
+++ b/flowstate/resources/Dockerfile.skill
@@ -1,0 +1,114 @@
+# Build up the skill with these stages:
+#   - base (ros:jazzy + settings) ->
+#   - underlay (dependencies) ->
+#   - overlay (user code) ->
+#   - result (base + copied install folder of underlay and overlay)
+
+ARG ROS_DISTRO=jazzy
+
+# base stage: ros:jazzy + configs
+FROM ros:${ROS_DISTRO} AS base
+
+WORKDIR /opt/ros/underlay
+
+ENV ROS_HOME=/tmp
+ENV RMW_IMPLEMENTATION=rmw_zenoh_cpp
+
+# underlay stage: base + dependencies built
+FROM base AS underlay
+
+ADD src/sdk-ros /opt/ros/underlay/src/sdk-ros
+
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
+    && apt-get update \
+    && rosdep update \
+    && rosdep install --from-paths src --ignore-src -r -y \
+    && apt install -y ros-${ROS_DISTRO}-ament-cmake-vendor-package \
+    && colcon build \
+        --continue-on-error \
+        --cmake-args -DCMAKE_BUILD_TYPE=Release \
+        --event-handlers=console_direct+ \
+        --merge-install \
+        --packages-up-to intrinsic_sdk
+
+# overlay stage: underlay + skill code built
+FROM underlay AS overlay
+
+ARG SKILL_PACKAGE
+ARG DEPENDENCIES
+
+ARG ROS_DISTRO=jazzy
+RUN apt-get update \
+    && apt install -y ros-${ROS_DISTRO}-rmw-zenoh-cpp python3-protobuf ${DEPENDENCIES} \
+    && rm -rf /var/lib/apt/lists/*
+
+ADD src /opt/ros/overlay/src
+
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
+    && . /opt/ros/underlay/install/setup.sh \
+    && cd /opt/ros/overlay \
+    && colcon build \
+      --cmake-args -DCMAKE_BUILD_TYPE=Release \
+      --event-handlers=console_direct+ \
+      --merge-install \
+      --packages-up-to=${SKILL_PACKAGE} \
+      --packages-skip intrinsic_sdk grpc_vendor
+
+# result stage: base + copied install folders from the overlay + skill setup
+FROM base
+
+ARG SKILL_PACKAGE
+ARG SKILL_NAME
+ARG SKILL_EXECUTABLE_NAME
+ARG DEPENDENCIES
+
+ARG ROS_DISTRO=jazzy
+RUN apt-get update \
+    && apt-get install -y ros-${ROS_DISTRO}-rmw-zenoh-cpp \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=overlay /opt/ros/underlay/install /opt/ros/underlay/install
+COPY --from=overlay /opt/ros/overlay/install /opt/ros/overlay/install
+
+# The reverse domain name for the organization in the asset-id label.
+ARG SKILL_ASSET_ID_ORG="ai.intrinsic"
+ENV ENTRYPOINT="ros2 run ${SKILL_PACKAGE} ${SKILL_EXECUTABLE_NAME}"
+ENV SKILL_CONFIG=share/${SKILL_PACKAGE}/${SKILL_NAME}_config.pbbin
+
+# Create linkable bash script to run the ENTRYPOINT executable
+RUN echo -e "#!/bin/bash\nexec $ENTRYPOINT \"\$@\"" > /run_skill.sh \
+    && chmod +x /run_skill.sh
+
+RUN set -x \
+    && mkdir -p /skills \
+    && ln -sf /run_skill.sh /skills/skill_service \
+    && ln -sf /opt/ros/overlay/install/$SKILL_CONFIG /skills/skill_service_config.proto.bin \
+    && sed --in-place \
+        --expression '$isource "/opt/ros/overlay/install/setup.bash"' \
+        /ros_entrypoint.sh \
+    && sed --in-place \
+        --expression '$iexport RMW_IMPLEMENTATION=rmw_zenoh_cpp' \
+        /ros_entrypoint.sh \
+    && sed --in-place \
+        --expression '$iexport ROS_HOME=/tmp' \
+        /ros_entrypoint.sh \
+    && sed --in-place \
+        --expression '$iexport ZENOH_CONFIG_OVERRIDE='\'connect/endpoints=[\"tcp/zenoh-router.app-intrinsic-base.svc.cluster.local:7447\"]\''' \
+        /ros_entrypoint.sh
+
+# Set some labels used by Flowstate.
+LABEL "ai.intrinsic.asset-id"="${SKILL_ASSET_ID_ORG}.${SKILL_PACKAGE}"
+LABEL "ai.intrinsic.skill-image-name"="${SKILL_PACKAGE}"
+
+# Build arguments are not substituted in the CMD command and hence we set environemnt variables
+# which can be substituted instead.
+ENV SKILL_PACKAGE=${SKILL_PACKAGE}
+ENV SKILL_NAME=${SKILL_NAME}
+ENV SKILL_EXECUTABLE_NAME=${SKILL_EXECUTABLE_NAME}
+ENV ENTRYPOINT=${ENTRYPOINT}
+ENV ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+
+# Execute the skill main by default, but note that Flowstate will likely override this statement.
+CMD [ \
+    "/skills/skill_service", \
+    "--skill_service_config_filename=/skills/skill_service_config.proto.bin"]

--- a/flowstate/resources/Dockerfile.skill
+++ b/flowstate/resources/Dockerfile.skill
@@ -1,12 +1,12 @@
 # Build up the skill with these stages:
-#   - base (ros:jazzy + settings) ->
+#   - base (ros:kilted + settings) ->
 #   - underlay (dependencies) ->
 #   - overlay (user code) ->
 #   - result (base + copied install folder of underlay and overlay)
 
-ARG ROS_DISTRO=jazzy
+ARG ROS_DISTRO=kilted
 
-# base stage: ros:jazzy + configs
+# base stage: ros:kilted + configs
 FROM ros:${ROS_DISTRO} AS base
 
 WORKDIR /opt/ros/underlay
@@ -37,7 +37,7 @@ FROM underlay AS overlay
 ARG SKILL_PACKAGE
 ARG DEPENDENCIES
 
-ARG ROS_DISTRO=jazzy
+ARG ROS_DISTRO=kilted
 RUN apt-get update \
     && apt install -y ros-${ROS_DISTRO}-rmw-zenoh-cpp python3-protobuf ${DEPENDENCIES} \
     && rm -rf /var/lib/apt/lists/*
@@ -62,7 +62,7 @@ ARG SKILL_NAME
 ARG SKILL_EXECUTABLE_NAME
 ARG DEPENDENCIES
 
-ARG ROS_DISTRO=jazzy
+ARG ROS_DISTRO=kilted
 RUN apt-get update \
     && apt-get install -y ros-${ROS_DISTRO}-rmw-zenoh-cpp \
     && rm -rf /var/lib/apt/lists/*

--- a/flowstate/scripts/build_container.sh
+++ b/flowstate/scripts/build_container.sh
@@ -134,11 +134,5 @@ elif [[ -n "$SKILL_NAME" && -n "$SKILL_PACKAGE" ]]; then
      "images/${SKILL_NAME}/${SKILL_NAME}_protos.desc"
     docker rm -f temp_container
 
-    echo "INFO: Building the skill bundle..."
-    ./inbuild skill bundle \
-      --file_descriptor_set "images/${SKILL_NAME}/${SKILL_NAME}_protos.desc" \
-      --manifest "${MANIFEST_PATH}" \
-      --oci_image "images/${SKILL_NAME}/${SKILL_NAME}.tar" \
-      --output "images/${SKILL_NAME}/${SKILL_NAME}.bundle.tar"
   fi
 fi

--- a/flowstate/scripts/build_container.sh
+++ b/flowstate/scripts/build_container.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+IMAGES_DIR=./images
+BUILDER_NAME=container-builder
+ROS_DISTRO=jazzy
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --images_dir)
+      IMAGES_DIR="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --builder_name)
+      BUILDER_NAME="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --service_name)
+      SERVICE_NAME="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --service_package)
+      SERVICE_PACKAGE="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --skill_name)
+      SKILL_NAME="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --skill_package)
+      SKILL_PACKAGE="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --dockerfile)
+      CUSTOM_DOCKERFILE="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --manifest_path)
+      MANIFEST_PATH="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --dependencies)
+      DEPENDENCIES="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --ros_distro)
+      ROS_DISTRO="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+  esac
+done
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+if [[ -n "$SERVICE_NAME" && -n "$SERVICE_PACKAGE" ]]; then
+  mkdir -p $IMAGES_DIR/$SERVICE_NAME
+
+  if [[ -n "$CUSTOM_DOCKERFILE" ]]; then
+    DOCKERFILE="$CUSTOM_DOCKERFILE"
+  else
+    DOCKERFILE="$SCRIPT_DIR/../resources/Dockerfile.service"
+  fi
+
+  docker buildx build -t $SERVICE_PACKAGE:$SERVICE_NAME \
+      --builder="$BUILDER_NAME" \
+      --output="\
+        type=docker,\
+        dest=$IMAGES_DIR/$SERVICE_NAME/$SERVICE_NAME.tar,\
+        compression=zstd,\
+        push=false,\
+        name=$SERVICE_PACKAGE:$SERVICE_NAME" \
+      --file $DOCKERFILE \
+      --build-arg="SERVICE_PACKAGE=$SERVICE_PACKAGE" \
+      --build-arg="SERVICE_NAME=$SERVICE_NAME" \
+      --build-arg="DEPENDENCIES=$DEPENDENCIES" \
+      --build-arg="SERVICE_EXECUTABLE_NAME=${SERVICE_NAME}_main" \
+      --build-arg="ROS_DISTRO=$ROS_DISTRO" \
+      .
+elif [[ -n "$SKILL_NAME" && -n "$SKILL_PACKAGE" ]]; then
+  mkdir -p $IMAGES_DIR/$SKILL_NAME
+
+  if [[ -n "$CUSTOM_DOCKERFILE" ]]; then
+    DOCKERFILE="$CUSTOM_DOCKERFILE"
+  else
+    DOCKERFILE="$SCRIPT_DIR/../resources/Dockerfile.skill"
+  fi
+
+  docker buildx build -t $SKILL_PACKAGE:$SKILL_NAME \
+      --builder="$BUILDER_NAME" \
+      --output="\
+        type=docker,\
+        dest=$IMAGES_DIR/$SKILL_NAME/$SKILL_NAME.tar,\
+        compression=zstd,\
+        push=false,\
+        name=$SKILL_PACKAGE:$SKILL_NAME" \
+      --file $DOCKERFILE \
+      --build-arg="SKILL_PACKAGE=$SKILL_PACKAGE" \
+      --build-arg="SKILL_NAME=$SKILL_NAME" \
+      --build-arg="SKILL_EXECUTABLE_NAME=${SKILL_NAME}_main" \
+      --build-arg="ROS_DISTRO=$ROS_DISTRO" \
+      .
+
+  if [[ -n "$MANIFEST_PATH" ]]; then
+    # Parse the SDK_VERSION from sdk_version.json
+    SDK_VERSION_FILE="$SCRIPT_DIR/../intrinsic_sdk_cmake/cmake/sdk_version.json"
+    SDK_VERSION=$(grep -oP '"sdk_version": "\K[^"]+' "$SDK_VERSION_FILE")
+
+    # Download the 'inbuild' tool if it doesn't exist
+    if [ ! -f ./inbuild ]; then
+        echo "INFO: Downloading inbuild tool version ${SDK_VERSION}..."
+        wget "https://github.com/intrinsic-ai/sdk/releases/download/${SDK_VERSION}/inbuild-linux-amd64" -O inbuild \
+          && chmod +x inbuild
+    fi
+
+    echo "INFO: Loading newly built image into local daemon..."
+    docker load -i "images/${SKILL_NAME}/${SKILL_NAME}.tar"
+
+    echo "INFO: Extracting descriptor set from container..."
+    docker create --name temp_container "$SKILL_PACKAGE:$SKILL_NAME"
+    docker cp "temp_container:/opt/ros/overlay/install/share/${SKILL_PACKAGE}/${SKILL_NAME}_protos.desc" \
+     "images/${SKILL_NAME}/${SKILL_NAME}_protos.desc"
+    docker rm -f temp_container
+
+    echo "INFO: Building the skill bundle..."
+    ./inbuild skill bundle \
+      --file_descriptor_set "images/${SKILL_NAME}/${SKILL_NAME}_protos.desc" \
+      --manifest "${MANIFEST_PATH}" \
+      --oci_image "images/${SKILL_NAME}/${SKILL_NAME}.tar" \
+      --output "images/${SKILL_NAME}/${SKILL_NAME}.bundle.tar"
+  fi
+fi

--- a/flowstate/scripts/build_container.sh
+++ b/flowstate/scripts/build_container.sh
@@ -2,7 +2,7 @@
 
 IMAGES_DIR=./images
 BUILDER_NAME=container-builder
-ROS_DISTRO=jazzy
+ROS_DISTRO=kilted
 
 while [[ $# -gt 0 ]]; do
   case $1 in


### PR DESCRIPTION
This PR:

1. Adds a Tare F/T sensor ROS service server to the `robot_control_bridge` plugin. 
  - Service is similar to the  `aic_controller/tare_force_torque_sensor` service from `aic_controller`. 

2. Adds a `tare_force_torque_sensor_skill` Flowstate skill
  - This skill calls the `aic_controller/tare_force_torque_sensor` service in  `robot_control_bridge`  to trigger taring of the F/T sensor. 
    - This results in the F/T sensor readings being zero-ed.
    - The service callback will re-establish a connection to the robot controller if it is not already connected.