### PR TITLE
Pin pixi version to avoid hash conflict

### DIFF
--- a/docker/aic_model/Dockerfile
+++ b/docker/aic_model/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/library/ros:kilted-ros-core AS build
 
 # Install pixi
-RUN apt update && apt install -y git && curl -fsSL https://pixi.sh/install.sh | PIXI_VERSION=0.63.2 bash
+RUN apt update && apt install -y git && curl -fsSL https://pixi.sh/install.sh | PIXI_VERSION=0.67.2 bash
 ENV PATH="/root/.pixi/bin:$PATH"
 
 # Add base dependencies

--- a/docker/aic_model/Dockerfile
+++ b/docker/aic_model/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/library/ros:kilted-ros-core AS build
 
 # Install pixi
-RUN apt update && apt install -y git && curl -fsSL https://pixi.sh/install.sh | bash
+RUN apt update && apt install -y git && curl -fsSL https://pixi.sh/install.sh | PIXI_VERSION=0.63.2 bash
 ENV PATH="/root/.pixi/bin:$PATH"
 
 # Add base dependencies


### PR DESCRIPTION
Seems like `aic_model` build is failing as we are not pinning pixi version in the Dockerfile which tries to update the pixi.lock to version 7 from 6. So, we get hash conflict for ROS package. Pinning the pixi version will do the job.