### PR TITLE
add an 'init timeout' to allow for slow policy init

### DIFF
--- a/aic_bringup/launch/aic_gz_bringup.launch.py
+++ b/aic_bringup/launch/aic_gz_bringup.launch.py
@@ -98,6 +98,7 @@ def launch_setup(context, *args, **kwargs):
     model_discovery_timeout_seconds = LaunchConfiguration(
         "model_discovery_timeout_seconds"
     )
+    model_init_timeout_seconds = LaunchConfiguration("model_init_timeout_seconds")
     model_configure_timeout_seconds = LaunchConfiguration(
         "model_configure_timeout_seconds"
     )
@@ -249,6 +250,7 @@ def launch_setup(context, *args, **kwargs):
                 "config_file_path": aic_engine_config_file,
                 "use_sim_time": True,
                 "model_discovery_timeout_seconds": model_discovery_timeout_seconds,
+                "model_init_timeout_seconds": model_init_timeout_seconds,
                 "model_configure_timeout_seconds": model_configure_timeout_seconds,
             },
         ],
@@ -780,7 +782,13 @@ def generate_launch_description():
             description="Timeout for model configuration checks.",
         )
     )
-
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "model_init_timeout_seconds",
+            default_value="60",
+            description="Timeout for model init to respond to Lifecycle queries).",
+        )
+    )
     declared_arguments.append(
         DeclareLaunchArgument(
             "model_discovery_timeout_seconds",

--- a/aic_engine/src/aic_engine.cpp
+++ b/aic_engine/src/aic_engine.cpp
@@ -312,6 +312,7 @@ Engine::Engine(const rclcpp::NodeOptions& options)
   skip_ready_simulator_ =
       node_->declare_parameter("skip_ready_simulator", false);
   node_->declare_parameter("model_discovery_timeout_seconds", 30);
+  node_->declare_parameter("model_init_timeout_seconds", 60);
   node_->declare_parameter("model_configure_timeout_seconds", 60);
   node_->declare_parameter("model_activate_timeout_seconds", 60);
   node_->declare_parameter("model_deactivate_timeout_seconds", 60);
@@ -909,7 +910,10 @@ bool Engine::model_node_is_unconfigured() {
   auto request = std::make_shared<lifecycle_msgs::srv::GetState::Request>();
   auto future = model_get_state_client_->async_send_request(request);
 
-  if (!wait_for_interruptible(future, std::chrono::seconds(5))) {
+  const int init_timeout =
+      this->node_->get_parameter("model_init_timeout_seconds").as_int();
+
+  if (!wait_for_interruptible(future, std::chrono::seconds(init_timeout))) {
     RCLCPP_ERROR(node_->get_logger(),
                  "GetState service call timed out for node '%s'",
                  model_node_name_.c_str());


### PR DESCRIPTION
Add a parameterizable timeout to allow for slow init of large policies, defaulting to 60 seconds, to replace the current hard-coded timeout.