### PR TITLE
Update build instructions for skills 

### DIFF
--- a/flowstate/README.md
+++ b/flowstate/README.md
@@ -112,7 +112,7 @@ cd ~/ws_aic_phase1
   --ros_distro kilted
 
 # This command bundles the skill into a deployable tarball
-inbuild skill bundle \
+./inbuild skill bundle \
   --file_descriptor_set images/insert_cable_skill/insert_cable_skill_protos.desc \
   --manifest src/aic/flowstate/aic_flowstate_skills/insert_cable_skill/src/insert_cable_skill.manifest.textproto \
   --oci_image images/insert_cable_skill/insert_cable_skill.tar \

--- a/flowstate/README.md
+++ b/flowstate/README.md
@@ -104,16 +104,19 @@ We can use the `build_container.sh` and `build_bundle.sh` script from the intrin
 cd ~/ws_aic_phase1
 
 # This command builds the insert_cable_skill, the Intrinsic SDK, and the necessary ROS dependencies into a tar image.
-./src/sdk-ros/scripts/build_container.sh \
-  --ros_distro "kilted" \
+./src/aic/flowstate/scripts/build_container.sh \
+  --skill_name insert_cable_skill \
   --skill_package aic_flowstate_skills \
-  --skill_name insert_cable_skill
+  --manifest_path src/aic/flowstate/aic_flowstate_skills/insert_cable_skill/src/insert_cable_skill.manifest.textproto \
+  --dockerfile ./src/aic/flowstate/resources/Dockerfile.skill \
+  --ros_distro kilted
 
 # This command bundles the skill into a deployable tarball
-./src/sdk-ros/scripts/build_bundle.sh \
-  --skill_package aic_flowstate_skills \
-  --skill_name insert_cable_skill \
-  --manifest_path src/aic/flowstate/aic_flowstate_skills/insert_cable_skill/src/insert_cable_skill.manifest.textproto
+inbuild skill bundle \
+  --file_descriptor_set images/insert_cable_skill/insert_cable_skill.desc \
+  --manifest src/aic/flowstate/aic_flowstate_skills/insert_cable_skill/src/insert_cable_skill.manifest.textproto \
+  --oci_image images/insert_cable_skill/insert_cable_skill.tar \
+  --output images/insert_cable_skill/insert_cable_skill.bundle.tar
 ```
 
 ---

--- a/flowstate/README.md
+++ b/flowstate/README.md
@@ -113,7 +113,7 @@ cd ~/ws_aic_phase1
 
 # This command bundles the skill into a deployable tarball
 inbuild skill bundle \
-  --file_descriptor_set images/insert_cable_skill/insert_cable_skill.desc \
+  --file_descriptor_set images/insert_cable_skill/insert_cable_skill_protos.desc \
   --manifest src/aic/flowstate/aic_flowstate_skills/insert_cable_skill/src/insert_cable_skill.manifest.textproto \
   --oci_image images/insert_cable_skill/insert_cable_skill.tar \
   --output images/insert_cable_skill/insert_cable_skill.bundle.tar

--- a/flowstate/README.md
+++ b/flowstate/README.md
@@ -91,3 +91,55 @@ export INTRINSIC_CLUSTER="vmp-xxxx-xxxxxxx"
 
 > [!NOTE]
 > It is possible that first time you run `inctl asset install` it fails with error. In that case, please try again.
+
+---
+
+## 🛠️ Building the Skill
+
+We can use the `build_container.sh` and `build_bundle.sh` script from the intrinsic-ai/sdk-ros repository to build and package the skill bundle. The instructions below build and bundle the `insert_cable_skill`.
+
+---
+
+```bash
+cd ~/ws_aic_phase1
+
+# This command builds the insert_cable_skill, the Intrinsic SDK, and the necessary ROS dependencies into a tar image.
+./src/sdk-ros/scripts/build_container.sh \
+  --ros_distro "kilted" \
+  --skill_package aic_flowstate_skills \
+  --skill_name insert_cable_skill
+
+# This command bundles the skill into a deployable tarball
+./src/sdk-ros/scripts/build_bundle.sh \
+  --skill_package aic_flowstate_skills \
+  --skill_name insert_cable_skill \
+  --manifest_path src/aic/flowstate/aic_flowstate_skills/insert_cable_skill/src/insert_cable_skill.manifest.textproto
+```
+
+---
+
+## 📥 Installing skills to Flowstate
+
+After building, upload and install the skill into your solution context.
+
+---
+
+```bash
+
+# 1. Export path to side-loaded service bundle
+export SKILL_BUNDLE=~/ws_aic_phase1/images/insert_cable_skill/insert_cable_skill.bundle.tar
+
+# 2. Add Organization
+export INTRINSIC_ORGANIZATION="<ORG_NAME>"
+
+# 3. Add Cluster Endpoint
+export INTRINSIC_CLUSTER="vmp-xxxx-xxxxxxx"
+
+./inctl asset install \
+  --org $INTRINSIC_ORGANIZATION \
+  --cluster $INTRINSIC_CLUSTER \
+  $SKILL_BUNDLE
+
+```
+
+---

--- a/flowstate/README.md
+++ b/flowstate/README.md
@@ -96,7 +96,7 @@ export INTRINSIC_CLUSTER="vmp-xxxx-xxxxxxx"
 
 ## 🛠️ Building the Skill
 
-We can use the `build_container.sh` and `build_bundle.sh` script from the intrinsic-ai/sdk-ros repository to build and package the skill bundle. The instructions below build and bundle the `insert_cable_skill`.
+We can use the `build_container.sh` script to build the skill and the `inbuild` tool to bundle the skill into a package that can be side-loaded. The instructions below build and bundle the `insert_cable_skill`.
 
 ---
 

--- a/flowstate/aic_flowstate_ros_bridge/README.md
+++ b/flowstate/aic_flowstate_ros_bridge/README.md
@@ -9,14 +9,14 @@ A Flowstate-ROS bridge plugin that bridges the real-time controller service to R
 Set up the Docker engine:
 
 ```bash
