### PR TITLE
Refactor CableModerator to support any cable insertion order

### DIFF
--- a/aic.repos
+++ b/aic.repos
@@ -95,7 +95,7 @@ repositories:
   gazebo/gz-sim:
     type: git
     url: https://github.com/gazebosim/gz-sim
-    version: d99d458c9987b20a18347b9a273f907d3391db61
+    version: 4ca1b44bcce5390bf5962d2af46db6b501907887
   gazebo/gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui
@@ -111,7 +111,7 @@ repositories:
   gazebo/gz-physics:
     type: git
     url: https://github.com/gazebosim/gz-physics
-    version: 5c173ea69cde372d6e49f6200580459659166ce3
+    version: 1048054ac536561fdffbeb9f292ceeaa145c02de
   gazebo/gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin

--- a/aic.repos
+++ b/aic.repos
@@ -103,7 +103,7 @@ repositories:
   gazebo/gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: b779522d210a09d163b4b79071ac9a56e0668f0f
+    version: 0c38e855c620e619d45a18401809bf02872cd1e4
   gazebo/gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs

--- a/aic_bringup/launch/spawn_cable.launch.py
+++ b/aic_bringup/launch/spawn_cable.launch.py
@@ -38,6 +38,7 @@ def launch_setup(context, *args, **kwargs):
     cable_yaw = LaunchConfiguration("cable_yaw")
     attach_cable_to_gripper = LaunchConfiguration("attach_cable_to_gripper")
     cable_type = LaunchConfiguration("cable_type")
