### PR TITLE
More updates to SFP Mount and SC Mount collisions

### DIFF
--- a/aic_assets/models/SC Mount/model.sdf
+++ b/aic_assets/models/SC Mount/model.sdf
@@ -21,7 +21,7 @@
         <pose>0.022568 -0.0054 0.013451 0.0 0.785398 -0.0</pose>
         <geometry>
           <box>
-            <size>0.025812 0.0032 0.013799</size>
+            <size>0.025812 0.0022 0.013799</size>
           </box>
         </geometry>
       </collision>
@@ -29,7 +29,7 @@
         <pose>0.022568 0.00585 0.013451 0.0 0.785398 -0.0</pose>
         <geometry>
           <box>
-            <size>0.025812 0.0023 0.013799</size>
+            <size>0.025812 0.0022 0.013799</size>
           </box>
         </geometry>
       </collision>
@@ -37,7 +37,7 @@
         <pose>0.01415 -0.0 0.02187 0.0 0.785398 -0.0</pose>
         <geometry>
           <box>
-            <size>0.002 0.014 0.013799</size>
+            <size>0.0012 0.014 0.013799</size>
           </box>
         </geometry>
       </collision>
@@ -45,7 +45,7 @@
         <pose>0.031064 -0.0 0.004956 0.0 0.785398 -0.0</pose>
         <geometry>
           <box>
-            <size>0.001842 0.014 0.013799</size>
+            <size>0.001042 0.014 0.013799</size>
           </box>
         </geometry>
       </collision>

--- a/aic_assets/models/SC Mount/sc_mount_macro.xacro
+++ b/aic_assets/models/SC Mount/sc_mount_macro.xacro
@@ -26,28 +26,28 @@
       <collision name="v1015079011_collider_box.001">
         <origin xyz="0.022568 -0.0054 0.013451" rpy="0.0 0.785398 0.0"/>
         <geometry>
-          <box size="0.025812 0.0032 0.013799"/>
+          <box size="0.025812 0.0022 0.013799"/>
         </geometry>
       </collision>
 
       <collision name="v1015079011_collider_box.002">
         <origin xyz="0.022568 0.00585 0.013451" rpy="0.0 0.785398 0.0"/>
         <geometry>
-          <box size="0.025812 0.0023 0.013799"/>
+          <box size="0.025812 0.0022 0.013799"/>
         </geometry>
       </collision>
 
       <collision name="v1015079011_collider_box003_collider_box">
         <origin xyz="0.01415 0.0 0.02187" rpy="0.0 0.785398 0.0"/>
         <geometry>
-          <box size="0.002 0.014 0.013799"/>
+          <box size="0.0012 0.014 0.013799"/>
         </geometry>
       </collision>
 
       <collision name="v1015079011_collider_box003_collider_box.001">
         <origin xyz="0.031064 0.0 0.004956" rpy="0.0 0.785398 0.0"/>
         <geometry>
-          <box size="0.001842 0.014 0.013799"/>
+          <box size="0.001042 0.014 0.013799"/>
         </geometry>
       </collision>
 

--- a/aic_assets/models/SFP Mount/model.sdf
+++ b/aic_assets/models/SFP Mount/model.sdf
@@ -21,7 +21,7 @@
         <pose>0.016366 -0.0 0.017144 0.0 -0.785398 0.0</pose>
         <geometry>
           <box>
-            <size>0.038533 0.01775 0.001728</size>
+            <size>0.038533 0.01775 0.001028</size>
           </box>
         </geometry>
       </collision>
@@ -29,7 +29,7 @@
         <pose>0.028636 -0.0 0.012684 0.0 -0.785398 0.0</pose>
         <geometry>
           <box>
-            <size>0.027485 0.01775 0.003688</size>
+            <size>0.027485 0.01775 0.002888</size>
           </box>
         </geometry>
       </collision>