-cd ~/ws_aic
+cd ~/ws_aic_phase1
 ./src/sdk-ros/scripts/setup_docker.sh
 ```
 
 Then, create the service bundle using the `build_service_bundle.sh` script.
 
 ```bash
-cd ~/ws_aic
+cd ~/ws_aic_phase1
 ./src/aic/flowstate/scripts/build_flowstate_ros_bridge.sh --ros_distro kilted
 ```
 
@@ -24,7 +24,7 @@ cd ~/ws_aic
 
 ```bash
 # 1. Export path to side-loaded service bundle
-export SERVICE_BUNDLE=~/ws_aic/images/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge.bundle.tar
+export SERVICE_BUNDLE=~/ws_aic_phase1/images/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge.bundle.tar
 
 # 2. Add Organization
 export INTRINSIC_ORGANIZATION="<ORG_NAME>"

--- a/flowstate/aic_flowstate_skills/insert_cable_skill/CMakeLists.txt
+++ b/flowstate/aic_flowstate_skills/insert_cable_skill/CMakeLists.txt
@@ -3,7 +3,7 @@ intrinsic_sdk_protobuf_generate(
   NAME insert_cable_skill
   SOURCES src/insert_cable_skill.proto
   TARGET insert_cable_skill_protos
-  DESCRIPTOR_SET_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_protos.desc"
+  DESCRIPTOR_SET_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill.desc"
 )
 
 # Generate the skill config file.
@@ -11,7 +11,7 @@ intrinsic_sdk_generate_skill_config(
   TARGET insert_cable_skill_config
   SKILL_NAME insert_cable_skill
   MANIFEST src/insert_cable_skill.manifest.textproto
-  PROTO_DESCRIPTOR_FILE "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_protos.desc"
+  PROTO_DESCRIPTOR_FILE "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill.desc"
   SKILL_CONFIG_FILE_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_config.pbbin"
 )
 