+    cable_name = LaunchConfiguration("cable_name")
 
     # Process cable description
     cable_description_content = Command(
@@ -63,7 +64,7 @@ def launch_setup(context, *args, **kwargs):
             "-string",
             cable_description_content,
             "-name",
-            "cable_0",
+            cable_name,
             "-allow_renaming",
             "true",
             "-x",
@@ -151,6 +152,13 @@ def generate_launch_description():
             default_value="sfp_sc_cable",
             description="Type of cable model to spawn. Available options: 'sfp_sc_cable', 'sfp_sc_cable_reversed', and 'sfp_sc_cable_phase_1'",
             choices=["sfp_sc_cable", "sfp_sc_cable_reversed", "sfp_sc_cable_phase_1"],
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "cable_name",
+            default_value="cable_0",
+            description="Name of the cable model to spawn",
         )
     )
     return LaunchDescription(

--- a/aic_description/world/aic.sdf
+++ b/aic_description/world/aic.sdf
@@ -153,6 +153,34 @@
         <cable_connection_1_link>sc_plug_link</cable_connection_1_link>
         <cable_connection_1_port>sc_port_base</cable_connection_1_port>
       </cable>
+      <cable>
+        <name>cable_1</name>
+        <cable_connection_0_link>lc_plug_link</cable_connection_0_link>
+        <cable_connection_0_port>nic_card_mount</cable_connection_0_port>
+        <cable_connection_1_link>sc_plug_link</cable_connection_1_link>
+        <cable_connection_1_port>sc_port_base</cable_connection_1_port>
+      </cable>
+      <cable>
+        <name>cable_2</name>
+        <cable_connection_0_link>lc_plug_link</cable_connection_0_link>
+        <cable_connection_0_port>nic_card_mount</cable_connection_0_port>
+        <cable_connection_1_link>sc_plug_link</cable_connection_1_link>
+        <cable_connection_1_port>sc_port_base</cable_connection_1_port>
+      </cable>
+      <cable>
+        <name>cable_3</name>
+        <cable_connection_0_link>lc_plug_link</cable_connection_0_link>
+        <cable_connection_0_port>nic_card_mount</cable_connection_0_port>
+        <cable_connection_1_link>sc_plug_link</cable_connection_1_link>
+        <cable_connection_1_port>sc_port_base</cable_connection_1_port>
+      </cable>
+      <cable>
+        <name>cable_4</name>
+        <cable_connection_0_link>lc_plug_link</cable_connection_0_link>
+        <cable_connection_0_port>nic_card_mount</cable_connection_0_port>
+        <cable_connection_1_link>sc_plug_link</cable_connection_1_link>
+        <cable_connection_1_port>sc_port_base</cable_connection_1_port>
+      </cable>
       <end_effector_model>ur5e</end_effector_model>
       <end_effector_link>ati/tool_link</end_effector_link>
     </plugin>

--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -137,9 +137,7 @@ void CableModeratorPlugin::Configure(
     cableElem = cableElem->GetNextElement("cable");
   }
 
-  for (size_t i = 0; i < this->cableConfigs.size(); ++i) {
-    this->cableTrackers.push_back(std::make_unique<CableTracker>());
-  }
+  this->cableTrackers.resize(this->cableConfigs.size());
 
   if (_sdf->HasElement("end_effector_model")) {
     this->endEffectorModelName = _sdf->Get<std::string>("end_effector_model");
@@ -154,7 +152,7 @@ void CableModeratorPlugin::Configure(
 
   this->creator = std::make_unique<SdfEntityCreator>(_ecm, _eventManager);
 
-  this->cableInsertionPub = this->node.Advertise<gz::msgs::StringMsg_V>(
+  this->cableInsertionPub = this->node.Advertise<gz::msgs::StringMsg>(
       "/cable_moderator/insertion_event");
 
   // Manual grasp subscribers for all cables
@@ -166,22 +164,22 @@ void CableModeratorPlugin::Configure(
     this->manualGraspSubs.push_back(this->node.CreateSubscriber(
         prefix + "/attach_end_0", std::function<void(const gz::msgs::Empty&)>(
                                       [&tracker](const gz::msgs::Empty&) {
-                                        tracker->attachEnd0Requested = true;
+                                        tracker.attachEnd0Requested = true;
                                       })));
     this->manualGraspSubs.push_back(this->node.CreateSubscriber(
         prefix + "/detach_end_0", std::function<void(const gz::msgs::Empty&)>(
                                       [&tracker](const gz::msgs::Empty&) {
-                                        tracker->detachEnd0Requested = true;
+                                        tracker.detachEnd0Requested = true;
                                       })));
     this->manualGraspSubs.push_back(this->node.CreateSubscriber(
         prefix + "/attach_end_1", std::function<void(const gz::msgs::Empty&)>(
                                       [&tracker](const gz::msgs::Empty&) {
-                                        tracker->attachEnd1Requested = true;
+                                        tracker.attachEnd1Requested = true;
                                       })));
     this->manualGraspSubs.push_back(this->node.CreateSubscriber(
         prefix + "/detach_end_1", std::function<void(const gz::msgs::Empty&)>(
                                       [&tracker](const gz::msgs::Empty&) {
-                                        tracker->detachEnd1Requested = true;
+                                        tracker.detachEnd1Requested = true;
                                       })));
   }
 }
@@ -191,31 +189,31 @@ void CableModeratorPlugin::ProcessManualGraspRequests(
     gz::sim::EntityComponentManager& _ecm) {
   for (size_t i = 0; i < this->cableTrackers.size(); ++i) {
     auto& tracker = this->cableTrackers[i];
-    if (!tracker->found) continue;
+    if (!tracker.found) continue;
 
-    if (tracker->attachEnd0Requested.exchange(false)) {
+    if (tracker.attachEnd0Requested.exchange(false)) {
       gzdbg << "Received manual attach request for "
             << this->cableConfigs[i].modelName << " end 0" << std::endl;
       if (this->endEffectorLinkEntity == kNullEntity) {
         gzerr << "Cannot attach: End effector link not found yet." << std::endl;
         continue;
       }
-      if (this->FindGripperJoint(tracker->connection0LinkEntity, _ecm) ==
+      if (this->FindGripperJoint(tracker.connection0LinkEntity, _ecm) ==
           kNullEntity) {
         Entity jointEntity = _ecm.CreateEntity();
         _ecm.CreateComponent(jointEntity,
                              components::DetachableJoint(
                                  {this->endEffectorLinkEntity,
-                                  tracker->connection0LinkEntity, "fixed"}));
+                                  tracker.connection0LinkEntity, "fixed"}));
         gzmsg << "Manually attached " << this->cableConfigs[i].modelName
               << " end 0" << std::endl;
       }
     }
-    if (tracker->detachEnd0Requested.exchange(false)) {
+    if (tracker.detachEnd0Requested.exchange(false)) {
       gzdbg << "Received manual detach request for "
             << this->cableConfigs[i].modelName << " end 0" << std::endl;
       Entity gripperJoint =
-          this->FindGripperJoint(tracker->connection0LinkEntity, _ecm);
+          this->FindGripperJoint(tracker.connection0LinkEntity, _ecm);
       if (gripperJoint != kNullEntity) {
         _ecm.RequestRemoveEntity(gripperJoint);
         gzmsg << "Manually detached " << this->cableConfigs[i].modelName
@@ -223,29 +221,29 @@ void CableModeratorPlugin::ProcessManualGraspRequests(
       }
     }
 
-    if (tracker->attachEnd1Requested.exchange(false)) {
+    if (tracker.attachEnd1Requested.exchange(false)) {
       gzdbg << "Received manual attach request for "
             << this->cableConfigs[i].modelName << " end 1" << std::endl;
       if (this->endEffectorLinkEntity == kNullEntity) {
         gzerr << "Cannot attach: End effector link not found yet." << std::endl;
         continue;
       }
-      if (this->FindGripperJoint(tracker->connection1LinkEntity, _ecm) ==
+      if (this->FindGripperJoint(tracker.connection1LinkEntity, _ecm) ==
           kNullEntity) {
         Entity jointEntity = _ecm.CreateEntity();
         _ecm.CreateComponent(jointEntity,
                              components::DetachableJoint(
                                  {this->endEffectorLinkEntity,
-                                  tracker->connection1LinkEntity, "fixed"}));
+                                  tracker.connection1LinkEntity, "fixed"}));
         gzmsg << "Manually attached " << this->cableConfigs[i].modelName
               << " end 1" << std::endl;
       }
     }
-    if (tracker->detachEnd1Requested.exchange(false)) {
+    if (tracker.detachEnd1Requested.exchange(false)) {
       gzdbg << "Received manual detach request for "
             << this->cableConfigs[i].modelName << " end 1" << std::endl;
       Entity gripperJoint =
-          this->FindGripperJoint(tracker->connection1LinkEntity, _ecm);
+          this->FindGripperJoint(tracker.connection1LinkEntity, _ecm);
       if (gripperJoint != kNullEntity) {
         _ecm.RequestRemoveEntity(gripperJoint);
         gzmsg << "Manually detached " << this->cableConfigs[i].modelName
@@ -259,15 +257,15 @@ void CableModeratorPlugin::ProcessManualGraspRequests(
 void CableModeratorPlugin::MakeCableStatic(
     size_t _cableIndex, gz::sim::EntityComponentManager& _ecm) {
   auto& tracker = this->cableTrackers[_cableIndex];
-  Model(tracker->modelEntity).SetStatic(_ecm, true);
+  Model(tracker.modelEntity).SetStatic(_ecm, true);
 
-  if (tracker->detachableJointStatic0Entity != kNullEntity) {
-    _ecm.RequestRemoveEntity(tracker->detachableJointStatic0Entity);
-    tracker->detachableJointStatic0Entity = kNullEntity;
+  if (tracker.detachableJointStatic0Entity != kNullEntity) {
+    _ecm.RequestRemoveEntity(tracker.detachableJointStatic0Entity);
+    tracker.detachableJointStatic0Entity = kNullEntity;
   }
-  if (tracker->detachableJointStatic1Entity != kNullEntity) {
-    _ecm.RequestRemoveEntity(tracker->detachableJointStatic1Entity);
-    tracker->detachableJointStatic1Entity = kNullEntity;
+  if (tracker.detachableJointStatic1Entity != kNullEntity) {
+    _ecm.RequestRemoveEntity(tracker.detachableJointStatic1Entity);
+    tracker.detachableJointStatic1Entity = kNullEntity;
   }
 }
 
@@ -275,7 +273,7 @@ void CableModeratorPlugin::MakeCableStatic(
 void CableModeratorPlugin::MakeCableDynamic(
     size_t _cableIndex, gz::sim::EntityComponentManager& _ecm) {
   auto& tracker = this->cableTrackers[_cableIndex];
-  Model(tracker->modelEntity).SetStatic(_ecm, false);
+  Model(tracker.modelEntity).SetStatic(_ecm, false);
 }
 
 //////////////////////////////////////////////////
@@ -305,83 +303,85 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
 
   for (size_t i = 0; i < this->cableTrackers.size(); ++i) {
     auto& tracker = this->cableTrackers[i];
-    if (!tracker->found || tracker->isCompleted) continue;
-    Entity graspJoint =
-        this->FindExternalGraspJoint(tracker->modelEntity, _ecm);
+    if (!tracker.found || tracker.isCompleted) continue;
+    Entity graspJoint = this->FindExternalGraspJoint(tracker, _ecm);
     if (graspJoint != kNullEntity) {
-      int closerEnd = this->FindGraspedEnd(i, graspJoint, _ecm);
-      if (tracker->activeGraspJoint.load() == kNullEntity ||
-          closerEnd != tracker->lastGraspedEnd) {
+      // Create subscribers if they weren't already.
+      if (tracker.portSubs.empty()) this->CreatePortSubscribers(i);
+
+      auto closerEnd = this->FindGraspedEnd(i, graspJoint, _ecm);
+      if (!closerEnd.has_value()) {
+        gzwarn << "Grasped end not found. Report this" << std::endl;
+        continue;
+      }
+      if (tracker.activeGraspJoint.load() == kNullEntity ||
+          closerEnd != tracker.lastGraspedEnd) {
         gzmsg << "Cable " << this->cableConfigs[i].modelName
-              << " grasp confirmed near End " << closerEnd
+              << " grasp confirmed near End " << *closerEnd
               << " (joint: " << graspJoint << ")" << std::endl;
-        tracker->lastGraspedEnd = closerEnd;
-        if (tracker->activeGraspJoint.load() == kNullEntity)
+        tracker.lastGraspedEnd = closerEnd;
+        if (tracker.activeGraspJoint.load() == kNullEntity)
           this->MakeCableDynamic(i, _ecm);
       }
 
       if (closerEnd == 0) {
         // Grasping near End 0: Unfreeze End 0 (if not inserted), Ensure End 1
         // is frozen
-        if (!tracker->end0Inserted &&
-            tracker->detachableJointStatic0Entity != kNullEntity) {
-          _ecm.RequestRemoveEntity(tracker->detachableJointStatic0Entity);
-          tracker->detachableJointStatic0Entity = kNullEntity;
+        if (!tracker.end0Inserted &&
+            tracker.detachableJointStatic0Entity != kNullEntity) {
+          _ecm.RequestRemoveEntity(tracker.detachableJointStatic0Entity);
+          tracker.detachableJointStatic0Entity = kNullEntity;
           gzmsg << "Unfreezing End 0 for manipulation." << std::endl;
         }
-        if (!tracker->end1Inserted &&
-            tracker->detachableJointStatic1Entity == kNullEntity) {
-          tracker->detachableJointStatic1Entity =
-              this->MakeStatic(tracker->connection1LinkEntity, true, _ecm);
+        if (!tracker.end1Inserted &&
+            tracker.detachableJointStatic1Entity == kNullEntity) {
+          tracker.detachableJointStatic1Entity =
+              this->MakeStatic(tracker.connection1LinkEntity, true, _ecm);
           gzdbg << "Locking End 1. Resulting joint: "
-                << tracker->detachableJointStatic1Entity << std::endl;
+                << tracker.detachableJointStatic1Entity << std::endl;
         }
       } else {
         // Grasping near End 1: Unfreeze End 1 (if not inserted), Ensure End 0
         // is frozen
-        if (!tracker->end1Inserted &&
-            tracker->detachableJointStatic1Entity != kNullEntity) {
-          _ecm.RequestRemoveEntity(tracker->detachableJointStatic1Entity);
-          tracker->detachableJointStatic1Entity = kNullEntity;
+        if (!tracker.end1Inserted &&
+            tracker.detachableJointStatic1Entity != kNullEntity) {
+          _ecm.RequestRemoveEntity(tracker.detachableJointStatic1Entity);
+          tracker.detachableJointStatic1Entity = kNullEntity;
           gzmsg << "Unfreezing End 1 for manipulation." << std::endl;
         }
-        if (!tracker->end0Inserted &&
-            tracker->detachableJointStatic0Entity == kNullEntity) {
-          tracker->detachableJointStatic0Entity =
-              this->MakeStatic(tracker->connection0LinkEntity, true, _ecm);
+        if (!tracker.end0Inserted &&
+            tracker.detachableJointStatic0Entity == kNullEntity) {
+          tracker.detachableJointStatic0Entity =
+              this->MakeStatic(tracker.connection0LinkEntity, true, _ecm);
           gzdbg << "Locking End 0. Resulting joint: "
-                << tracker->detachableJointStatic0Entity << std::endl;
+                << tracker.detachableJointStatic0Entity << std::endl;
         }
       }
-      tracker->activeGraspJoint.store(graspJoint);
+      tracker.activeGraspJoint.store(graspJoint);
     } else {
-      if (tracker->activeGraspJoint.load() != kNullEntity) {
+      if (tracker.activeGraspJoint.exchange(kNullEntity) != kNullEntity) {
         this->MakeCableStatic(i, _ecm);
       }
-      tracker->activeGraspJoint.store(kNullEntity);
-      tracker->lastGraspedEnd = -1;
+      tracker.lastGraspedEnd = std::nullopt;
     }
 
-    // Keep searching for port topics until we find at least one (or more)
-    if (tracker->portSubs.empty()) this->CreatePortSubscribers(i);
-
-    if (tracker->end0Inserted &&
-        tracker->detachableJointStatic0Entity == kNullEntity) {
-      tracker->detachableJointStatic0Entity =
-          this->MakeStatic(tracker->connection0LinkEntity, true, _ecm);
+    if (tracker.end0Inserted &&
+        tracker.detachableJointStatic0Entity == kNullEntity) {
+      tracker.detachableJointStatic0Entity =
+          this->MakeStatic(tracker.connection0LinkEntity, true, _ecm);
     }
-    if (tracker->end1Inserted &&
-        tracker->detachableJointStatic1Entity == kNullEntity) {
-      tracker->detachableJointStatic1Entity =
-          this->MakeStatic(tracker->connection1LinkEntity, true, _ecm);
+    if (tracker.end1Inserted &&
+        tracker.detachableJointStatic1Entity == kNullEntity) {
+      tracker.detachableJointStatic1Entity =
+          this->MakeStatic(tracker.connection1LinkEntity, true, _ecm);
     }
 
-    if (tracker->end0Inserted && tracker->end1Inserted &&
-        !tracker->isCompleted) {
-      tracker->isCompleted = true;
+    if (tracker.end0Inserted && tracker.end1Inserted && !tracker.isCompleted) {
+      tracker.isCompleted = true;
       this->MakeCableStatic(i, _ecm);
       gzmsg << "Cable " << this->cableConfigs[i].modelName << " fully inserted."
             << std::endl;
+      tracker.portSubs.clear();
     }
   }
 }
@@ -476,18 +476,14 @@ Entity CableModeratorPlugin::FindGripperJoint(
 
 //////////////////////////////////////////////////
 Entity CableModeratorPlugin::FindExternalGraspJoint(
-    Entity _cableModelEntity, const EntityComponentManager& _ecm) const {
-  if (_cableModelEntity == kNullEntity) return kNullEntity;
-  Model model(_cableModelEntity);
-  auto cableLinks = model.Links(_ecm);
-  std::unordered_set<Entity> cableLinkSet(cableLinks.begin(), cableLinks.end());
+    const CableTracker& _tracker, const EntityComponentManager& _ecm) const {
   Entity result = kNullEntity;
   _ecm.Each<components::DetachableJoint>(
       [&](const Entity& _entity,
           const components::DetachableJoint* _joint) -> bool {
         const auto& info = _joint->Data();
-        bool parentInCable = cableLinkSet.count(info.parentLink) > 0;
-        bool childInCable = cableLinkSet.count(info.childLink) > 0;
+        bool parentInCable = _tracker.neighbors.count(info.parentLink) > 0;
+        bool childInCable = _tracker.neighbors.count(info.childLink) > 0;
         if (parentInCable != childInCable) {
           Entity externalLink =
               parentInCable ? info.childLink : info.parentLink;
@@ -511,17 +507,17 @@ Entity CableModeratorPlugin::FindExternalGraspJoint(
 //////////////////////////////////////////////////
 void CableModeratorPlugin::FindCableModels(const EntityComponentManager& _ecm) {
   for (size_t i = 0; i < this->cableConfigs.size(); ++i) {
-    if (!this->cableTrackers[i]->found) {
+    if (!this->cableTrackers[i].found) {
       auto entitiesMatchingName =
           entitiesFromScopedName(this->cableConfigs[i].modelName, _ecm);
       if (!entitiesMatchingName.empty()) {
         Entity modelEntity = *entitiesMatchingName.begin();
-        this->cableTrackers[i]->modelEntity = modelEntity;
-        this->cableTrackers[i]->found = true;
+        this->cableTrackers[i].modelEntity = modelEntity;
+        this->cableTrackers[i].found = true;
         Model model(modelEntity);
-        this->cableTrackers[i]->connection0LinkEntity =
+        this->cableTrackers[i].connection0LinkEntity =
             model.LinkByName(_ecm, this->cableConfigs[i].connection0LinkName);
-        this->cableTrackers[i]->connection1LinkEntity =
+        this->cableTrackers[i].connection1LinkEntity =
             model.LinkByName(_ecm, this->cableConfigs[i].connection1LinkName);
 
         // Build the topological graph of the cable
@@ -532,8 +528,8 @@ void CableModeratorPlugin::FindCableModels(const EntityComponentManager& _ecm) {
             Entity pEnt = model.LinkByName(_ecm, pName->Data());
             Entity cEnt = model.LinkByName(_ecm, cName->Data());
             if (pEnt != kNullEntity && cEnt != kNullEntity) {
-              this->cableTrackers[i]->neighbors[pEnt].push_back(cEnt);
-              this->cableTrackers[i]->neighbors[cEnt].push_back(pEnt);
+              this->cableTrackers[i].neighbors[pEnt].push_back(cEnt);
+              this->cableTrackers[i].neighbors[cEnt].push_back(pEnt);
             }
           }
         }
@@ -560,75 +556,72 @@ void CableModeratorPlugin::CreatePortSubscribers(size_t _cableIndex) {
     if (_msg.data()) {
       auto& tracker = this->cableTrackers[_cableIndex];
       // Grasp filter: Only report insertion if this cable is actually being
-      // held
-      if (tracker->activeGraspJoint.load() == kNullEntity) {
+      // held and the touch plugin reported touch on the grasped end
+      if (tracker.activeGraspJoint.load() == kNullEntity ||
+          tracker.lastGraspedEnd != end) {
         gzdbg << "Ignoring touch event for "
               << this->cableConfigs[_cableIndex].modelName << " on port "
               << _info.Topic() << " (Not grasped)" << std::endl;
         return;
       }
 
-      if (end == 0 ? tracker->end0Inserted : tracker->end1Inserted) return;
+      if (end == 0 ? tracker.end0Inserted : tracker.end1Inserted) return;
       if (end == 0)
-        tracker->end0Inserted = true;
+        tracker.end0Inserted = true;
       else
-        tracker->end1Inserted = true;
+        tracker.end1Inserted = true;
       gzmsg << "Touch event received for "
             << this->cableConfigs[_cableIndex].modelName << " end " << end
             << " from topic " << _info.Topic() << std::endl;
       auto pos = _info.Topic().rfind("/");
       if (pos != std::string::npos)
-        tracker->touchEventCallbackNamespace = _info.Topic().substr(0, pos);
-      gz::msgs::StringMsg_V pubMsg;
-      pubMsg.add_data(this->cableConfigs[_cableIndex].modelName);
-      pubMsg.add_data(std::to_string(end));
-      pubMsg.add_data(tracker->touchEventCallbackNamespace);
+        tracker.touchEventCallbackNamespace = _info.Topic().substr(0, pos);
+      gz::msgs::StringMsg pubMsg;
+      pubMsg.set_data(this->cableConfigs[_cableIndex].modelName + "#" +
+                      std::to_string(end) + "#" +
+                      tracker.touchEventCallbackNamespace);
       this->cableInsertionPub.Publish(pubMsg);
     }
+  };
+
+  auto subscribe = [this, &config, &tracker, cb](const std::string& _topic,
+                                                 int _end) {
+    gzmsg << "Subscribing End " << _end << " of " << config.modelName
+          << " to: " << _topic << std::endl;
+    tracker.portSubs.emplace_back(this->node.CreateSubscriber(
+        _topic, std::function<void(const gz::msgs::Boolean&,
+                                   const gz::transport::MessageInfo&)>(
+                    std::bind(cb, std::placeholders::_1, std::placeholders::_2,
+                              _end))));
   };
 
   for (const auto& topic : allTopics) {
     if (topic.find("touched") == std::string::npos) continue;
 
     if (topic.find(config.connection0PortName) != std::string::npos) {
-      gzmsg << "Subscribing End 0 of " << config.modelName << " to: " << topic
-            << std::endl;
-      tracker->portSubs.emplace_back(this->node.CreateSubscriber(
-          topic,
-          std::function<void(const gz::msgs::Boolean&,
-                             const gz::transport::MessageInfo&)>(
-              std::bind(cb, std::placeholders::_1, std::placeholders::_2, 0))));
+      subscribe(topic, 0);
     }
     if (topic.find(config.connection1PortName) != std::string::npos) {
-      gzmsg << "Subscribing End 1 of " << config.modelName << " to: " << topic
-            << std::endl;
-      tracker->portSubs.emplace_back(this->node.CreateSubscriber(
-          topic,
-          std::function<void(const gz::msgs::Boolean&,
-                             const gz::transport::MessageInfo&)>(
-              std::bind(cb, std::placeholders::_1, std::placeholders::_2, 1))));
+      subscribe(topic, 1);
     }
   }
 }
 
 //////////////////////////////////////////////////
-int CableModeratorPlugin::FindGraspedEnd(
+std::optional<int> CableModeratorPlugin::FindGraspedEnd(
     size_t _cableIndex, Entity _graspJoint,
     const EntityComponentManager& _ecm) const {
   auto& tracker = this->cableTrackers[_cableIndex];
   auto jointComp = _ecm.Component<components::DetachableJoint>(_graspJoint);
-  if (!jointComp) return -1;
+  if (!jointComp) return std::nullopt;
   const auto& info = jointComp->Data();
 
-  Model model(tracker->modelEntity);
-  auto cableLinks = model.Links(_ecm);
-  std::unordered_set<Entity> cableLinkSet(cableLinks.begin(), cableLinks.end());
+  Entity cableLink = tracker.neighbors.count(info.parentLink) > 0
+                         ? info.parentLink
+                         : info.childLink;
 
-  Entity cableLink = cableLinkSet.count(info.parentLink) > 0 ? info.parentLink
-                                                             : info.childLink;
-
-  if (cableLink == tracker->connection0LinkEntity) return 0;
-  if (cableLink == tracker->connection1LinkEntity) return 1;
+  if (cableLink == tracker.connection0LinkEntity) return 0;
+  if (cableLink == tracker.connection1LinkEntity) return 1;
 
   // Fallback: Topological distance (link count).
   // This is used if the gripper attaches to a link that isn't one of the ends.
@@ -639,21 +632,17 @@ int CableModeratorPlugin::FindGraspedEnd(
   q.push(cableLink);
   dists[cableLink] = 0;
 
-  int d0 = -1, d1 = -1;
   while (!q.empty()) {
     Entity curr = q.front();
     q.pop();
     int d = dists[curr];
 
     // Check if we've reached either end link
-    if (curr == tracker->connection0LinkEntity) d0 = d;
-    if (curr == tracker->connection1LinkEntity) d1 = d;
+    if (curr == tracker.connection0LinkEntity) return 0;
+    if (curr == tracker.connection1LinkEntity) return 1;
 
-    // Stop early if both ends are found
-    if (d0 != -1 && d1 != -1) break;
-
-    auto it = tracker->neighbors.find(curr);
-    if (it != tracker->neighbors.end()) {
+    auto it = tracker.neighbors.find(curr);
+    if (it != tracker.neighbors.end()) {
       for (Entity next : it->second) {
         if (dists.find(next) == dists.end()) {
           dists[next] = d + 1;
@@ -663,12 +652,8 @@ int CableModeratorPlugin::FindGraspedEnd(
     }
   }
 
-  // If one end is unreachable, assume the other is the closer one
-  if (d0 == -1) return 1;
-  if (d1 == -1) return 0;
-
-  // Return the logically closer end
-  return (d0 < d1) ? 0 : 1;
+  // Failed to find a connection to any link
+  return std::nullopt;
 }
 
 }  // namespace aic_gazebo

--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -97,14 +97,41 @@ void CableModeratorPlugin::Configure(
       continue;
     }
 
-    config.connection0LinkName =
-        cableElem->Get<std::string>("cable_connection_0_link");
-    config.connection0PortName =
-        cableElem->Get<std::string>("cable_connection_0_port");
-    config.connection1LinkName =
-        cableElem->Get<std::string>("cable_connection_1_link");
-    config.connection1PortName =
-        cableElem->Get<std::string>("cable_connection_1_port");
+    if (cableElem->HasElement("cable_connection_0_link")) {
+      config.connection0LinkName =
+          cableElem->Get<std::string>("cable_connection_0_link");
+    } else {
+      gzerr << "Missing <cable_connection_0_link> parameter." << std::endl;
+      cableElem = cableElem->GetNextElement("cable");
+      continue;
+    }
+
+    if (cableElem->HasElement("cable_connection_0_port")) {
+      config.connection0PortName =
+          cableElem->Get<std::string>("cable_connection_0_port");
+    } else {
+      gzerr << "Missing <cable_connection_0_port> parameter." << std::endl;
+      cableElem = cableElem->GetNextElement("cable");
+      continue;
+    }
+
+    if (cableElem->HasElement("cable_connection_1_link")) {
+      config.connection1LinkName =
+          cableElem->Get<std::string>("cable_connection_1_link");
+    } else {
+      gzerr << "Missing <cable_connection_1_link> parameter." << std::endl;
+      cableElem = cableElem->GetNextElement("cable");
+      continue;
+    }
+
+    if (cableElem->HasElement("cable_connection_1_port")) {
+      config.connection1PortName =
+          cableElem->Get<std::string>("cable_connection_1_port");
+    } else {
+      gzerr << "Missing <cable_connection_1_port> parameter." << std::endl;
+      cableElem = cableElem->GetNextElement("cable");
+      continue;
+    }
 
     this->cableConfigs.push_back(config);
     cableElem = cableElem->GetNextElement("cable");
@@ -260,15 +287,6 @@ void CableModeratorPlugin::Cleanup(gz::sim::EntityComponentManager& _ecm) {
 }
 
 //////////////////////////////////////////////////
-bool CableModeratorPlugin::IsModelValid(
-    const gz::sim::EntityComponentManager& _ecm) {
-  for (const auto& tracker : this->cableTrackers) {
-    if (tracker->found && !_ecm.HasEntity(tracker->modelEntity)) return false;
-  }
-  return true;
-}
-
-//////////////////////////////////////////////////
 void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
                                      gz::sim::EntityComponentManager& _ecm) {
   this->FindCableModels(_ecm);
@@ -344,7 +362,7 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
       tracker->lastGraspedEnd = -1;
     }
 
-    // Keep searching for port topics until we find at least one (or both)
+    // Keep searching for port topics until we find at least one (or more)
     if (tracker->portSubs.empty()) this->CreatePortSubscribers(i);
 
     if (tracker->end0Inserted &&
@@ -505,6 +523,21 @@ void CableModeratorPlugin::FindCableModels(const EntityComponentManager& _ecm) {
             model.LinkByName(_ecm, this->cableConfigs[i].connection0LinkName);
         this->cableTrackers[i]->connection1LinkEntity =
             model.LinkByName(_ecm, this->cableConfigs[i].connection1LinkName);
+
+        // Build the topological graph of the cable
+        for (Entity jointEnt : model.Joints(_ecm)) {
+          auto pName = _ecm.Component<components::ParentLinkName>(jointEnt);
+          auto cName = _ecm.Component<components::ChildLinkName>(jointEnt);
+          if (pName && cName) {
+            Entity pEnt = model.LinkByName(_ecm, pName->Data());
+            Entity cEnt = model.LinkByName(_ecm, cName->Data());
+            if (pEnt != kNullEntity && cEnt != kNullEntity) {
+              this->cableTrackers[i]->neighbors[pEnt].push_back(cEnt);
+              this->cableTrackers[i]->neighbors[cEnt].push_back(pEnt);
+            }
+          }
+        }
+
         this->MakeCableStatic(i, const_cast<EntityComponentManager&>(_ecm));
         gzmsg << "Found cable model: " << this->cableConfigs[i].modelName
               << std::endl;
@@ -599,25 +632,8 @@ int CableModeratorPlugin::FindGraspedEnd(
 
   // Fallback: Topological distance (link count).
   // This is used if the gripper attaches to a link that isn't one of the ends.
-  // It builds a graph of the cable's links and performs a BFS to find the
-  // logical distance (number of joints) to each end.
-  std::unordered_map<Entity, std::vector<Entity>> neighbors;
-  for (Entity jointEnt : model.Joints(_ecm)) {
-    // Identify the links connected by this joint by name
-    auto pName = _ecm.Component<components::ParentLinkName>(jointEnt);
-    auto cName = _ecm.Component<components::ChildLinkName>(jointEnt);
-    if (pName && cName) {
-      // Resolve names to entities within the model
-      Entity pEnt = model.LinkByName(_ecm, pName->Data());
-      Entity cEnt = model.LinkByName(_ecm, cName->Data());
-      if (pEnt != kNullEntity && cEnt != kNullEntity) {
-        neighbors[pEnt].push_back(cEnt);
-        neighbors[cEnt].push_back(pEnt);
-      }
-    }
-  }
-
-  // Perform BFS to find the shortest topological path to both ends
+  // Perform BFS to find the shortest topological path to both ends using cached
+  // graph
   std::unordered_map<Entity, int> dists;
   std::queue<Entity> q;
   q.push(cableLink);
@@ -636,10 +652,13 @@ int CableModeratorPlugin::FindGraspedEnd(
     // Stop early if both ends are found
     if (d0 != -1 && d1 != -1) break;
 
-    for (Entity next : neighbors[curr]) {
-      if (dists.find(next) == dists.end()) {
-        dists[next] = d + 1;
-        q.push(next);
+    auto it = tracker->neighbors.find(curr);
+    if (it != tracker->neighbors.end()) {
+      for (Entity next : it->second) {
+        if (dists.find(next) == dists.end()) {
+          dists[next] = d + 1;
+          q.push(next);
+        }
       }
     }
   }

--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -34,6 +34,7 @@
 #include <gz/sim/components/ParentLinkName.hh>
 #include <gz/sim/components/Pose.hh>
 #include <gz/sim/components/World.hh>
+#include <gz/sim/config.hh>
 #include <queue>
 #include <unordered_map>
 
@@ -257,7 +258,18 @@ void CableModeratorPlugin::ProcessManualGraspRequests(
 void CableModeratorPlugin::MakeCableStatic(
     size_t _cableIndex, gz::sim::EntityComponentManager& _ecm) {
   auto& tracker = this->cableTrackers[_cableIndex];
+#if (GZ_SIM_MAJOR_VERSION == 9 && GZ_SIM_MINOR_VERSION >= 6) ||  \
+    (GZ_SIM_MAJOR_VERSION == 10 && GZ_SIM_MINOR_VERSION >= 3) || \
+    (GZ_SIM_MAJOR_VERSION > 10)
   Model(tracker.modelEntity).SetStatic(_ecm, true);
+#else
+  static bool warnedOnce = false;
+  if (!warnedOnce) {
+    gzwarn << "Unable to set model static state in version "
+           << GZ_SIM_VERSION_FULL << std::endl;
+    warnedOnce = true;
+  }
+#endif
 
   if (tracker.detachableJointStatic0Entity != kNullEntity) {
     _ecm.RequestRemoveEntity(tracker.detachableJointStatic0Entity);
@@ -272,8 +284,21 @@ void CableModeratorPlugin::MakeCableStatic(
 //////////////////////////////////////////////////
 void CableModeratorPlugin::MakeCableDynamic(
     size_t _cableIndex, gz::sim::EntityComponentManager& _ecm) {
+#if (GZ_SIM_MAJOR_VERSION == 9 && GZ_SIM_MINOR_VERSION >= 6) ||  \
+    (GZ_SIM_MAJOR_VERSION == 10 && GZ_SIM_MINOR_VERSION >= 3) || \
+    (GZ_SIM_MAJOR_VERSION > 10)
   auto& tracker = this->cableTrackers[_cableIndex];
   Model(tracker.modelEntity).SetStatic(_ecm, false);
+#else
+  static bool warnedOnce = false;
+  if (!warnedOnce) {
+    gzwarn << "Unable to set model static state in version "
+           << GZ_SIM_VERSION_FULL << std::endl;
+    warnedOnce = true;
+  }
+  (void)_cableIndex;
+  (void)_ecm;
+#endif
 }
 
 //////////////////////////////////////////////////

--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -25,12 +25,17 @@
 #include <gz/plugin/Register.hh>
 #include <gz/sim/Util.hh>
 #include <gz/sim/components/CanonicalLink.hh>
+#include <gz/sim/components/ChildLinkName.hh>
 #include <gz/sim/components/DetachableJoint.hh>
 #include <gz/sim/components/Link.hh>
 #include <gz/sim/components/Model.hh>
 #include <gz/sim/components/Name.hh>
 #include <gz/sim/components/ParentEntity.hh>
+#include <gz/sim/components/ParentLinkName.hh>
+#include <gz/sim/components/Pose.hh>
 #include <gz/sim/components/World.hh>
+#include <queue>
+#include <unordered_map>
 
 using namespace gz;
 using namespace sim;
@@ -61,8 +66,6 @@ Entity findLinkInModel(const std::string& _modelName,
     return _ecm.EntityByComponents(components::Link(),
                                    components::ParentEntity(modelEntity),
                                    components::Name(_linkName));
-  } else {
-    // gzwarn << "Model " << _modelName << " could not be found.\n";
   }
   return kNullEntity;
 }
@@ -94,318 +97,285 @@ void CableModeratorPlugin::Configure(
       continue;
     }
 
-    if (cableElem->HasElement("cable_connection_0_link")) {
-      config.connection0LinkName =
-          cableElem->Get<std::string>("cable_connection_0_link");
-    } else {
-      gzerr << "Missing <cable_connection_0_link> parameter." << std::endl;
-      cableElem = cableElem->GetNextElement("cable");
-      continue;
-    }
-
-    if (cableElem->HasElement("cable_connection_0_port")) {
-      config.connection0PortName =
-          cableElem->Get<std::string>("cable_connection_0_port");
-    } else {
-      gzerr << "Missing <cable_connection_0_port> parameter." << std::endl;
-      cableElem = cableElem->GetNextElement("cable");
-      continue;
-    }
-
-    if (cableElem->HasElement("cable_connection_1_link")) {
-      config.connection1LinkName =
-          cableElem->Get<std::string>("cable_connection_1_link");
-    } else {
-      gzerr << "Missing <cable_connection_1_link> parameter." << std::endl;
-      cableElem = cableElem->GetNextElement("cable");
-      continue;
-    }
-
-    if (cableElem->HasElement("cable_connection_1_port")) {
-      config.connection1PortName =
-          cableElem->Get<std::string>("cable_connection_1_port");
-    } else {
-      gzerr << "Missing <cable_connection_1_port> parameter." << std::endl;
-      cableElem = cableElem->GetNextElement("cable");
-      continue;
-    }
+    config.connection0LinkName =
+        cableElem->Get<std::string>("cable_connection_0_link");
+    config.connection0PortName =
+        cableElem->Get<std::string>("cable_connection_0_port");
+    config.connection1LinkName =
+        cableElem->Get<std::string>("cable_connection_1_link");
+    config.connection1PortName =
+        cableElem->Get<std::string>("cable_connection_1_port");
 
     this->cableConfigs.push_back(config);
     cableElem = cableElem->GetNextElement("cable");
   }
 
-  this->cableTrackers.resize(this->cableConfigs.size());
-
-  if (this->cableConfigs.empty()) {
-    gzerr << "Missing valid <cable> parameters." << std::endl;
-    return;
+  for (size_t i = 0; i < this->cableConfigs.size(); ++i) {
+    this->cableTrackers.push_back(std::make_unique<CableTracker>());
   }
 
   if (_sdf->HasElement("end_effector_model")) {
     this->endEffectorModelName = _sdf->Get<std::string>("end_effector_model");
-  } else {
-    gzerr << "Missing <end_effector_model> parameter." << std::endl;
-    return;
+    gzdbg << "Moderator targeting end effector model: "
+          << this->endEffectorModelName << std::endl;
   }
-
   if (_sdf->HasElement("end_effector_link")) {
     this->endEffectorLinkName = _sdf->Get<std::string>("end_effector_link");
-  } else {
-    gzerr << "Missing <end_effector_link> parameter." << std::endl;
-    return;
+    gzdbg << "Moderator targeting end effector link: "
+          << this->endEffectorLinkName << std::endl;
   }
 
   this->creator = std::make_unique<SdfEntityCreator>(_ecm, _eventManager);
 
-  this->taskCompletionPub = this->node.Advertise<gz::msgs::StringMsg>(
+  this->cableInsertionPub = this->node.Advertise<gz::msgs::StringMsg_V>(
       "/cable_moderator/insertion_event");
 
-  gzmsg << "Initializing to NEXT_CABLE state." << std::endl;
-  this->cableState = CableState::NEXT_CABLE;
+  // Manual grasp subscribers for all cables
+  for (size_t i = 0; i < this->cableTrackers.size(); ++i) {
+    const auto& config = this->cableConfigs[i];
+    auto& tracker = this->cableTrackers[i];
+    std::string prefix = "/" + config.modelName;
+
+    this->manualGraspSubs.push_back(this->node.CreateSubscriber(
+        prefix + "/attach_end_0", std::function<void(const gz::msgs::Empty&)>(
+                                      [&tracker](const gz::msgs::Empty&) {
+                                        tracker->attachEnd0Requested = true;
+                                      })));
+    this->manualGraspSubs.push_back(this->node.CreateSubscriber(
+        prefix + "/detach_end_0", std::function<void(const gz::msgs::Empty&)>(
+                                      [&tracker](const gz::msgs::Empty&) {
+                                        tracker->detachEnd0Requested = true;
+                                      })));
+    this->manualGraspSubs.push_back(this->node.CreateSubscriber(
+        prefix + "/attach_end_1", std::function<void(const gz::msgs::Empty&)>(
+                                      [&tracker](const gz::msgs::Empty&) {
+                                        tracker->attachEnd1Requested = true;
+                                      })));
+    this->manualGraspSubs.push_back(this->node.CreateSubscriber(
+        prefix + "/detach_end_1", std::function<void(const gz::msgs::Empty&)>(
+                                      [&tracker](const gz::msgs::Empty&) {
+                                        tracker->detachEnd1Requested = true;
+                                      })));
+  }
 }
 
 //////////////////////////////////////////////////
 void CableModeratorPlugin::ProcessManualGraspRequests(
     gz::sim::EntityComponentManager& _ecm) {
-  if (this->cableIndex < 0) return;
+  for (size_t i = 0; i < this->cableTrackers.size(); ++i) {
+    auto& tracker = this->cableTrackers[i];
+    if (!tracker->found) continue;
 
-  const auto& tracker = this->cableTrackers[this->cableIndex];
-  if (this->attachEnd0Requested.exchange(false)) {
-    if (this->FindGripperJoint(tracker.connection0LinkEntity, _ecm) ==
-        kNullEntity) {
-      Entity jointEntity = _ecm.CreateEntity();
-      _ecm.CreateComponent(jointEntity,
-                           components::DetachableJoint(
-                               {this->endEffectorLinkEntity,
-                                tracker.connection0LinkEntity, "fixed"}));
-      gzdbg << "Manually attached end 0" << std::endl;
+    if (tracker->attachEnd0Requested.exchange(false)) {
+      gzdbg << "Received manual attach request for "
+            << this->cableConfigs[i].modelName << " end 0" << std::endl;
+      if (this->endEffectorLinkEntity == kNullEntity) {
+        gzerr << "Cannot attach: End effector link not found yet." << std::endl;
+        continue;
+      }
+      if (this->FindGripperJoint(tracker->connection0LinkEntity, _ecm) ==
+          kNullEntity) {
+        Entity jointEntity = _ecm.CreateEntity();
+        _ecm.CreateComponent(jointEntity,
+                             components::DetachableJoint(
+                                 {this->endEffectorLinkEntity,
+                                  tracker->connection0LinkEntity, "fixed"}));
+        gzmsg << "Manually attached " << this->cableConfigs[i].modelName
+              << " end 0" << std::endl;
+      }
     }
-  }
-  if (this->detachEnd0Requested.exchange(false)) {
-    Entity gripperJoint =
-        this->FindGripperJoint(tracker.connection0LinkEntity, _ecm);
-    if (gripperJoint != kNullEntity) {
-      _ecm.RequestRemoveEntity(gripperJoint);
-      gzdbg << "Manually detached end 0" << std::endl;
+    if (tracker->detachEnd0Requested.exchange(false)) {
+      gzdbg << "Received manual detach request for "
+            << this->cableConfigs[i].modelName << " end 0" << std::endl;
+      Entity gripperJoint =
+          this->FindGripperJoint(tracker->connection0LinkEntity, _ecm);
+      if (gripperJoint != kNullEntity) {
+        _ecm.RequestRemoveEntity(gripperJoint);
+        gzmsg << "Manually detached " << this->cableConfigs[i].modelName
+              << " end 0" << std::endl;
+      }
     }
-  }
 
-  if (this->attachEnd1Requested.exchange(false)) {
-    if (this->FindGripperJoint(tracker.connection1LinkEntity, _ecm) ==
-        kNullEntity) {
-      Entity jointEntity = _ecm.CreateEntity();
-      _ecm.CreateComponent(jointEntity,
-                           components::DetachableJoint(
-                               {this->endEffectorLinkEntity,
-                                tracker.connection1LinkEntity, "fixed"}));
-      gzdbg << "Manually attached end 1" << std::endl;
+    if (tracker->attachEnd1Requested.exchange(false)) {
+      gzdbg << "Received manual attach request for "
+            << this->cableConfigs[i].modelName << " end 1" << std::endl;
+      if (this->endEffectorLinkEntity == kNullEntity) {
+        gzerr << "Cannot attach: End effector link not found yet." << std::endl;
+        continue;
+      }
+      if (this->FindGripperJoint(tracker->connection1LinkEntity, _ecm) ==
+          kNullEntity) {
+        Entity jointEntity = _ecm.CreateEntity();
+        _ecm.CreateComponent(jointEntity,
+                             components::DetachableJoint(
+                                 {this->endEffectorLinkEntity,
+                                  tracker->connection1LinkEntity, "fixed"}));
+        gzmsg << "Manually attached " << this->cableConfigs[i].modelName
+              << " end 1" << std::endl;
+      }
     }
-  }
-  if (this->detachEnd1Requested.exchange(false)) {
-    Entity gripperJoint =
-        this->FindGripperJoint(tracker.connection1LinkEntity, _ecm);
-    if (gripperJoint != kNullEntity) {
-      _ecm.RequestRemoveEntity(gripperJoint);
-      gzdbg << "Manually detached end 1" << std::endl;
+    if (tracker->detachEnd1Requested.exchange(false)) {
+      gzdbg << "Received manual detach request for "
+            << this->cableConfigs[i].modelName << " end 1" << std::endl;
+      Entity gripperJoint =
+          this->FindGripperJoint(tracker->connection1LinkEntity, _ecm);
+      if (gripperJoint != kNullEntity) {
+        _ecm.RequestRemoveEntity(gripperJoint);
+        gzmsg << "Manually detached " << this->cableConfigs[i].modelName
+              << " end 1" << std::endl;
+      }
     }
   }
 }
 
 //////////////////////////////////////////////////
 void CableModeratorPlugin::MakeCableStatic(
-    int _cableIndex, gz::sim::EntityComponentManager& _ecm) {
-  const auto& config = this->cableConfigs[_cableIndex];
-  const auto cableModelName =
-      Model(this->cableTrackers[_cableIndex].modelEntity).Name(_ecm);
+    size_t _cableIndex, gz::sim::EntityComponentManager& _ecm) {
+  auto& tracker = this->cableTrackers[_cableIndex];
+  Model(tracker->modelEntity).SetStatic(_ecm, true);
 
-  Entity connection0 =
-      findLinkInModel(cableModelName, config.connection0LinkName, _ecm);
-  Entity connection1 =
-      findLinkInModel(cableModelName, config.connection1LinkName, _ecm);
-
-  if (connection0 != kNullEntity) {
-    this->cableTrackers[_cableIndex].detachableJointStatic0Entity =
-        this->MakeStatic(connection0, true, _ecm);
+  if (tracker->detachableJointStatic0Entity != kNullEntity) {
+    _ecm.RequestRemoveEntity(tracker->detachableJointStatic0Entity);
+    tracker->detachableJointStatic0Entity = kNullEntity;
   }
-
-  if (connection1 != kNullEntity) {
-    this->cableTrackers[_cableIndex].detachableJointStatic1Entity =
-        this->MakeStatic(connection1, true, _ecm);
+  if (tracker->detachableJointStatic1Entity != kNullEntity) {
+    _ecm.RequestRemoveEntity(tracker->detachableJointStatic1Entity);
+    tracker->detachableJointStatic1Entity = kNullEntity;
   }
 }
 
 //////////////////////////////////////////////////
 void CableModeratorPlugin::MakeCableDynamic(
-    size_t /*_cableIndex*/, gz::sim::EntityComponentManager& /*_ecm*/) {
-  // For now noop
-  // TODO(anyone) Consider making the links dynamic if they are made
-  // static in MakeCableStatic
+    size_t _cableIndex, gz::sim::EntityComponentManager& _ecm) {
+  auto& tracker = this->cableTrackers[_cableIndex];
+  Model(tracker->modelEntity).SetStatic(_ecm, false);
+}
+
+//////////////////////////////////////////////////
+void CableModeratorPlugin::Cleanup(gz::sim::EntityComponentManager& _ecm) {
+  for (const auto& ent : this->staticEntities) {
+    if (ent != kNullEntity) _ecm.RequestRemoveEntity(ent);
+  }
+  this->staticEntities.clear();
+}
+
+//////////////////////////////////////////////////
+bool CableModeratorPlugin::IsModelValid(
+    const gz::sim::EntityComponentManager& _ecm) {
+  for (const auto& tracker : this->cableTrackers) {
+    if (tracker->found && !_ecm.HasEntity(tracker->modelEntity)) return false;
+  }
+  return true;
 }
 
 //////////////////////////////////////////////////
 void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
                                      gz::sim::EntityComponentManager& _ecm) {
-  if (this->cableState == CableState::COMPLETED) return;
-
   this->FindCableModels(_ecm);
-
-  if (this->endEffectorLinkEntity == kNullEntity) {
-    this->endEffectorLinkEntity =
-        findLinkInModel(this->endEffectorModelName, endEffectorLinkName, _ecm);
-  }
-  if (this->endEffectorLinkEntity == kNullEntity) return;
 
   this->ProcessManualGraspRequests(_ecm);
 
-  if (this->cableState == CableState::WAITING_CONN_0) {
-    this->activeGraspJoint = this->FindExternalGraspJoint(_ecm);
-    if (this->activeGraspJoint != kNullEntity) {
-      // External skill has grasped the cable - remove the static hold
-      auto& joint0 =
-          this->cableTrackers[this->cableIndex].detachableJointStatic0Entity;
-      if (joint0 != kNullEntity) {
-        _ecm.RequestRemoveEntity(joint0);
-        joint0 = kNullEntity;
+  if (this->endEffectorLinkEntity == kNullEntity) {
+    this->endEffectorLinkEntity = findLinkInModel(
+        this->endEffectorModelName, this->endEffectorLinkName, _ecm);
+    if (this->endEffectorLinkEntity != kNullEntity) {
+      gzmsg << "End effector link discovered: " << this->endEffectorLinkName
+            << std::endl;
+    }
+  }
+  if (this->endEffectorLinkEntity == kNullEntity) return;
+
+  for (size_t i = 0; i < this->cableTrackers.size(); ++i) {
+    auto& tracker = this->cableTrackers[i];
+    if (!tracker->found || tracker->isCompleted) continue;
+    Entity graspJoint =
+        this->FindExternalGraspJoint(tracker->modelEntity, _ecm);
+    if (graspJoint != kNullEntity) {
+      int closerEnd = this->FindGraspedEnd(i, graspJoint, _ecm);
+      if (tracker->activeGraspJoint.load() == kNullEntity ||
+          closerEnd != tracker->lastGraspedEnd) {
+        gzmsg << "Cable " << this->cableConfigs[i].modelName
+              << " grasp confirmed near End " << closerEnd
+              << " (joint: " << graspJoint << ")" << std::endl;
+        tracker->lastGraspedEnd = closerEnd;
+        if (tracker->activeGraspJoint.load() == kNullEntity)
+          this->MakeCableDynamic(i, _ecm);
       }
-      gzmsg << "Cable transitioning to ATTACHED_TO_GRIPPER_CONN_0 state."
-            << std::endl;
-      this->cableState = CableState::ATTACHED_TO_GRIPPER_CONN_0;
-    }
-  }
 
-  if (this->cableState == CableState::ATTACHED_TO_GRIPPER_CONN_0) {
-    if (this->cableConnectionPortSubs.empty()) {
-      this->CreatePortSubscribers(
-          this->cableConfigs[this->cableIndex].connection0PortName);
-    }
-
-    if (this->attachCableConnectionToPort) {
-      this->cableConnectionPortSubs.clear();
-      this->attachCableConnectionToPort = false;
-      this->touchEventCallbackNamespace = std::nullopt;
-
-      gzmsg << "Cable transitioning to ATTACH_TO_PORT_CONN_0 state."
-            << std::endl;
-      this->cableState = CableState::ATTACH_TO_PORT_CONN_0;
-    }
-  }
-
-  if (this->cableState == CableState::ATTACH_TO_PORT_CONN_0) {
-    auto& tracker = this->cableTrackers[this->cableIndex];
-    if (this->activeGraspJoint == kNullEntity ||
-        !_ecm.HasEntity(this->activeGraspJoint)) {
-      tracker.detachableJointStatic0Entity =
-          this->MakeStatic(tracker.connection0LinkEntity, true, _ecm);
-
-      this->activeGraspJoint = kNullEntity;
-      gzmsg << "Cable transitioning to WAITING_CONN_1 state." << std::endl;
-      this->cableState = CableState::WAITING_CONN_1;
-    }
-  }
-
-  if (this->cableState == CableState::WAITING_CONN_1) {
-    this->activeGraspJoint = this->FindExternalGraspJoint(_ecm);
-    if (this->activeGraspJoint != kNullEntity) {
-      // External skill has grasped the cable - remove the static hold
-      auto& joint1 =
-          this->cableTrackers[this->cableIndex].detachableJointStatic1Entity;
-      if (joint1 != kNullEntity) {
-        _ecm.RequestRemoveEntity(joint1);
-        joint1 = kNullEntity;
+      if (closerEnd == 0) {
+        // Grasping near End 0: Unfreeze End 0 (if not inserted), Ensure End 1
+        // is frozen
+        if (!tracker->end0Inserted &&
+            tracker->detachableJointStatic0Entity != kNullEntity) {
+          _ecm.RequestRemoveEntity(tracker->detachableJointStatic0Entity);
+          tracker->detachableJointStatic0Entity = kNullEntity;
+          gzmsg << "Unfreezing End 0 for manipulation." << std::endl;
+        }
+        if (!tracker->end1Inserted &&
+            tracker->detachableJointStatic1Entity == kNullEntity) {
+          tracker->detachableJointStatic1Entity =
+              this->MakeStatic(tracker->connection1LinkEntity, true, _ecm);
+          gzdbg << "Locking End 1. Resulting joint: "
+                << tracker->detachableJointStatic1Entity << std::endl;
+        }
+      } else {
+        // Grasping near End 1: Unfreeze End 1 (if not inserted), Ensure End 0
+        // is frozen
+        if (!tracker->end1Inserted &&
+            tracker->detachableJointStatic1Entity != kNullEntity) {
+          _ecm.RequestRemoveEntity(tracker->detachableJointStatic1Entity);
+          tracker->detachableJointStatic1Entity = kNullEntity;
+          gzmsg << "Unfreezing End 1 for manipulation." << std::endl;
+        }
+        if (!tracker->end0Inserted &&
+            tracker->detachableJointStatic0Entity == kNullEntity) {
+          tracker->detachableJointStatic0Entity =
+              this->MakeStatic(tracker->connection0LinkEntity, true, _ecm);
+          gzdbg << "Locking End 0. Resulting joint: "
+                << tracker->detachableJointStatic0Entity << std::endl;
+        }
       }
-      gzmsg << "Cable transitioning to ATTACHED_TO_GRIPPER_CONN_1 state."
-            << std::endl;
-      this->cableState = CableState::ATTACHED_TO_GRIPPER_CONN_1;
-    }
-  }
-
-  if (this->cableState == CableState::ATTACHED_TO_GRIPPER_CONN_1) {
-    if (this->cableConnectionPortSubs.empty()) {
-      this->CreatePortSubscribers(
-          this->cableConfigs[this->cableIndex].connection1PortName);
-    }
-
-    if (this->attachCableConnectionToPort) {
-      this->cableConnectionPortSubs.clear();
-      this->attachCableConnectionToPort = false;
-      this->touchEventCallbackNamespace = std::nullopt;
-
-      gzmsg << "Cable transitioning to ATTACH_TO_PORT_CONN_1 state."
-            << std::endl;
-      this->cableState = CableState::ATTACH_TO_PORT_CONN_1;
-    }
-  }
-
-  if (this->cableState == CableState::ATTACH_TO_PORT_CONN_1) {
-    auto& tracker = this->cableTrackers[this->cableIndex];
-    if (this->activeGraspJoint == kNullEntity ||
-        !_ecm.HasEntity(this->activeGraspJoint)) {
-      tracker.detachableJointStatic1Entity =
-          this->MakeStatic(tracker.connection1LinkEntity, true, _ecm);
-
-      this->activeGraspJoint = kNullEntity;
-      gzmsg << "Cable transitioning to NEXT_CABLE state." << std::endl;
-      this->cableState = CableState::NEXT_CABLE;
-    }
-  }
-
-  if (this->cableState == CableState::NEXT_CABLE) {
-    this->cableConnectionPortSubs.clear();
-    this->attachCableConnectionToPort = false;
-    this->touchEventCallbackNamespace = std::nullopt;
-
-    if (static_cast<std::size_t>(this->cableIndex + 1) <
-        this->cableTrackers.size()) {
-      // There are more cables to be processed
-      if (this->ToggleActiveCable(_ecm)) {
-        gzmsg << "Cable transitioning to WAITING_CONN_0 state for next cable."
-              << std::endl;
-        this->cableState = CableState::WAITING_CONN_0;
-      }
+      tracker->activeGraspJoint.store(graspJoint);
     } else {
-      gz::msgs::StringMsg msg;
-      msg.set_data("all_cables_completed");
-      this->taskCompletionPub.Publish(msg);
+      if (tracker->activeGraspJoint.load() != kNullEntity) {
+        this->MakeCableStatic(i, _ecm);
+      }
+      tracker->activeGraspJoint.store(kNullEntity);
+      tracker->lastGraspedEnd = -1;
+    }
 
-      gzmsg << "All cables processed. Transitioning to COMPLETED state."
+    // Keep searching for port topics until we find at least one (or both)
+    if (tracker->portSubs.empty()) this->CreatePortSubscribers(i);
+
+    if (tracker->end0Inserted &&
+        tracker->detachableJointStatic0Entity == kNullEntity) {
+      tracker->detachableJointStatic0Entity =
+          this->MakeStatic(tracker->connection0LinkEntity, true, _ecm);
+    }
+    if (tracker->end1Inserted &&
+        tracker->detachableJointStatic1Entity == kNullEntity) {
+      tracker->detachableJointStatic1Entity =
+          this->MakeStatic(tracker->connection1LinkEntity, true, _ecm);
+    }
+
+    if (tracker->end0Inserted && tracker->end1Inserted &&
+        !tracker->isCompleted) {
+      tracker->isCompleted = true;
+      this->MakeCableStatic(i, _ecm);
+      gzmsg << "Cable " << this->cableConfigs[i].modelName << " fully inserted."
             << std::endl;
-      this->cableState = CableState::COMPLETED;
     }
   }
 }
 
 //////////////////////////////////////////////////
-void CableModeratorPlugin::Update(const gz::sim::UpdateInfo& /*_info*/,
-                                  gz::sim::EntityComponentManager& /*_ecm*/) {}
-
-//////////////////////////////////////////////////
-void CableModeratorPlugin::PostUpdate(
-    const gz::sim::UpdateInfo& /*_info*/,
-    const gz::sim::EntityComponentManager& /*_ecm*/) {}
-
-//////////////////////////////////////////////////
-void CableModeratorPlugin::Reset(const gz::sim::UpdateInfo& /*_info*/,
-                                 gz::sim::EntityComponentManager& /*_ecm*/) {
+void CableModeratorPlugin::Update(const gz::sim::UpdateInfo&,
+                                  gz::sim::EntityComponentManager&) {}
+void CableModeratorPlugin::PostUpdate(const gz::sim::UpdateInfo&,
+                                      const gz::sim::EntityComponentManager&) {}
+void CableModeratorPlugin::Reset(const gz::sim::UpdateInfo&,
+                                 gz::sim::EntityComponentManager&) {
   gzdbg << "aic_gazebo::CableModeratorPlugin::Reset" << std::endl;
-}
-
-//////////////////////////////////////////////////
-void CableModeratorPlugin::Cleanup(gz::sim::EntityComponentManager& _ecm) {
-  // TODO(luca) reinstate, should probably iterate over all cables
-  /*
-  if (this->detachableJointStatic0Entity != kNullEntity)
-    _ecm.RequestRemoveEntity(this->detachableJointStatic0Entity);
-  if (this->detachableJointStatic1Entity != kNullEntity)
-    _ecm.RequestRemoveEntity(this->detachableJointStatic1Entity);
-  */
-
-  for (const auto& ent : this->staticEntities) {
-    if (ent != kNullEntity) {
-      _ecm.RequestRemoveEntity(ent);
-    }
-  }
-
-  this->staticEntities.clear();
 }
 
 //////////////////////////////////////////////////
@@ -468,15 +438,12 @@ Entity CableModeratorPlugin::MakeStatic(Entity _entity,
 
 //////////////////////////////////////////////////
 Entity CableModeratorPlugin::FindGripperJoint(
-    gz::sim::Entity _connectionLinkEntity,
-    const gz::sim::EntityComponentManager& _ecm) const {
+    Entity _connectionLinkEntity, const EntityComponentManager& _ecm) const {
   Entity result = kNullEntity;
   _ecm.Each<components::DetachableJoint>(
       [&](const Entity& _entity,
           const components::DetachableJoint* _joint) -> bool {
         const auto& info = _joint->Data();
-        // Check if this joint connects the end-effector to the connection link
-        // (in either parent/child order)
         if ((info.parentLink == this->endEffectorLinkEntity &&
              info.childLink == _connectionLinkEntity) ||
             (info.parentLink == _connectionLinkEntity &&
@@ -491,42 +458,32 @@ Entity CableModeratorPlugin::FindGripperJoint(
 
 //////////////////////////////////////////////////
 Entity CableModeratorPlugin::FindExternalGraspJoint(
-    const gz::sim::EntityComponentManager& _ecm) const {
-  if (this->cableModel.Entity() == kNullEntity) return kNullEntity;
-
-  auto cableLinks = this->cableModel.Links(_ecm);
+    Entity _cableModelEntity, const EntityComponentManager& _ecm) const {
+  if (_cableModelEntity == kNullEntity) return kNullEntity;
+  Model model(_cableModelEntity);
+  auto cableLinks = model.Links(_ecm);
   std::unordered_set<Entity> cableLinkSet(cableLinks.begin(), cableLinks.end());
-
   Entity result = kNullEntity;
   _ecm.Each<components::DetachableJoint>(
       [&](const Entity& _entity,
           const components::DetachableJoint* _joint) -> bool {
         const auto& info = _joint->Data();
-
         bool parentInCable = cableLinkSet.count(info.parentLink) > 0;
         bool childInCable = cableLinkSet.count(info.childLink) > 0;
-
-        // We are looking for a joint between a cable link and a non-cable link
         if (parentInCable != childInCable) {
           Entity externalLink =
               parentInCable ? info.childLink : info.parentLink;
-
-          // Check if this is a plugin-created static hold
-          // These connect to a model containing "__static__"
           auto parentEnt =
               _ecm.Component<components::ParentEntity>(externalLink);
           if (parentEnt) {
             auto modelName =
                 _ecm.Component<components::Name>(parentEnt->Data());
             if (modelName &&
-                modelName->Data().find("__static__") != std::string::npos) {
-              return true;  // Skip plugin-created static holds
-            }
+                modelName->Data().find("__static__") != std::string::npos)
+              return true;
           }
-
-          // If we are here, it's an external joint
           result = _entity;
-          return false;  // Found it
+          return false;
         }
         return true;
       });
@@ -534,118 +491,165 @@ Entity CableModeratorPlugin::FindExternalGraspJoint(
 }
 
 //////////////////////////////////////////////////
-bool CableModeratorPlugin::FindCableModels(
-    const gz::sim::EntityComponentManager& _ecm) {
-  bool allFound = true;
+void CableModeratorPlugin::FindCableModels(const EntityComponentManager& _ecm) {
   for (size_t i = 0; i < this->cableConfigs.size(); ++i) {
-    if (!this->cableTrackers[i].found) {
+    if (!this->cableTrackers[i]->found) {
       auto entitiesMatchingName =
           entitiesFromScopedName(this->cableConfigs[i].modelName, _ecm);
-      if (entitiesMatchingName.size() == 1) {
-        this->cableTrackers[i].modelEntity = *entitiesMatchingName.begin();
-        this->cableTrackers[i].found = true;
-        gzdbg << "Found cable model " << this->cableConfigs[i].modelName
+      if (!entitiesMatchingName.empty()) {
+        Entity modelEntity = *entitiesMatchingName.begin();
+        this->cableTrackers[i]->modelEntity = modelEntity;
+        this->cableTrackers[i]->found = true;
+        Model model(modelEntity);
+        this->cableTrackers[i]->connection0LinkEntity =
+            model.LinkByName(_ecm, this->cableConfigs[i].connection0LinkName);
+        this->cableTrackers[i]->connection1LinkEntity =
+            model.LinkByName(_ecm, this->cableConfigs[i].connection1LinkName);
+        this->MakeCableStatic(i, const_cast<EntityComponentManager&>(_ecm));
+        gzmsg << "Found cable model: " << this->cableConfigs[i].modelName
               << std::endl;
+      }
+    }
+  }
+}
 
-        this->MakeCableStatic(i, const_cast<gz::sim::EntityComponentManager&>(_ecm));
-        gzmsg << "Froze cable " << this->cableConfigs[i].modelName << std::endl;
-      } else {
-        allFound = false;
+//////////////////////////////////////////////////
+void CableModeratorPlugin::CreatePortSubscribers(size_t _cableIndex) {
+  auto& config = this->cableConfigs[_cableIndex];
+  auto& tracker = this->cableTrackers[_cableIndex];
+
+  std::vector<std::string> allTopics;
+  this->node.TopicList(allTopics);
+
+  auto cb = [this, _cableIndex](const gz::msgs::Boolean& _msg,
+                                const gz::transport::MessageInfo& _info,
+                                int end) {
+    if (_msg.data()) {
+      auto& tracker = this->cableTrackers[_cableIndex];
+      // Grasp filter: Only report insertion if this cable is actually being
+      // held
+      if (tracker->activeGraspJoint.load() == kNullEntity) {
+        gzdbg << "Ignoring touch event for "
+              << this->cableConfigs[_cableIndex].modelName << " on port "
+              << _info.Topic() << " (Not grasped)" << std::endl;
+        return;
+      }
+
+      if (end == 0 ? tracker->end0Inserted : tracker->end1Inserted) return;
+      if (end == 0)
+        tracker->end0Inserted = true;
+      else
+        tracker->end1Inserted = true;
+      gzmsg << "Touch event received for "
+            << this->cableConfigs[_cableIndex].modelName << " end " << end
+            << " from topic " << _info.Topic() << std::endl;
+      auto pos = _info.Topic().rfind("/");
+      if (pos != std::string::npos)
+        tracker->touchEventCallbackNamespace = _info.Topic().substr(0, pos);
+      gz::msgs::StringMsg_V pubMsg;
+      pubMsg.add_data(this->cableConfigs[_cableIndex].modelName);
+      pubMsg.add_data(std::to_string(end));
+      pubMsg.add_data(tracker->touchEventCallbackNamespace);
+      this->cableInsertionPub.Publish(pubMsg);
+    }
+  };
+
+  for (const auto& topic : allTopics) {
+    if (topic.find("touched") == std::string::npos) continue;
+
+    if (topic.find(config.connection0PortName) != std::string::npos) {
+      gzmsg << "Subscribing End 0 of " << config.modelName << " to: " << topic
+            << std::endl;
+      tracker->portSubs.emplace_back(this->node.CreateSubscriber(
+          topic,
+          std::function<void(const gz::msgs::Boolean&,
+                             const gz::transport::MessageInfo&)>(
+              std::bind(cb, std::placeholders::_1, std::placeholders::_2, 0))));
+    }
+    if (topic.find(config.connection1PortName) != std::string::npos) {
+      gzmsg << "Subscribing End 1 of " << config.modelName << " to: " << topic
+            << std::endl;
+      tracker->portSubs.emplace_back(this->node.CreateSubscriber(
+          topic,
+          std::function<void(const gz::msgs::Boolean&,
+                             const gz::transport::MessageInfo&)>(
+              std::bind(cb, std::placeholders::_1, std::placeholders::_2, 1))));
+    }
+  }
+}
+
+//////////////////////////////////////////////////
+int CableModeratorPlugin::FindGraspedEnd(
+    size_t _cableIndex, Entity _graspJoint,
+    const EntityComponentManager& _ecm) const {
+  auto& tracker = this->cableTrackers[_cableIndex];
+  auto jointComp = _ecm.Component<components::DetachableJoint>(_graspJoint);
+  if (!jointComp) return -1;
+  const auto& info = jointComp->Data();
+
+  Model model(tracker->modelEntity);
+  auto cableLinks = model.Links(_ecm);
+  std::unordered_set<Entity> cableLinkSet(cableLinks.begin(), cableLinks.end());
+
+  Entity cableLink = cableLinkSet.count(info.parentLink) > 0 ? info.parentLink
+                                                             : info.childLink;
+
+  if (cableLink == tracker->connection0LinkEntity) return 0;
+  if (cableLink == tracker->connection1LinkEntity) return 1;
+
+  // Fallback: Topological distance (link count).
+  // This is used if the gripper attaches to a link that isn't one of the ends.
+  // It builds a graph of the cable's links and performs a BFS to find the
+  // logical distance (number of joints) to each end.
+  std::unordered_map<Entity, std::vector<Entity>> neighbors;
+  for (Entity jointEnt : model.Joints(_ecm)) {
+    // Identify the links connected by this joint by name
+    auto pName = _ecm.Component<components::ParentLinkName>(jointEnt);
+    auto cName = _ecm.Component<components::ChildLinkName>(jointEnt);
+    if (pName && cName) {
+      // Resolve names to entities within the model
+      Entity pEnt = model.LinkByName(_ecm, pName->Data());
+      Entity cEnt = model.LinkByName(_ecm, cName->Data());
+      if (pEnt != kNullEntity && cEnt != kNullEntity) {
+        neighbors[pEnt].push_back(cEnt);
+        neighbors[cEnt].push_back(pEnt);
       }
     }
   }
 
-  return allFound;
-}
+  // Perform BFS to find the shortest topological path to both ends
+  std::unordered_map<Entity, int> dists;
+  std::queue<Entity> q;
+  q.push(cableLink);
+  dists[cableLink] = 0;
 
-//////////////////////////////////////////////////
-void CableModeratorPlugin::CreatePortSubscribers(const std::string& _portName) {
-  std::vector<std::string> allTopics;
-  this->node.TopicList(allTopics);
+  int d0 = -1, d1 = -1;
+  while (!q.empty()) {
+    Entity curr = q.front();
+    q.pop();
+    int d = dists[curr];
 
-  std::function<void(const msgs::Boolean&, const transport::MessageInfo&)>
-      callback = [this](const msgs::Boolean& _msg,
-                        const transport::MessageInfo& _info) {
-        size_t pos = _info.Topic().rfind("/");
-        // TODO(luca) If we only ever receive true boolean messages consider
-        // removing the atomic bool and only having the namespace as a
-        // std::optional
-        // TODO(luca) Protect the namespace with a mutex since it can't be
-        // atomic and it is set in a separate thread.
-        // TODO(luca) Check if we need the namespace at all, it is used to check
-        // if we plugged into the right port but this might be done by another
-        // plugin (scoring)
-        this->touchEventCallbackNamespace = _info.Topic().substr(0, pos);
-        this->attachCableConnectionToPort = _msg.data();
-        gzdbg << "Cable connection touched: " << _msg.data()
-              << ". Topic: " << _info.Topic() << std::endl;
-      };
+    // Check if we've reached either end link
+    if (curr == tracker->connection0LinkEntity) d0 = d;
+    if (curr == tracker->connection1LinkEntity) d1 = d;
 
-  for (const auto& topic : allTopics) {
-    if (topic.find(_portName) != std::string::npos &&
-        topic.find("touched") != std::string::npos) {
-      this->cableConnectionPortSubs.emplace_back(
-          this->node.CreateSubscriber(topic, callback));
+    // Stop early if both ends are found
+    if (d0 != -1 && d1 != -1) break;
+
+    for (Entity next : neighbors[curr]) {
+      if (dists.find(next) == dists.end()) {
+        dists[next] = d + 1;
+        q.push(next);
+      }
     }
   }
-}
 
-//////////////////////////////////////////////////
-bool CableModeratorPlugin::ToggleActiveCable(
-    gz::sim::EntityComponentManager& _ecm) {
-  int nextIndex = this->cableIndex + 1;
-  if (static_cast<std::size_t>(nextIndex) >= this->cableTrackers.size())
-    return false;
+  // If one end is unreachable, assume the other is the closer one
+  if (d0 == -1) return 1;
+  if (d1 == -1) return 0;
 
-  auto& tracker = this->cableTrackers[nextIndex];
-  if (!tracker.found) return false;
-
-  Model model(tracker.modelEntity);
-  const auto& cableModelName = model.Name(_ecm);
-
-  if (!model.Valid(_ecm)) return false;
-
-  const auto& config = this->cableConfigs[nextIndex];
-
-  Entity connection0 =
-      findLinkInModel(cableModelName, config.connection0LinkName, _ecm);
-
-  Entity connection1 =
-      findLinkInModel(cableModelName, config.connection1LinkName, _ecm);
-
-  if (connection0 == kNullEntity || connection1 == kNullEntity) return false;
-
-  tracker.connection0LinkEntity = connection0;
-  tracker.connection1LinkEntity = connection1;
-
-  this->cableModel = model;
-  this->activeGraspJoint = kNullEntity;
-  this->cableIndex = nextIndex;
-
-  // Make sure we unfreeze the newly active cable
-  this->MakeCableDynamic(this->cableIndex, _ecm);
-
-  this->manualGraspSubs.clear();
-
-  auto cbAttach0 = std::function<void(const gz::msgs::Empty&)>(
-      [this](const gz::msgs::Empty&) { this->attachEnd0Requested = true; });
-  auto cbDetach0 = std::function<void(const gz::msgs::Empty&)>(
-      [this](const gz::msgs::Empty&) { this->detachEnd0Requested = true; });
-  auto cbAttach1 = std::function<void(const gz::msgs::Empty&)>(
-      [this](const gz::msgs::Empty&) { this->attachEnd1Requested = true; });
-  auto cbDetach1 = std::function<void(const gz::msgs::Empty&)>(
-      [this](const gz::msgs::Empty&) { this->detachEnd1Requested = true; });
-
-  this->manualGraspSubs.emplace_back(this->node.CreateSubscriber(
-      "/" + cableModelName + "/attach_end_0", cbAttach0));
-  this->manualGraspSubs.emplace_back(this->node.CreateSubscriber(
-      "/" + cableModelName + "/detach_end_0", cbDetach0));
-  this->manualGraspSubs.emplace_back(this->node.CreateSubscriber(
-      "/" + cableModelName + "/attach_end_1", cbAttach1));
-  this->manualGraspSubs.emplace_back(this->node.CreateSubscriber(
-      "/" + cableModelName + "/detach_end_1", cbDetach1));
-
-  return true;
+  // Return the logically closer end
+  return (d0 < d1) ? 0 : 1;
 }
 
 }  // namespace aic_gazebo

--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -247,15 +247,7 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
                                      gz::sim::EntityComponentManager& _ecm) {
   if (this->cableState == CableState::COMPLETED) return;
 
-  if (!this->foundAllCables) {
-    this->foundAllCables = this->FindCableModels(_ecm);
-    if (this->foundAllCables) {
-      for (std::size_t i = 0; i < this->cableTrackers.size(); ++i) {
-        this->MakeCableStatic(i, _ecm);
-        gzmsg << "Froze cable " << this->cableConfigs[i].modelName << std::endl;
-      }
-    }
-  }
+  this->FindCableModels(_ecm);
 
   if (this->endEffectorLinkEntity == kNullEntity) {
     this->endEffectorLinkEntity =
@@ -362,17 +354,13 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
     this->attachCableConnectionToPort = false;
     this->touchEventCallbackNamespace = std::nullopt;
 
-    if (this->cableIndex + 1 < static_cast<int>(this->cableTrackers.size())) {
+    if (static_cast<std::size_t>(this->cableIndex + 1) <
+        this->cableTrackers.size()) {
       // There are more cables to be processed
       if (this->ToggleActiveCable(_ecm)) {
         gzmsg << "Cable transitioning to WAITING_CONN_0 state for next cable."
               << std::endl;
         this->cableState = CableState::WAITING_CONN_0;
-      } else {
-        gzmsg << "Failed to toggle active cable. Transitioning to COMPLETED "
-                 "state."
-              << std::endl;
-        this->cableState = CableState::COMPLETED;
       }
     } else {
       gz::msgs::StringMsg msg;
@@ -558,9 +546,10 @@ bool CableModeratorPlugin::FindCableModels(
         this->cableTrackers[i].found = true;
         gzdbg << "Found cable model " << this->cableConfigs[i].modelName
               << std::endl;
+
+        this->MakeCableStatic(i, const_cast<gz::sim::EntityComponentManager&>(_ecm));
+        gzmsg << "Froze cable " << this->cableConfigs[i].modelName << std::endl;
       } else {
-        // gzwarn << "Cable model " << this->cableConfigs[i].modelName << "
-        // could not be found.\n";
         allFound = false;
       }
     }
@@ -604,28 +593,37 @@ void CableModeratorPlugin::CreatePortSubscribers(const std::string& _portName) {
 //////////////////////////////////////////////////
 bool CableModeratorPlugin::ToggleActiveCable(
     gz::sim::EntityComponentManager& _ecm) {
-  this->cableIndex++;
-  auto& tracker = this->cableTrackers[this->cableIndex];
-  // Make sure we unfreeze the newly active cable
-  this->MakeCableDynamic(this->cableIndex, _ecm);
+  int nextIndex = this->cableIndex + 1;
+  if (static_cast<std::size_t>(nextIndex) >= this->cableTrackers.size())
+    return false;
 
-  this->cableModel = Model(tracker.modelEntity);
-  this->activeGraspJoint = kNullEntity;
-  const auto& cableModelName = this->cableModel.Name(_ecm);
+  auto& tracker = this->cableTrackers[nextIndex];
+  if (!tracker.found) return false;
 
-  if (!this->cableModel.Valid(_ecm)) return false;
+  Model model(tracker.modelEntity);
+  const auto& cableModelName = model.Name(_ecm);
 
-  const auto& config = this->cableConfigs[this->cableIndex];
+  if (!model.Valid(_ecm)) return false;
 
-  tracker.connection0LinkEntity =
+  const auto& config = this->cableConfigs[nextIndex];
+
+  Entity connection0 =
       findLinkInModel(cableModelName, config.connection0LinkName, _ecm);
 
-  tracker.connection1LinkEntity =
+  Entity connection1 =
       findLinkInModel(cableModelName, config.connection1LinkName, _ecm);
 
-  if (tracker.connection0LinkEntity == kNullEntity ||
-      tracker.connection1LinkEntity == kNullEntity)
-    return false;
+  if (connection0 == kNullEntity || connection1 == kNullEntity) return false;
+
+  tracker.connection0LinkEntity = connection0;
+  tracker.connection1LinkEntity = connection1;
+
+  this->cableModel = model;
+  this->activeGraspJoint = kNullEntity;
+  this->cableIndex = nextIndex;
+
+  // Make sure we unfreeze the newly active cable
+  this->MakeCableDynamic(this->cableIndex, _ecm);
 
   this->manualGraspSubs.clear();
 

--- a/aic_gazebo/src/CableModeratorPlugin.hh
+++ b/aic_gazebo/src/CableModeratorPlugin.hh
@@ -21,8 +21,12 @@
 #include <atomic>
 #include <chrono>
 #include <unordered_set>
+#include <vector>
+#include <string>
+#include <memory>
 
 #include <gz/transport/Node.hh>
+#include <gz/msgs/stringmsg_v.pb.h>
 #include <gz/sim/EventManager.hh>
 #include <gz/sim/Model.hh>
 #include <gz/sim/SdfEntityCreator.hh>
@@ -30,35 +34,6 @@
 
 namespace aic_gazebo
 {
-  /// \brief State of the cable
-  enum class CableState {
-    /// \brief Being initialized
-    INITIALIZATION,
-
-    /// \brief Waiting for end effector to approach connection 0
-    WAITING_CONN_0,
-
-    /// \brief Connection 0 attached to gripper, wait for touch
-    ATTACHED_TO_GRIPPER_CONN_0,
-
-    /// \brief Detach connection 0 from gripper, make static
-    ATTACH_TO_PORT_CONN_0,
-
-    /// \brief Waiting for end effector to approach connection 1
-    WAITING_CONN_1,
-
-    /// \brief Connection 1 attached to gripper, wait for touch
-    ATTACHED_TO_GRIPPER_CONN_1,
-
-    /// \brief Detach connection 1 from gripper, make static
-    ATTACH_TO_PORT_CONN_1,
-
-    /// \brief Move to the next cable
-    NEXT_CABLE,
-
-    /// \brief Task complete - cable connections are completed
-    COMPLETED,
-  };
 
   /// \brief Configuration for a cable
   struct CableConfig {
@@ -92,6 +67,33 @@ namespace aic_gazebo
     gz::sim::Entity connection0LinkEntity{gz::sim::kNullEntity};
     /// \brief Connection 1 link entity in the cable model
     gz::sim::Entity connection1LinkEntity{gz::sim::kNullEntity};
+
+    /// \brief Whether connection 0 has been inserted into a port
+    bool end0Inserted{false};
+    /// \brief Whether connection 1 has been inserted into a port
+    bool end1Inserted{false};
+    /// \brief Whether connection 0 insertion has been published
+    bool end0Published{false};
+    /// \brief Whether connection 1 insertion has been published
+    bool end1Published{false};
+    /// \brief Whether the cable task is completed
+    bool isCompleted{false};
+    /// \brief Entity of the detachable joint found while waiting for grasp
+    std::atomic<gz::sim::Entity> activeGraspJoint{gz::sim::kNullEntity};
+    /// \brief Topic namespace from the touched port
+    std::string touchEventCallbackNamespace;
+    /// \brief Which end was last identified as grasped (0, 1, or -1)
+    int lastGraspedEnd{-1};
+    /// \brief Cable connection port subscribers
+    std::vector<gz::transport::Node::Subscriber> portSubs;
+
+    /// \brief Flags for manual attach/detach of connection 0
+    std::atomic<bool> attachEnd0Requested{false};
+    std::atomic<bool> detachEnd0Requested{false};
+
+    /// \brief Flags for manual attach/detach of connection 1
+    std::atomic<bool> attachEnd1Requested{false};
+    std::atomic<bool> detachEnd1Requested{false};
   };
 
   /// \brief Plugin for initializing the cable
@@ -137,6 +139,7 @@ namespace aic_gazebo
 
     /// \brief Make an entity static by spawning a static model and attaching
     /// the entity to a static model
+    /// \param[in] _entity The entity to make static
     /// \param[in] _attachEntityAsParentOfJoint True to attach entity as parent
     /// of the detachable joint.
     /// \param[in] _ecm Entity component manager
@@ -154,10 +157,12 @@ namespace aic_gazebo
         const gz::sim::EntityComponentManager& _ecm) const;
 
     /// \brief Find a detachable joint created by an external plugin that
-    /// connects any link in the current cable model to an external link.
+    /// connects any link in the given cable model to an external link.
+    /// \param[in] _cableModelEntity The cable model entity to check
     /// \param[in] _ecm Entity Component Manager
     /// \return Entity of the grasp joint if found, kNullEntity otherwise
     private: gz::sim::Entity FindExternalGraspJoint(
+        gz::sim::Entity _cableModelEntity,
         const gz::sim::EntityComponentManager& _ecm) const;
 
     /// \brief Process any pending manual attach/detach requests
@@ -165,49 +170,45 @@ namespace aic_gazebo
     private: void ProcessManualGraspRequests(
         gz::sim::EntityComponentManager& _ecm);
 
-    /// \brief Freezes all links in the given cable in place by making them static
+    /// \brief Freezes the cable model by making it static
     /// \param[in] _cableIndex The index of the cable to freeze
     /// \param[in] _ecm Entity Component Manager
-    private: void MakeCableStatic(int _cableIndex,
+    private: void MakeCableStatic(size_t _cableIndex,
         gz::sim::EntityComponentManager& _ecm);
 
-    /// \brief Unfreezes all links in the given cable by removing static joints
+    /// \brief Unfreezes the cable model by making it dynamic
     /// \param[in] _cableIndex The index of the cable to unfreeze
     /// \param[in] _ecm Entity Component Manager
     private: void MakeCableDynamic(size_t _cableIndex,
         gz::sim::EntityComponentManager& _ecm);
 
-    /// \brief Toggle active cable. Done by setting internal vairables to keep
-    /// track of the connection link entities of the next cable in the queue
+    /// \brief Find which end of the cable the gripper is closer to
+    /// \param[in] _cableIndex The index of the cable
+    /// \param[in] _graspJoint The entity of the detachable joint representing the grasp
     /// \param[in] _ecm Entity Component Manager
-    private: bool ToggleActiveCable(
-        gz::sim::EntityComponentManager& _ecm);
+    /// \return 0 for end 0, 1 for end 1, -1 if cannot be determined
+    private: int FindGraspedEnd(size_t _cableIndex, gz::sim::Entity _graspJoint,
+        const gz::sim::EntityComponentManager& _ecm) const;
 
     /// \brief Find Cable model entities based on their names
     /// \param[in] _ecm Entity Component Manager
-    private: bool FindCableModels(const gz::sim::EntityComponentManager& _ecm);
+    private: void FindCableModels(const gz::sim::EntityComponentManager& _ecm);
 
-    /// \brief Initialize port contact subscribers for the given port
-    /// \param[in] _portName The name of the port to subscribe to for contacts
-    private: void CreatePortSubscribers(const std::string& _portName);
+    /// \brief Initialize port contact subscribers for the given cable
+    /// \param[in] _cableIndex The index of the cable to subscribe for
+    private: void CreatePortSubscribers(size_t _cableIndex);
 
     /// \brief Entity of attachment link in the end effector model
     private: gz::sim::Entity endEffectorLinkEntity{gz::sim::kNullEntity};
 
-    /// \brief Entity of the detachable joint found while waiting for grasp
-    private: gz::sim::Entity activeGraspJoint{gz::sim::kNullEntity};
-
     /// \brief A list of cable configurations
     private: std::vector<CableConfig> cableConfigs;
 
-    /// \brief The current active cable model.
-    private: gz::sim::Model cableModel;
-
-    /// \brief Index of the active cable model.
-    private: int cableIndex{-1};
-
     /// \brief State trackers for the cable models
-    private: std::vector<CableTracker> cableTrackers;
+    private: std::vector<std::unique_ptr<CableTracker>> cableTrackers;
+
+    /// \brief Index of the cable currently being manually tested
+    private: int cableIndex{0};
 
     /// \brief Name of the end effector model
     private: std::string endEffectorModelName;
@@ -219,23 +220,8 @@ namespace aic_gazebo
     /// Used for holding cable connections in place
     private: std::unique_ptr<gz::sim::SdfEntityCreator> creator{nullptr};
 
-    /// \brief Current state of the cable
-    private: CableState cableState{CableState::INITIALIZATION};
-
-    /// \brief Cable connection port subscribers
-    private: std::vector<gz::transport::Node::Subscriber>
-        cableConnectionPortSubs;
-
-    /// \brief Task completion event publisher
-    private: gz::transport::Node::Publisher taskCompletionPub;
-
-    /// \brief Whether to attach cable connection to the port
-    /// This is set on cableConnectionPortSub callback
-    private: std::atomic<bool> attachCableConnectionToPort{false};
-
-    /// \brief Topic in which the touch event is received
-    /// This is set on cableConnectionPortSub callback
-    private: std::optional<std::string> touchEventCallbackNamespace;
+    /// \brief Cable insertion event publisher
+    private: gz::transport::Node::Publisher cableInsertionPub;
 
     /// \brief Gazebo transport node
     private: gz::transport::Node node;
@@ -243,17 +229,9 @@ namespace aic_gazebo
     /// \brief Static entities created by this plugin
     private: std::unordered_set<gz::sim::Entity> staticEntities;
 
-    /// \brief Flags for manual attach/detach of connection 0
-    private: std::atomic<bool> attachEnd0Requested{false};
-    private: std::atomic<bool> detachEnd0Requested{false};
-
-    /// \brief Flags for manual attach/detach of connection 1
-    private: std::atomic<bool> attachEnd1Requested{false};
-    private: std::atomic<bool> detachEnd1Requested{false};
-
     /// \brief Manual grasp subscribers
     private: std::vector<gz::transport::Node::Subscriber> manualGraspSubs;
 
-};
+  };
 }
 #endif

--- a/aic_gazebo/src/CableModeratorPlugin.hh
+++ b/aic_gazebo/src/CableModeratorPlugin.hh
@@ -87,6 +87,9 @@ namespace aic_gazebo
     /// \brief Cable connection port subscribers
     std::vector<gz::transport::Node::Subscriber> portSubs;
 
+    /// \brief Topological graph of the cable (link -> neighbor links)
+    std::unordered_map<gz::sim::Entity, std::vector<gz::sim::Entity>> neighbors;
+
     /// \brief Flags for manual attach/detach of connection 0
     std::atomic<bool> attachEnd0Requested{false};
     std::atomic<bool> detachEnd0Requested{false};
@@ -128,10 +131,6 @@ namespace aic_gazebo
     // Documentation inherited
     public: void Reset(const gz::sim::UpdateInfo &_info,
                        gz::sim::EntityComponentManager &_ecm) override;
-
-    /// \brief Check if model entity is removed
-    /// \param[in] _ecm Immutable reference to the Entity Component Manager.
-    private: bool IsModelValid(const gz::sim::EntityComponentManager& _ecm);
 
     /// \brief Clean up entities created by this plugin
     /// \param[in] _ecm Mutable reference to the Entity Component Manager.

--- a/aic_gazebo/src/CableModeratorPlugin.hh
+++ b/aic_gazebo/src/CableModeratorPlugin.hh
@@ -22,11 +22,12 @@
 #include <chrono>
 #include <unordered_set>
 #include <vector>
+#include <deque>
 #include <string>
 #include <memory>
 
 #include <gz/transport/Node.hh>
-#include <gz/msgs/stringmsg_v.pb.h>
+#include <gz/msgs/stringmsg.pb.h>
 #include <gz/sim/EventManager.hh>
 #include <gz/sim/Model.hh>
 #include <gz/sim/SdfEntityCreator.hh>
@@ -82,8 +83,8 @@ namespace aic_gazebo
     std::atomic<gz::sim::Entity> activeGraspJoint{gz::sim::kNullEntity};
     /// \brief Topic namespace from the touched port
     std::string touchEventCallbackNamespace;
-    /// \brief Which end was last identified as grasped (0, 1, or -1)
-    int lastGraspedEnd{-1};
+    /// \brief Which end was last identified as grasped (0, 1)
+    std::optional<int> lastGraspedEnd;
     /// \brief Cable connection port subscribers
     std::vector<gz::transport::Node::Subscriber> portSubs;
 
@@ -157,11 +158,11 @@ namespace aic_gazebo
 
     /// \brief Find a detachable joint created by an external plugin that
     /// connects any link in the given cable model to an external link.
-    /// \param[in] _cableModelEntity The cable model entity to check
+    /// \param[in] _tracker The cable tracker to check
     /// \param[in] _ecm Entity Component Manager
     /// \return Entity of the grasp joint if found, kNullEntity otherwise
     private: gz::sim::Entity FindExternalGraspJoint(
-        gz::sim::Entity _cableModelEntity,
+        const CableTracker& _tracker,
         const gz::sim::EntityComponentManager& _ecm) const;
 
     /// \brief Process any pending manual attach/detach requests
@@ -185,8 +186,9 @@ namespace aic_gazebo
     /// \param[in] _cableIndex The index of the cable
     /// \param[in] _graspJoint The entity of the detachable joint representing the grasp
     /// \param[in] _ecm Entity Component Manager
-    /// \return 0 for end 0, 1 for end 1, -1 if cannot be determined
-    private: int FindGraspedEnd(size_t _cableIndex, gz::sim::Entity _graspJoint,
+    /// \return 0 for end 0, 1 for end 1, std::nullopt if cannot be determined
+    private: std::optional<int> FindGraspedEnd(size_t _cableIndex,
+        gz::sim::Entity _graspJoint,
         const gz::sim::EntityComponentManager& _ecm) const;
 
     /// \brief Find Cable model entities based on their names
@@ -204,7 +206,7 @@ namespace aic_gazebo
     private: std::vector<CableConfig> cableConfigs;
 
     /// \brief State trackers for the cable models
-    private: std::vector<std::unique_ptr<CableTracker>> cableTrackers;
+    private: std::deque<CableTracker> cableTrackers;
 
     /// \brief Index of the cable currently being manually tested
     private: int cableIndex{0};

--- a/aic_gazebo/src/CableModeratorPlugin.hh
+++ b/aic_gazebo/src/CableModeratorPlugin.hh
@@ -254,8 +254,6 @@ namespace aic_gazebo
     /// \brief Manual grasp subscribers
     private: std::vector<gz::transport::Node::Subscriber> manualGraspSubs;
 
-    /// \brief Flag to indicate if all cable model entities are found.
-    private: bool foundAllCables = false;
 };
 }
 #endif


### PR DESCRIPTION
Updated to support the following requirements:
* any cable can start first. It does not need to be left to right
* any cable end can be inserted first. It does not need to be end 0 then end 1.

This required a major refactor. Changes are:
* Removed state machine since the strict ordering is no longer needed.
* Updated `MakeCableDynamic` and `MakeCableStatic` function to use the new features added in https://github.com/gazebosim/gz-sim/pull/3532. The `aic.repos` are updated to use custom branches with those changes backported. 
   * A cable becomes static when first spawned into the world, and also after insertion completion, i.e. when both ends are inserted.
  * A cable becomes dynamic when it's first grasped by the gripper
* Updated logic to determine when to make a cable active / dynamic. Previously the first cable specified in sdf is the one that's made active first. Now whichever cable that has an external grasp joint is created with its link becomes the active cable.

To test:

Launch world with one cable, 1 NIC Card mount, and 2 SC Ports
```
ros2 launch aic_bringup aic_gz_bringup.launch.py ground_truth:=false spawn_cable:=true attach_cable_to_gripper:=false spawn_task_board:=true nic_card_mount_0_present:=true sc_port_0_present:=true sc_port_1_present:=true launch_rviz:=false  sfp_mount_rail_0_present:=true sc_mount_rail_0_present:=true
```

Spawn a second cable:

```
ros2 launch aic_bringup spawn_cable.launch.py cable_name:=cable_1 cable_type:=sfp_sc_cable_phase_1 cable_x:=0.007617000257607526 cable_y:=-0.19373721480369568 cable_z:=1.2291434873584547 cable_roll:=-2.48609329 cable_pitch:=-1.3863089 cable_yaw:=2.65047282
```

In a seperate terminal monitor for insertion events:

```
gz topic -e -t /cable_moderator/insertion_event
```

Now, start publishing mock event messages to test insertion:

``` bash
# attach cable_0 to gripper
gz topic -t "/cable_0/attach_end_0" -m gz.msgs.Empty -p " "
# insert into nic card mount 0's sfp port 0
gz topic -t "/nic_card_mount_0/sfp_port_0/touched" -m gz.msgs.Boolean -p "data: true"
```

You should see an insertion event in the other terminal

```
data: "cable_0"
data: "0"
data: "/nic_card_mount_0/sfp_port_0"
```

Make sure to detach cable_0 from gripper afterwards

```
gz topic -t "/cable_0/detach_end_0" -m gz.msgs.Empty -p " "
```

Try inserting cable_0 end 1 into the SC port:

```
gz topic -t "/cable_0/attach_end_1" -m gz.msgs.Empty -p " "
gz topic -t "/sc_port_0/sc_port_base/touched" -m gz.msgs.Boolean -p "data: true"
gz topic -t "/cable_0/detach_end_1" -m gz.msgs.Empty -p " "
```

You should see the insertion event:

```
data: "cable_0"
data: "1"
data: "/sc_port_0/sc_port_base"
```


Repeat the test for the cable_1, make sure to insert into different ports:

```bash
# insert cable 1 end 0 ito nic card mount 0 sfp port 1
gz topic -t "/cable_1/attach_end_0" -m gz.msgs.Empty -p " "
gz topic -t "/nic_card_mount_0/sfp_port_1/touched" -m gz.msgs.Boolean -p "data: true"
gz topic -t "/cable_1/detach_end_0" -m gz.msgs.Empty -p " "

# insert cable 1 end 1 into sc port 1
gz topic -t "/cable_1/attach_end_1" -m gz.msgs.Empty -p " "
gz topic -t "/sc_port_1/sc_port_base/touched" -m gz.msgs.Boolean -p "data: true"
gz topic -t "/cable_1/detach_end_1" -m gz.msgs.Empty -p " "

```

You should see the following events:

```
data: "cable_1"
data: "0"
data: "/nic_card_mount_0/sfp_port_1"

data: "cable_1"
data: "1"
data: "/sc_port_1/sc_port_base"

```

Play with different insertion order, e.g. start with cable 1 and end 1 first, etc.