@@ -37,7 +37,7 @@
         <pose>0.021242 0.0080 0.013979 0.0 -0.785398 0.0</pose>
         <geometry>
           <box>
-            <size>0.036111 0.0018 0.010956</size>
+            <size>0.036111 0.0012 0.010956</size>
           </box>
         </geometry>
       </collision>
@@ -45,7 +45,7 @@
         <pose>0.021003 -0.008 0.014217 0.0 -0.785398 0.0</pose>
         <geometry>
           <box>
-            <size>0.036111 0.0018 0.01163</size>
+            <size>0.036111 0.0012 0.01163</size>
           </box>
         </geometry>
       </collision>

--- a/aic_assets/models/SFP Mount/sfp_mount_macro.xacro
+++ b/aic_assets/models/SFP Mount/sfp_mount_macro.xacro
@@ -26,28 +26,28 @@
       <collision name="iso_4762_m2_x_8072_collider_box_001">
         <origin xyz="0.016366 0.0 0.017144" rpy="0.0 -0.785398 0.0"/>
         <geometry>
-          <box size="0.038533 0.01775 0.001728"/>
+          <box size="0.038533 0.01775 0.001028"/>
         </geometry>
       </collision>
 
       <collision name="iso_4762_m2_x_8072_collider_box_002">
         <origin xyz="0.028636 0.0 0.012684" rpy="0.0 -0.785398 0.0"/>
         <geometry>
-          <box size="0.027485 0.01775 0.003688"/>
+          <box size="0.027485 0.01775 0.002888"/>
         </geometry>
       </collision>
 
       <collision name="iso_4762_m2_x_8072_collider_box_003">
         <origin xyz="0.021242 0.007723 0.013979" rpy="0.0 -0.785398 0.0"/>
         <geometry>
-          <box size="0.036111 0.002305 0.010956"/>
+          <box size="0.036111 0.0012 0.010956"/>
         </geometry>
       </collision>
 
       <collision name="iso_4762_m2_x_8072_collider_box_004">
         <origin xyz="0.021003 -0.007938 0.014217" rpy="0.0 -0.785398 0.0"/>
         <geometry>
-          <box size="0.036111 0.001875 0.01163"/>
+          <box size="0.036111 0.0012 0.01163"/>
         </geometry>
       </collision>
 


### PR DESCRIPTION
More updates to the mount collisions. This time reducing the size of the collisions even more to make the opening much larger. This makes it much easier to seat the SFP module and SC plug in the mounts without causing unnecessary contacts. 

The RTF went from 45% to 95% for me (when running the world below with 1 cable)

To Test:

Run command below to launch world and spawn cable for testing. Note: The cable spawn pose matters. It still needs to be precise

```sh
ros2 launch aic_bringup aic_gz_bringup.launch.py ground_truth:=false spawn_cable:=true attach_cable_to_gripper:=false spawn_task_board:=true nic_card_mount_0_present:=true sc_port_0_present:=true launch_rviz:=false  sfp_mount_rail_0_present:=true sc_mount_rail_0_present:=true cable_type:=sfp_sc_cable_phase_1 cable_x:=0.007617000257607526 cable_y:=-0.09373721480369568 cable_z:=1.2291434873584547 cable_roll:=-2.48609329 cable_pitch:=-1.3863089 cable_yaw:=2.65047282

```

Before : lots of contacts (blue spheres) between the plugs and the mounts.  The cable plugs are pinned by the CableModeratorPlugin but contacts still occur.


<img width="613" height="558" alt="Screenshot from 2026-05-05 17-29-00" src="https://github.com/user-attachments/assets/17ed17e3-1551-45e9-ad78-c3b6ea3133e2" />


After: No contacts

<img width="618" height="468" alt="Screenshot from 2026-05-05 17-21-08" src="https://github.com/user-attachments/assets/61cbf63c-20c0-4dc9-a6d6-1b7dfc842571" />