@@ -19,7 +19,6 @@ install(
   FILES
     src/insert_cable_skill.manifest.textproto
     "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_config.pbbin"
-    "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_protos.desc"
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/flowstate/aic_flowstate_skills/insert_cable_skill/CMakeLists.txt
+++ b/flowstate/aic_flowstate_skills/insert_cable_skill/CMakeLists.txt
@@ -3,7 +3,7 @@ intrinsic_sdk_protobuf_generate(
   NAME insert_cable_skill
   SOURCES src/insert_cable_skill.proto
   TARGET insert_cable_skill_protos
-  DESCRIPTOR_SET_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill.desc"
+  DESCRIPTOR_SET_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_protos.desc"
 )
 
 # Generate the skill config file.
@@ -11,7 +11,7 @@ intrinsic_sdk_generate_skill_config(
   TARGET insert_cable_skill_config
   SKILL_NAME insert_cable_skill
   MANIFEST src/insert_cable_skill.manifest.textproto
-  PROTO_DESCRIPTOR_FILE "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill.desc"
+  PROTO_DESCRIPTOR_FILE "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_protos.desc"
   SKILL_CONFIG_FILE_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_config.pbbin"
 )
 
@@ -19,6 +19,7 @@ install(
   FILES
     src/insert_cable_skill.manifest.textproto
     "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_config.pbbin"
+    "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_protos.desc"
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/flowstate/aic_flowstate_skills/insert_cable_skill/CMakeLists.txt
+++ b/flowstate/aic_flowstate_skills/insert_cable_skill/CMakeLists.txt
@@ -19,6 +19,7 @@ install(
   FILES
     src/insert_cable_skill.manifest.textproto
     "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_config.pbbin"
+    "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_protos.desc"
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/flowstate/aic_flowstate_skills/insert_cable_skill/CMakeLists.txt
+++ b/flowstate/aic_flowstate_skills/insert_cable_skill/CMakeLists.txt
@@ -3,7 +3,7 @@ intrinsic_sdk_protobuf_generate(
   NAME insert_cable_skill
   SOURCES src/insert_cable_skill.proto
   TARGET insert_cable_skill_protos
-  DESCRIPTOR_SET_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill.desc"
+  DESCRIPTOR_SET_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_protos.desc"
 )
 
 # Generate the skill config file.
@@ -11,7 +11,7 @@ intrinsic_sdk_generate_skill_config(
   TARGET insert_cable_skill_config
   SKILL_NAME insert_cable_skill
   MANIFEST src/insert_cable_skill.manifest.textproto
-  PROTO_DESCRIPTOR_FILE "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill.desc"
+  PROTO_DESCRIPTOR_FILE "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_protos.desc"
   SKILL_CONFIG_FILE_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_config.pbbin"
 )
 

--- a/flowstate/resources/Dockerfile.skill
+++ b/flowstate/resources/Dockerfile.skill
@@ -1,0 +1,114 @@
+# Build up the skill with these stages:
+#   - base (ros:jazzy + settings) ->
+#   - underlay (dependencies) ->
+#   - overlay (user code) ->
+#   - result (base + copied install folder of underlay and overlay)
+
+ARG ROS_DISTRO=jazzy
+
+# base stage: ros:jazzy + configs
+FROM ros:${ROS_DISTRO} AS base
+
+WORKDIR /opt/ros/underlay
+
+ENV ROS_HOME=/tmp
+ENV RMW_IMPLEMENTATION=rmw_zenoh_cpp
+
+# underlay stage: base + dependencies built
+FROM base AS underlay
+
+ADD src/sdk-ros /opt/ros/underlay/src/sdk-ros
+
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
+    && apt-get update \
+    && rosdep update \
+    && rosdep install --from-paths src --ignore-src -r -y \
+    && apt install -y ros-${ROS_DISTRO}-ament-cmake-vendor-package \
+    && colcon build \
+        --continue-on-error \
+        --cmake-args -DCMAKE_BUILD_TYPE=Release \
+        --event-handlers=console_direct+ \
+        --merge-install \
+        --packages-up-to intrinsic_sdk
+
+# overlay stage: underlay + skill code built
+FROM underlay AS overlay
+
+ARG SKILL_PACKAGE
+ARG DEPENDENCIES
+
+ARG ROS_DISTRO=jazzy
+RUN apt-get update \
+    && apt install -y ros-${ROS_DISTRO}-rmw-zenoh-cpp python3-protobuf ${DEPENDENCIES} \
+    && rm -rf /var/lib/apt/lists/*
+
+ADD src /opt/ros/overlay/src
+
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
+    && . /opt/ros/underlay/install/setup.sh \
+    && cd /opt/ros/overlay \
+    && colcon build \
+      --cmake-args -DCMAKE_BUILD_TYPE=Release \
+      --event-handlers=console_direct+ \
+      --merge-install \
+      --packages-up-to=${SKILL_PACKAGE} \
+      --packages-skip intrinsic_sdk grpc_vendor
+
+# result stage: base + copied install folders from the overlay + skill setup
+FROM base
+
+ARG SKILL_PACKAGE
+ARG SKILL_NAME
+ARG SKILL_EXECUTABLE_NAME
+ARG DEPENDENCIES
+
+ARG ROS_DISTRO=jazzy
+RUN apt-get update \
+    && apt-get install -y ros-${ROS_DISTRO}-rmw-zenoh-cpp \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=overlay /opt/ros/underlay/install /opt/ros/underlay/install
+COPY --from=overlay /opt/ros/overlay/install /opt/ros/overlay/install
+
+# The reverse domain name for the organization in the asset-id label.
+ARG SKILL_ASSET_ID_ORG="ai.intrinsic"
+ENV ENTRYPOINT="ros2 run ${SKILL_PACKAGE} ${SKILL_EXECUTABLE_NAME}"
+ENV SKILL_CONFIG=share/${SKILL_PACKAGE}/${SKILL_NAME}_config.pbbin
+
+# Create linkable bash script to run the ENTRYPOINT executable
+RUN echo -e "#!/bin/bash\nexec $ENTRYPOINT \"\$@\"" > /run_skill.sh \
+    && chmod +x /run_skill.sh
+
+RUN set -x \
+    && mkdir -p /skills \
+    && ln -sf /run_skill.sh /skills/skill_service \
+    && ln -sf /opt/ros/overlay/install/$SKILL_CONFIG /skills/skill_service_config.proto.bin \
+    && sed --in-place \
+        --expression '$isource "/opt/ros/overlay/install/setup.bash"' \
+        /ros_entrypoint.sh \
+    && sed --in-place \
+        --expression '$iexport RMW_IMPLEMENTATION=rmw_zenoh_cpp' \
+        /ros_entrypoint.sh \
+    && sed --in-place \
+        --expression '$iexport ROS_HOME=/tmp' \
+        /ros_entrypoint.sh \
+    && sed --in-place \
+        --expression '$iexport ZENOH_CONFIG_OVERRIDE='\'connect/endpoints=[\"tcp/zenoh-router.app-intrinsic-base.svc.cluster.local:7447\"]\''' \
+        /ros_entrypoint.sh
+
+# Set some labels used by Flowstate.
+LABEL "ai.intrinsic.asset-id"="${SKILL_ASSET_ID_ORG}.${SKILL_PACKAGE}"
+LABEL "ai.intrinsic.skill-image-name"="${SKILL_PACKAGE}"
+
+# Build arguments are not substituted in the CMD command and hence we set environemnt variables
+# which can be substituted instead.
+ENV SKILL_PACKAGE=${SKILL_PACKAGE}
+ENV SKILL_NAME=${SKILL_NAME}
+ENV SKILL_EXECUTABLE_NAME=${SKILL_EXECUTABLE_NAME}
+ENV ENTRYPOINT=${ENTRYPOINT}
+ENV ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+
+# Execute the skill main by default, but note that Flowstate will likely override this statement.
+CMD [ \
+    "/skills/skill_service", \
+    "--skill_service_config_filename=/skills/skill_service_config.proto.bin"]

--- a/flowstate/scripts/build_container.sh
+++ b/flowstate/scripts/build_container.sh
@@ -134,11 +134,5 @@ elif [[ -n "$SKILL_NAME" && -n "$SKILL_PACKAGE" ]]; then
      "images/${SKILL_NAME}/${SKILL_NAME}_protos.desc"
     docker rm -f temp_container
 
-    echo "INFO: Building the skill bundle..."
-    ./inbuild skill bundle \
-      --file_descriptor_set "images/${SKILL_NAME}/${SKILL_NAME}_protos.desc" \
-      --manifest "${MANIFEST_PATH}" \
-      --oci_image "images/${SKILL_NAME}/${SKILL_NAME}.tar" \
-      --output "images/${SKILL_NAME}/${SKILL_NAME}.bundle.tar"
   fi
 fi

--- a/flowstate/scripts/build_container.sh
+++ b/flowstate/scripts/build_container.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+IMAGES_DIR=./images
+BUILDER_NAME=container-builder
+ROS_DISTRO=jazzy
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --images_dir)
+      IMAGES_DIR="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --builder_name)
+      BUILDER_NAME="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --service_name)
+      SERVICE_NAME="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --service_package)
+      SERVICE_PACKAGE="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --skill_name)
+      SKILL_NAME="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --skill_package)
+      SKILL_PACKAGE="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --dockerfile)
+      CUSTOM_DOCKERFILE="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --manifest_path)
+      MANIFEST_PATH="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --dependencies)
+      DEPENDENCIES="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --ros_distro)
+      ROS_DISTRO="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+  esac
+done
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+if [[ -n "$SERVICE_NAME" && -n "$SERVICE_PACKAGE" ]]; then
+  mkdir -p $IMAGES_DIR/$SERVICE_NAME
+
+  if [[ -n "$CUSTOM_DOCKERFILE" ]]; then
+    DOCKERFILE="$CUSTOM_DOCKERFILE"
+  else
+    DOCKERFILE="$SCRIPT_DIR/../resources/Dockerfile.service"
+  fi
+
+  docker buildx build -t $SERVICE_PACKAGE:$SERVICE_NAME \
+      --builder="$BUILDER_NAME" \
+      --output="\
+        type=docker,\
+        dest=$IMAGES_DIR/$SERVICE_NAME/$SERVICE_NAME.tar,\
+        compression=zstd,\
+        push=false,\
+        name=$SERVICE_PACKAGE:$SERVICE_NAME" \
+      --file $DOCKERFILE \
+      --build-arg="SERVICE_PACKAGE=$SERVICE_PACKAGE" \
+      --build-arg="SERVICE_NAME=$SERVICE_NAME" \
+      --build-arg="DEPENDENCIES=$DEPENDENCIES" \
+      --build-arg="SERVICE_EXECUTABLE_NAME=${SERVICE_NAME}_main" \
+      --build-arg="ROS_DISTRO=$ROS_DISTRO" \
+      .
+elif [[ -n "$SKILL_NAME" && -n "$SKILL_PACKAGE" ]]; then
+  mkdir -p $IMAGES_DIR/$SKILL_NAME
+
+  if [[ -n "$CUSTOM_DOCKERFILE" ]]; then
+    DOCKERFILE="$CUSTOM_DOCKERFILE"
+  else
+    DOCKERFILE="$SCRIPT_DIR/../resources/Dockerfile.skill"
+  fi
+
+  docker buildx build -t $SKILL_PACKAGE:$SKILL_NAME \
+      --builder="$BUILDER_NAME" \
+      --output="\
+        type=docker,\
+        dest=$IMAGES_DIR/$SKILL_NAME/$SKILL_NAME.tar,\
+        compression=zstd,\
+        push=false,\
+        name=$SKILL_PACKAGE:$SKILL_NAME" \
+      --file $DOCKERFILE \
+      --build-arg="SKILL_PACKAGE=$SKILL_PACKAGE" \
+      --build-arg="SKILL_NAME=$SKILL_NAME" \
+      --build-arg="SKILL_EXECUTABLE_NAME=${SKILL_NAME}_main" \
+      --build-arg="ROS_DISTRO=$ROS_DISTRO" \
+      .
+
+  if [[ -n "$MANIFEST_PATH" ]]; then
+    # Parse the SDK_VERSION from sdk_version.json
+    SDK_VERSION_FILE="$SCRIPT_DIR/../intrinsic_sdk_cmake/cmake/sdk_version.json"
+    SDK_VERSION=$(grep -oP '"sdk_version": "\K[^"]+' "$SDK_VERSION_FILE")
+
+    # Download the 'inbuild' tool if it doesn't exist
+    if [ ! -f ./inbuild ]; then
+        echo "INFO: Downloading inbuild tool version ${SDK_VERSION}..."
+        wget "https://github.com/intrinsic-ai/sdk/releases/download/${SDK_VERSION}/inbuild-linux-amd64" -O inbuild \
+          && chmod +x inbuild
+    fi
+
+    echo "INFO: Loading newly built image into local daemon..."
+    docker load -i "images/${SKILL_NAME}/${SKILL_NAME}.tar"
+
+    echo "INFO: Extracting descriptor set from container..."
+    docker create --name temp_container "$SKILL_PACKAGE:$SKILL_NAME"
+    docker cp "temp_container:/opt/ros/overlay/install/share/${SKILL_PACKAGE}/${SKILL_NAME}_protos.desc" \
+     "images/${SKILL_NAME}/${SKILL_NAME}_protos.desc"
+    docker rm -f temp_container
+
+    echo "INFO: Building the skill bundle..."
+    ./inbuild skill bundle \
+      --file_descriptor_set "images/${SKILL_NAME}/${SKILL_NAME}_protos.desc" \
+      --manifest "${MANIFEST_PATH}" \
+      --oci_image "images/${SKILL_NAME}/${SKILL_NAME}.tar" \
+      --output "images/${SKILL_NAME}/${SKILL_NAME}.bundle.tar"
+  fi
+fi


### PR DESCRIPTION
This PR:
1. Updates the README with instructions on building and bundling skills using updated scripts from the intrinsic-ai/sdk-ros repository.
2. Updates the CMakeList.txt to update the filename of the proto descriptors expected by the build and bundle scripts.
3. Adds the `Dockerfile.skill` and `build_container.sh` to ensure a consistent skill building workflow.