### PR TITLE
Update SC mount and SFP mount xacro files

### DIFF
--- a/aic_assets/models/SC Mount/sc_mount_macro.xacro
+++ b/aic_assets/models/SC Mount/sc_mount_macro.xacro
@@ -61,7 +61,7 @@
       <collision name="v1015079011_collider_box003_collider_box.003">
         <origin xyz="0.017774 0.0 0.008656" rpy="0.0 0.785398 0.0"/>
         <geometry>
-          <box size="0.025812 0.014 0.001239"/>
+          <box size="0.009 0.014 0.001239"/>
         </geometry>
       </collision>
 

--- a/aic_assets/models/SFP Mount/sfp_mount_macro.xacro
+++ b/aic_assets/models/SFP Mount/sfp_mount_macro.xacro
@@ -38,16 +38,16 @@
       </collision>
 
       <collision name="iso_4762_m2_x_8072_collider_box_003">
-        <origin xyz="0.021242 0.007723 0.013979" rpy="0.0 -0.785398 0.0"/>
+        <origin xyz="0.021242 0.0080 0.013979" rpy="0.0 -0.785398 0.0"/>
         <geometry>
-          <box size="0.036111 0.002305 0.010956"/>
+          <box size="0.036111 0.0018 0.010956"/>
         </geometry>
       </collision>
 
       <collision name="iso_4762_m2_x_8072_collider_box_004">
-        <origin xyz="0.021003 -0.007938 0.014217" rpy="0.0 -0.785398 0.0"/>
+        <origin xyz="0.021003 -0.008 0.014217" rpy="0.0 -0.785398 0.0"/>
         <geometry>
-          <box size="0.036111 0.001875 0.01163"/>
+          <box size="0.036111 0.0018 0.01163"/>
         </geometry>
       </collision>
 


### PR DESCRIPTION
Applies the same changes as https://github.com/intrinsic-dev/aic/pull/501 but to the xacro files.  These are actually the ones used by `task_board.urdf.xacro`. The model.sdf files are not used.