### PR TITLE
Update near clipping range of camera

### DIFF
--- a/aic_assets/models/Basler Camera/model.sdf
+++ b/aic_assets/models/Basler Camera/model.sdf
@@ -52,7 +52,7 @@
              <format>R8G8B8</format> 
           </image>
           <clip>
-            <near>0.0</near>
+            <near>0.07</near>
             <far>20.0</far>
           </clip>
           <lens>


### PR DESCRIPTION
The near clipping range should be 0.07 or else edges of the body of camera lens is visible in the view.