### PR TITLE
Fix Github Action build failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install build dependencies
         run: |
           apt-get update && apt-get upgrade -y
-          apt-get install -y python3-colcon-common-extensions
+          apt-get install -y python3-colcon-common-extensions python3-toml
 
       - name: Set up git authentication
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,8 @@ jobs:
             {
               "build": {
                 "packages-skip": [
-                  "aic_flowstate_skills"
+                  "aic_flowstate_skills",
+                  "aic_flowstate_ros_bridge"
                   ],
                 "cmake-args": [
                   "-DCMAKE_BUILD_TYPE=Release"


### PR DESCRIPTION
Resolved two causes for build failure:
1. Python `toml` library not present 
2. `aic_flowstate_ros_bridge` fails during colcon build as `sdk-ros` not present

For now skipping `aic_flowstate_ros_bridge` build.