### PR TITLE
Luca/cable order

### DIFF
--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -307,11 +307,17 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
     Entity graspJoint =
         this->FindExternalGraspJoint(tracker.modelEntity, _ecm);
     if (graspJoint != kNullEntity) {
-      int closerEnd = this->FindGraspedEnd(i, graspJoint, _ecm);
+      // Create subscribers if they weren't already.
+      if (tracker.portSubs.empty()) this->CreatePortSubscribers(i);
+
+      auto closerEnd = this->FindGraspedEnd(i, graspJoint, _ecm);
+      if (!closerEnd.has_value()) {
+        gzwarn << "Grasped end not found. Report this" << std::endl;
+      }
       if (tracker.activeGraspJoint.load() == kNullEntity ||
           closerEnd != tracker.lastGraspedEnd) {
         gzmsg << "Cable " << this->cableConfigs[i].modelName
-              << " grasp confirmed near End " << closerEnd
+              << " grasp confirmed near End " << *closerEnd
               << " (joint: " << graspJoint << ")" << std::endl;
         tracker.lastGraspedEnd = closerEnd;
         if (tracker.activeGraspJoint.load() == kNullEntity)
@@ -353,15 +359,11 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
       }
       tracker.activeGraspJoint.store(graspJoint);
     } else {
-      if (tracker.activeGraspJoint.load() != kNullEntity) {
+      if (tracker.activeGraspJoint.exchange(kNullEntity) != kNullEntity) {
         this->MakeCableStatic(i, _ecm);
       }
-      tracker.activeGraspJoint.store(kNullEntity);
       tracker.lastGraspedEnd = -1;
     }
-
-    // Keep searching for port topics until we find at least one (or more)
-    if (tracker.portSubs.empty()) this->CreatePortSubscribers(i);
 
     if (tracker.end0Inserted &&
         tracker.detachableJointStatic0Entity == kNullEntity) {
@@ -380,6 +382,7 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
       this->MakeCableStatic(i, _ecm);
       gzmsg << "Cable " << this->cableConfigs[i].modelName << " fully inserted."
             << std::endl;
+      tracker.portSubs.clear();
     }
   }
 }
@@ -611,12 +614,12 @@ void CableModeratorPlugin::CreatePortSubscribers(size_t _cableIndex) {
 }
 
 //////////////////////////////////////////////////
-int CableModeratorPlugin::FindGraspedEnd(
+std::optional<int> CableModeratorPlugin::FindGraspedEnd(
     size_t _cableIndex, Entity _graspJoint,
     const EntityComponentManager& _ecm) const {
   auto& tracker = this->cableTrackers[_cableIndex];
   auto jointComp = _ecm.Component<components::DetachableJoint>(_graspJoint);
-  if (!jointComp) return -1;
+  if (!jointComp) return std::nullopt;
   const auto& info = jointComp->Data();
 
   Model model(tracker.modelEntity);
@@ -638,18 +641,14 @@ int CableModeratorPlugin::FindGraspedEnd(
   q.push(cableLink);
   dists[cableLink] = 0;
 
-  int d0 = -1, d1 = -1;
   while (!q.empty()) {
     Entity curr = q.front();
     q.pop();
     int d = dists[curr];
 
     // Check if we've reached either end link
-    if (curr == tracker.connection0LinkEntity) d0 = d;
-    if (curr == tracker.connection1LinkEntity) d1 = d;
-
-    // Stop early if both ends are found
-    if (d0 != -1 && d1 != -1) break;
+    if (curr == tracker.connection0LinkEntity) return 0;
+    if (curr == tracker.connection1LinkEntity) return 1;
 
     auto it = tracker.neighbors.find(curr);
     if (it != tracker.neighbors.end()) {
@@ -662,12 +661,8 @@ int CableModeratorPlugin::FindGraspedEnd(
     }
   }
 
-  // If one end is unreachable, assume the other is the closer one
-  if (d0 == -1) return 1;
-  if (d1 == -1) return 0;
-
-  // Return the logically closer end
-  return (d0 < d1) ? 0 : 1;
+  // Failed to find a connection to any link
+  return std::nullopt;
 }
 
 }  // namespace aic_gazebo

--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -137,9 +137,7 @@ void CableModeratorPlugin::Configure(
     cableElem = cableElem->GetNextElement("cable");
   }
 
-  for (size_t i = 0; i < this->cableConfigs.size(); ++i) {
-    this->cableTrackers.push_back(std::make_unique<CableTracker>());
-  }
+  this->cableTrackers.resize(this->cableConfigs.size());
 
   if (_sdf->HasElement("end_effector_model")) {
     this->endEffectorModelName = _sdf->Get<std::string>("end_effector_model");
@@ -166,22 +164,22 @@ void CableModeratorPlugin::Configure(
     this->manualGraspSubs.push_back(this->node.CreateSubscriber(
         prefix + "/attach_end_0", std::function<void(const gz::msgs::Empty&)>(
                                       [&tracker](const gz::msgs::Empty&) {
-                                        tracker->attachEnd0Requested = true;
+                                        tracker.attachEnd0Requested = true;
                                       })));
     this->manualGraspSubs.push_back(this->node.CreateSubscriber(
         prefix + "/detach_end_0", std::function<void(const gz::msgs::Empty&)>(
                                       [&tracker](const gz::msgs::Empty&) {
-                                        tracker->detachEnd0Requested = true;
+                                        tracker.detachEnd0Requested = true;
                                       })));
     this->manualGraspSubs.push_back(this->node.CreateSubscriber(
         prefix + "/attach_end_1", std::function<void(const gz::msgs::Empty&)>(
                                       [&tracker](const gz::msgs::Empty&) {
-                                        tracker->attachEnd1Requested = true;
+                                        tracker.attachEnd1Requested = true;
                                       })));
     this->manualGraspSubs.push_back(this->node.CreateSubscriber(
         prefix + "/detach_end_1", std::function<void(const gz::msgs::Empty&)>(
                                       [&tracker](const gz::msgs::Empty&) {
-                                        tracker->detachEnd1Requested = true;
+                                        tracker.detachEnd1Requested = true;
                                       })));
   }
 }
@@ -191,31 +189,31 @@ void CableModeratorPlugin::ProcessManualGraspRequests(
     gz::sim::EntityComponentManager& _ecm) {
   for (size_t i = 0; i < this->cableTrackers.size(); ++i) {
     auto& tracker = this->cableTrackers[i];
-    if (!tracker->found) continue;
+    if (!tracker.found) continue;
 
-    if (tracker->attachEnd0Requested.exchange(false)) {
+    if (tracker.attachEnd0Requested.exchange(false)) {
       gzdbg << "Received manual attach request for "
             << this->cableConfigs[i].modelName << " end 0" << std::endl;
       if (this->endEffectorLinkEntity == kNullEntity) {
         gzerr << "Cannot attach: End effector link not found yet." << std::endl;
         continue;
       }
-      if (this->FindGripperJoint(tracker->connection0LinkEntity, _ecm) ==
+      if (this->FindGripperJoint(tracker.connection0LinkEntity, _ecm) ==
           kNullEntity) {
         Entity jointEntity = _ecm.CreateEntity();
         _ecm.CreateComponent(jointEntity,
                              components::DetachableJoint(
                                  {this->endEffectorLinkEntity,
-                                  tracker->connection0LinkEntity, "fixed"}));
+                                  tracker.connection0LinkEntity, "fixed"}));
         gzmsg << "Manually attached " << this->cableConfigs[i].modelName
               << " end 0" << std::endl;
       }
     }
-    if (tracker->detachEnd0Requested.exchange(false)) {
+    if (tracker.detachEnd0Requested.exchange(false)) {
       gzdbg << "Received manual detach request for "
             << this->cableConfigs[i].modelName << " end 0" << std::endl;
       Entity gripperJoint =
-          this->FindGripperJoint(tracker->connection0LinkEntity, _ecm);
+          this->FindGripperJoint(tracker.connection0LinkEntity, _ecm);
       if (gripperJoint != kNullEntity) {
         _ecm.RequestRemoveEntity(gripperJoint);
         gzmsg << "Manually detached " << this->cableConfigs[i].modelName
@@ -223,29 +221,29 @@ void CableModeratorPlugin::ProcessManualGraspRequests(
       }
     }
 
-    if (tracker->attachEnd1Requested.exchange(false)) {
+    if (tracker.attachEnd1Requested.exchange(false)) {
       gzdbg << "Received manual attach request for "
             << this->cableConfigs[i].modelName << " end 1" << std::endl;
       if (this->endEffectorLinkEntity == kNullEntity) {
         gzerr << "Cannot attach: End effector link not found yet." << std::endl;
         continue;
       }
-      if (this->FindGripperJoint(tracker->connection1LinkEntity, _ecm) ==
+      if (this->FindGripperJoint(tracker.connection1LinkEntity, _ecm) ==
           kNullEntity) {
         Entity jointEntity = _ecm.CreateEntity();
         _ecm.CreateComponent(jointEntity,
                              components::DetachableJoint(
                                  {this->endEffectorLinkEntity,
-                                  tracker->connection1LinkEntity, "fixed"}));
+                                  tracker.connection1LinkEntity, "fixed"}));
         gzmsg << "Manually attached " << this->cableConfigs[i].modelName
               << " end 1" << std::endl;
       }
     }
-    if (tracker->detachEnd1Requested.exchange(false)) {
+    if (tracker.detachEnd1Requested.exchange(false)) {
       gzdbg << "Received manual detach request for "
             << this->cableConfigs[i].modelName << " end 1" << std::endl;
       Entity gripperJoint =
-          this->FindGripperJoint(tracker->connection1LinkEntity, _ecm);
+          this->FindGripperJoint(tracker.connection1LinkEntity, _ecm);
       if (gripperJoint != kNullEntity) {
         _ecm.RequestRemoveEntity(gripperJoint);
         gzmsg << "Manually detached " << this->cableConfigs[i].modelName
@@ -259,15 +257,15 @@ void CableModeratorPlugin::ProcessManualGraspRequests(
 void CableModeratorPlugin::MakeCableStatic(
     size_t _cableIndex, gz::sim::EntityComponentManager& _ecm) {
   auto& tracker = this->cableTrackers[_cableIndex];
-  Model(tracker->modelEntity).SetStatic(_ecm, true);
+  Model(tracker.modelEntity).SetStatic(_ecm, true);
 
-  if (tracker->detachableJointStatic0Entity != kNullEntity) {
-    _ecm.RequestRemoveEntity(tracker->detachableJointStatic0Entity);
-    tracker->detachableJointStatic0Entity = kNullEntity;
+  if (tracker.detachableJointStatic0Entity != kNullEntity) {
+    _ecm.RequestRemoveEntity(tracker.detachableJointStatic0Entity);
+    tracker.detachableJointStatic0Entity = kNullEntity;
   }
-  if (tracker->detachableJointStatic1Entity != kNullEntity) {
-    _ecm.RequestRemoveEntity(tracker->detachableJointStatic1Entity);
-    tracker->detachableJointStatic1Entity = kNullEntity;
+  if (tracker.detachableJointStatic1Entity != kNullEntity) {
+    _ecm.RequestRemoveEntity(tracker.detachableJointStatic1Entity);
+    tracker.detachableJointStatic1Entity = kNullEntity;
   }
 }
 
@@ -275,7 +273,7 @@ void CableModeratorPlugin::MakeCableStatic(
 void CableModeratorPlugin::MakeCableDynamic(
     size_t _cableIndex, gz::sim::EntityComponentManager& _ecm) {
   auto& tracker = this->cableTrackers[_cableIndex];
-  Model(tracker->modelEntity).SetStatic(_ecm, false);
+  Model(tracker.modelEntity).SetStatic(_ecm, false);
 }
 
 //////////////////////////////////////////////////
@@ -305,80 +303,80 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
 
   for (size_t i = 0; i < this->cableTrackers.size(); ++i) {
     auto& tracker = this->cableTrackers[i];
-    if (!tracker->found || tracker->isCompleted) continue;
+    if (!tracker.found || tracker.isCompleted) continue;
     Entity graspJoint =
-        this->FindExternalGraspJoint(tracker->modelEntity, _ecm);
+        this->FindExternalGraspJoint(tracker.modelEntity, _ecm);
     if (graspJoint != kNullEntity) {
       int closerEnd = this->FindGraspedEnd(i, graspJoint, _ecm);
-      if (tracker->activeGraspJoint.load() == kNullEntity ||
-          closerEnd != tracker->lastGraspedEnd) {
+      if (tracker.activeGraspJoint.load() == kNullEntity ||
+          closerEnd != tracker.lastGraspedEnd) {
         gzmsg << "Cable " << this->cableConfigs[i].modelName
               << " grasp confirmed near End " << closerEnd
               << " (joint: " << graspJoint << ")" << std::endl;
-        tracker->lastGraspedEnd = closerEnd;
-        if (tracker->activeGraspJoint.load() == kNullEntity)
+        tracker.lastGraspedEnd = closerEnd;
+        if (tracker.activeGraspJoint.load() == kNullEntity)
           this->MakeCableDynamic(i, _ecm);
       }
 
       if (closerEnd == 0) {
         // Grasping near End 0: Unfreeze End 0 (if not inserted), Ensure End 1
         // is frozen
-        if (!tracker->end0Inserted &&
-            tracker->detachableJointStatic0Entity != kNullEntity) {
-          _ecm.RequestRemoveEntity(tracker->detachableJointStatic0Entity);
-          tracker->detachableJointStatic0Entity = kNullEntity;
+        if (!tracker.end0Inserted &&
+            tracker.detachableJointStatic0Entity != kNullEntity) {
+          _ecm.RequestRemoveEntity(tracker.detachableJointStatic0Entity);
+          tracker.detachableJointStatic0Entity = kNullEntity;
           gzmsg << "Unfreezing End 0 for manipulation." << std::endl;
         }
-        if (!tracker->end1Inserted &&
-            tracker->detachableJointStatic1Entity == kNullEntity) {
-          tracker->detachableJointStatic1Entity =
-              this->MakeStatic(tracker->connection1LinkEntity, true, _ecm);
+        if (!tracker.end1Inserted &&
+            tracker.detachableJointStatic1Entity == kNullEntity) {
+          tracker.detachableJointStatic1Entity =
+              this->MakeStatic(tracker.connection1LinkEntity, true, _ecm);
           gzdbg << "Locking End 1. Resulting joint: "
-                << tracker->detachableJointStatic1Entity << std::endl;
+                << tracker.detachableJointStatic1Entity << std::endl;
         }
       } else {
         // Grasping near End 1: Unfreeze End 1 (if not inserted), Ensure End 0
         // is frozen
-        if (!tracker->end1Inserted &&
-            tracker->detachableJointStatic1Entity != kNullEntity) {
-          _ecm.RequestRemoveEntity(tracker->detachableJointStatic1Entity);
-          tracker->detachableJointStatic1Entity = kNullEntity;
+        if (!tracker.end1Inserted &&
+            tracker.detachableJointStatic1Entity != kNullEntity) {
+          _ecm.RequestRemoveEntity(tracker.detachableJointStatic1Entity);
+          tracker.detachableJointStatic1Entity = kNullEntity;
           gzmsg << "Unfreezing End 1 for manipulation." << std::endl;
         }
-        if (!tracker->end0Inserted &&
-            tracker->detachableJointStatic0Entity == kNullEntity) {
-          tracker->detachableJointStatic0Entity =
-              this->MakeStatic(tracker->connection0LinkEntity, true, _ecm);
+        if (!tracker.end0Inserted &&
+            tracker.detachableJointStatic0Entity == kNullEntity) {
+          tracker.detachableJointStatic0Entity =
+              this->MakeStatic(tracker.connection0LinkEntity, true, _ecm);
           gzdbg << "Locking End 0. Resulting joint: "
-                << tracker->detachableJointStatic0Entity << std::endl;
+                << tracker.detachableJointStatic0Entity << std::endl;
         }
       }
-      tracker->activeGraspJoint.store(graspJoint);
+      tracker.activeGraspJoint.store(graspJoint);
     } else {
-      if (tracker->activeGraspJoint.load() != kNullEntity) {
+      if (tracker.activeGraspJoint.load() != kNullEntity) {
         this->MakeCableStatic(i, _ecm);
       }
-      tracker->activeGraspJoint.store(kNullEntity);
-      tracker->lastGraspedEnd = -1;
+      tracker.activeGraspJoint.store(kNullEntity);
+      tracker.lastGraspedEnd = -1;
     }
 
     // Keep searching for port topics until we find at least one (or more)
-    if (tracker->portSubs.empty()) this->CreatePortSubscribers(i);
+    if (tracker.portSubs.empty()) this->CreatePortSubscribers(i);
 
-    if (tracker->end0Inserted &&
-        tracker->detachableJointStatic0Entity == kNullEntity) {
-      tracker->detachableJointStatic0Entity =
-          this->MakeStatic(tracker->connection0LinkEntity, true, _ecm);
+    if (tracker.end0Inserted &&
+        tracker.detachableJointStatic0Entity == kNullEntity) {
+      tracker.detachableJointStatic0Entity =
+          this->MakeStatic(tracker.connection0LinkEntity, true, _ecm);
     }
-    if (tracker->end1Inserted &&
-        tracker->detachableJointStatic1Entity == kNullEntity) {
-      tracker->detachableJointStatic1Entity =
-          this->MakeStatic(tracker->connection1LinkEntity, true, _ecm);
+    if (tracker.end1Inserted &&
+        tracker.detachableJointStatic1Entity == kNullEntity) {
+      tracker.detachableJointStatic1Entity =
+          this->MakeStatic(tracker.connection1LinkEntity, true, _ecm);
     }
 
-    if (tracker->end0Inserted && tracker->end1Inserted &&
-        !tracker->isCompleted) {
-      tracker->isCompleted = true;
+    if (tracker.end0Inserted && tracker.end1Inserted &&
+        !tracker.isCompleted) {
+      tracker.isCompleted = true;
       this->MakeCableStatic(i, _ecm);
       gzmsg << "Cable " << this->cableConfigs[i].modelName << " fully inserted."
             << std::endl;
@@ -511,17 +509,17 @@ Entity CableModeratorPlugin::FindExternalGraspJoint(
 //////////////////////////////////////////////////
 void CableModeratorPlugin::FindCableModels(const EntityComponentManager& _ecm) {
   for (size_t i = 0; i < this->cableConfigs.size(); ++i) {
-    if (!this->cableTrackers[i]->found) {
+    if (!this->cableTrackers[i].found) {
       auto entitiesMatchingName =
           entitiesFromScopedName(this->cableConfigs[i].modelName, _ecm);
       if (!entitiesMatchingName.empty()) {
         Entity modelEntity = *entitiesMatchingName.begin();
-        this->cableTrackers[i]->modelEntity = modelEntity;
-        this->cableTrackers[i]->found = true;
+        this->cableTrackers[i].modelEntity = modelEntity;
+        this->cableTrackers[i].found = true;
         Model model(modelEntity);
-        this->cableTrackers[i]->connection0LinkEntity =
+        this->cableTrackers[i].connection0LinkEntity =
             model.LinkByName(_ecm, this->cableConfigs[i].connection0LinkName);
-        this->cableTrackers[i]->connection1LinkEntity =
+        this->cableTrackers[i].connection1LinkEntity =
             model.LinkByName(_ecm, this->cableConfigs[i].connection1LinkName);
 
         // Build the topological graph of the cable
@@ -532,8 +530,8 @@ void CableModeratorPlugin::FindCableModels(const EntityComponentManager& _ecm) {
             Entity pEnt = model.LinkByName(_ecm, pName->Data());
             Entity cEnt = model.LinkByName(_ecm, cName->Data());
             if (pEnt != kNullEntity && cEnt != kNullEntity) {
-              this->cableTrackers[i]->neighbors[pEnt].push_back(cEnt);
-              this->cableTrackers[i]->neighbors[cEnt].push_back(pEnt);
+              this->cableTrackers[i].neighbors[pEnt].push_back(cEnt);
+              this->cableTrackers[i].neighbors[cEnt].push_back(pEnt);
             }
           }
         }
@@ -561,28 +559,28 @@ void CableModeratorPlugin::CreatePortSubscribers(size_t _cableIndex) {
       auto& tracker = this->cableTrackers[_cableIndex];
       // Grasp filter: Only report insertion if this cable is actually being
       // held
-      if (tracker->activeGraspJoint.load() == kNullEntity) {
+      if (tracker.activeGraspJoint.load() == kNullEntity) {
         gzdbg << "Ignoring touch event for "
               << this->cableConfigs[_cableIndex].modelName << " on port "
               << _info.Topic() << " (Not grasped)" << std::endl;
         return;
       }
 
-      if (end == 0 ? tracker->end0Inserted : tracker->end1Inserted) return;
+      if (end == 0 ? tracker.end0Inserted : tracker.end1Inserted) return;
       if (end == 0)
-        tracker->end0Inserted = true;
+        tracker.end0Inserted = true;
       else
-        tracker->end1Inserted = true;
+        tracker.end1Inserted = true;
       gzmsg << "Touch event received for "
             << this->cableConfigs[_cableIndex].modelName << " end " << end
             << " from topic " << _info.Topic() << std::endl;
       auto pos = _info.Topic().rfind("/");
       if (pos != std::string::npos)
-        tracker->touchEventCallbackNamespace = _info.Topic().substr(0, pos);
+        tracker.touchEventCallbackNamespace = _info.Topic().substr(0, pos);
       gz::msgs::StringMsg_V pubMsg;
       pubMsg.add_data(this->cableConfigs[_cableIndex].modelName);
       pubMsg.add_data(std::to_string(end));
-      pubMsg.add_data(tracker->touchEventCallbackNamespace);
+      pubMsg.add_data(tracker.touchEventCallbackNamespace);
       this->cableInsertionPub.Publish(pubMsg);
     }
   };
@@ -593,7 +591,7 @@ void CableModeratorPlugin::CreatePortSubscribers(size_t _cableIndex) {
     if (topic.find(config.connection0PortName) != std::string::npos) {
       gzmsg << "Subscribing End 0 of " << config.modelName << " to: " << topic
             << std::endl;
-      tracker->portSubs.emplace_back(this->node.CreateSubscriber(
+      tracker.portSubs.emplace_back(this->node.CreateSubscriber(
           topic,
           std::function<void(const gz::msgs::Boolean&,
                              const gz::transport::MessageInfo&)>(
@@ -602,7 +600,7 @@ void CableModeratorPlugin::CreatePortSubscribers(size_t _cableIndex) {
     if (topic.find(config.connection1PortName) != std::string::npos) {
       gzmsg << "Subscribing End 1 of " << config.modelName << " to: " << topic
             << std::endl;
-      tracker->portSubs.emplace_back(this->node.CreateSubscriber(
+      tracker.portSubs.emplace_back(this->node.CreateSubscriber(
           topic,
           std::function<void(const gz::msgs::Boolean&,
                              const gz::transport::MessageInfo&)>(
@@ -620,15 +618,15 @@ int CableModeratorPlugin::FindGraspedEnd(
   if (!jointComp) return -1;
   const auto& info = jointComp->Data();
 
-  Model model(tracker->modelEntity);
+  Model model(tracker.modelEntity);
   auto cableLinks = model.Links(_ecm);
   std::unordered_set<Entity> cableLinkSet(cableLinks.begin(), cableLinks.end());
 
   Entity cableLink = cableLinkSet.count(info.parentLink) > 0 ? info.parentLink
                                                              : info.childLink;
 
-  if (cableLink == tracker->connection0LinkEntity) return 0;
-  if (cableLink == tracker->connection1LinkEntity) return 1;
+  if (cableLink == tracker.connection0LinkEntity) return 0;
+  if (cableLink == tracker.connection1LinkEntity) return 1;
 
   // Fallback: Topological distance (link count).
   // This is used if the gripper attaches to a link that isn't one of the ends.
@@ -646,14 +644,14 @@ int CableModeratorPlugin::FindGraspedEnd(
     int d = dists[curr];
 
     // Check if we've reached either end link
-    if (curr == tracker->connection0LinkEntity) d0 = d;
-    if (curr == tracker->connection1LinkEntity) d1 = d;
+    if (curr == tracker.connection0LinkEntity) d0 = d;
+    if (curr == tracker.connection1LinkEntity) d1 = d;
 
     // Stop early if both ends are found
     if (d0 != -1 && d1 != -1) break;
 
-    auto it = tracker->neighbors.find(curr);
-    if (it != tracker->neighbors.end()) {
+    auto it = tracker.neighbors.find(curr);
+    if (it != tracker.neighbors.end()) {
       for (Entity next : it->second) {
         if (dists.find(next) == dists.end()) {
           dists[next] = d + 1;

--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -558,8 +558,9 @@ void CableModeratorPlugin::CreatePortSubscribers(size_t _cableIndex) {
     if (_msg.data()) {
       auto& tracker = this->cableTrackers[_cableIndex];
       // Grasp filter: Only report insertion if this cable is actually being
-      // held
-      if (tracker.activeGraspJoint.load() == kNullEntity) {
+      // held and the touch plugin reported touch on the grasped end
+      if (tracker.activeGraspJoint.load() == kNullEntity
+          || tracker.lastGraspedEnd != end) {
         gzdbg << "Ignoring touch event for "
               << this->cableConfigs[_cableIndex].modelName << " on port "
               << _info.Topic() << " (Not grasped)" << std::endl;

--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -313,6 +313,7 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
       auto closerEnd = this->FindGraspedEnd(i, graspJoint, _ecm);
       if (!closerEnd.has_value()) {
         gzwarn << "Grasped end not found. Report this" << std::endl;
+        continue;
       }
       if (tracker.activeGraspJoint.load() == kNullEntity ||
           closerEnd != tracker.lastGraspedEnd) {
@@ -362,7 +363,7 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
       if (tracker.activeGraspJoint.exchange(kNullEntity) != kNullEntity) {
         this->MakeCableStatic(i, _ecm);
       }
-      tracker.lastGraspedEnd = -1;
+      tracker.lastGraspedEnd = std::nullopt;
     }
 
     if (tracker.end0Inserted &&

--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -590,26 +590,25 @@ void CableModeratorPlugin::CreatePortSubscribers(size_t _cableIndex) {
     }
   };
 
+  auto subscribe = [this, &config, &tracker, cb](const std::string& _topic,
+                                                 int _end) {
+    gzmsg << "Subscribing End " << _end << " of " << config.modelName
+      << " to: " << _topic << std::endl;
+    tracker.portSubs.emplace_back(this->node.CreateSubscriber(
+      _topic,
+      std::function<void(const gz::msgs::Boolean&,
+                         const gz::transport::MessageInfo&)>(
+          std::bind(cb, std::placeholders::_1, std::placeholders::_2, _end))));
+  };
+
   for (const auto& topic : allTopics) {
     if (topic.find("touched") == std::string::npos) continue;
 
     if (topic.find(config.connection0PortName) != std::string::npos) {
-      gzmsg << "Subscribing End 0 of " << config.modelName << " to: " << topic
-            << std::endl;
-      tracker.portSubs.emplace_back(this->node.CreateSubscriber(
-          topic,
-          std::function<void(const gz::msgs::Boolean&,
-                             const gz::transport::MessageInfo&)>(
-              std::bind(cb, std::placeholders::_1, std::placeholders::_2, 0))));
+      subscribe(topic, 0);
     }
     if (topic.find(config.connection1PortName) != std::string::npos) {
-      gzmsg << "Subscribing End 1 of " << config.modelName << " to: " << topic
-            << std::endl;
-      tracker.portSubs.emplace_back(this->node.CreateSubscriber(
-          topic,
-          std::function<void(const gz::msgs::Boolean&,
-                             const gz::transport::MessageInfo&)>(
-              std::bind(cb, std::placeholders::_1, std::placeholders::_2, 1))));
+      subscribe(topic, 1);
     }
   }
 }

--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -304,7 +304,7 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
   for (size_t i = 0; i < this->cableTrackers.size(); ++i) {
     auto& tracker = this->cableTrackers[i];
     if (!tracker.found || tracker.isCompleted) continue;
-    Entity graspJoint = this->FindExternalGraspJoint(tracker.modelEntity, _ecm);
+    Entity graspJoint = this->FindExternalGraspJoint(tracker, _ecm);
     if (graspJoint != kNullEntity) {
       // Create subscribers if they weren't already.
       if (tracker.portSubs.empty()) this->CreatePortSubscribers(i);
@@ -476,18 +476,14 @@ Entity CableModeratorPlugin::FindGripperJoint(
 
 //////////////////////////////////////////////////
 Entity CableModeratorPlugin::FindExternalGraspJoint(
-    Entity _cableModelEntity, const EntityComponentManager& _ecm) const {
-  if (_cableModelEntity == kNullEntity) return kNullEntity;
-  Model model(_cableModelEntity);
-  auto cableLinks = model.Links(_ecm);
-  std::unordered_set<Entity> cableLinkSet(cableLinks.begin(), cableLinks.end());
+    const CableTracker& _tracker, const EntityComponentManager& _ecm) const {
   Entity result = kNullEntity;
   _ecm.Each<components::DetachableJoint>(
       [&](const Entity& _entity,
           const components::DetachableJoint* _joint) -> bool {
         const auto& info = _joint->Data();
-        bool parentInCable = cableLinkSet.count(info.parentLink) > 0;
-        bool childInCable = cableLinkSet.count(info.childLink) > 0;
+        bool parentInCable = _tracker.neighbors.count(info.parentLink) > 0;
+        bool childInCable = _tracker.neighbors.count(info.childLink) > 0;
         if (parentInCable != childInCable) {
           Entity externalLink =
               parentInCable ? info.childLink : info.parentLink;
@@ -620,12 +616,9 @@ std::optional<int> CableModeratorPlugin::FindGraspedEnd(
   if (!jointComp) return std::nullopt;
   const auto& info = jointComp->Data();
 
-  Model model(tracker.modelEntity);
-  auto cableLinks = model.Links(_ecm);
-  std::unordered_set<Entity> cableLinkSet(cableLinks.begin(), cableLinks.end());
-
-  Entity cableLink = cableLinkSet.count(info.parentLink) > 0 ? info.parentLink
-                                                             : info.childLink;
+  Entity cableLink = tracker.neighbors.count(info.parentLink) > 0
+                         ? info.parentLink
+                         : info.childLink;
 
   if (cableLink == tracker.connection0LinkEntity) return 0;
   if (cableLink == tracker.connection1LinkEntity) return 1;

--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -304,8 +304,7 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
   for (size_t i = 0; i < this->cableTrackers.size(); ++i) {
     auto& tracker = this->cableTrackers[i];
     if (!tracker.found || tracker.isCompleted) continue;
-    Entity graspJoint =
-        this->FindExternalGraspJoint(tracker.modelEntity, _ecm);
+    Entity graspJoint = this->FindExternalGraspJoint(tracker.modelEntity, _ecm);
     if (graspJoint != kNullEntity) {
       // Create subscribers if they weren't already.
       if (tracker.portSubs.empty()) this->CreatePortSubscribers(i);
@@ -377,8 +376,7 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
           this->MakeStatic(tracker.connection1LinkEntity, true, _ecm);
     }
 
-    if (tracker.end0Inserted && tracker.end1Inserted &&
-        !tracker.isCompleted) {
+    if (tracker.end0Inserted && tracker.end1Inserted && !tracker.isCompleted) {
       tracker.isCompleted = true;
       this->MakeCableStatic(i, _ecm);
       gzmsg << "Cable " << this->cableConfigs[i].modelName << " fully inserted."
@@ -563,8 +561,8 @@ void CableModeratorPlugin::CreatePortSubscribers(size_t _cableIndex) {
       auto& tracker = this->cableTrackers[_cableIndex];
       // Grasp filter: Only report insertion if this cable is actually being
       // held and the touch plugin reported touch on the grasped end
-      if (tracker.activeGraspJoint.load() == kNullEntity
-          || tracker.lastGraspedEnd != end) {
+      if (tracker.activeGraspJoint.load() == kNullEntity ||
+          tracker.lastGraspedEnd != end) {
         gzdbg << "Ignoring touch event for "
               << this->cableConfigs[_cableIndex].modelName << " on port "
               << _info.Topic() << " (Not grasped)" << std::endl;
@@ -593,12 +591,12 @@ void CableModeratorPlugin::CreatePortSubscribers(size_t _cableIndex) {
   auto subscribe = [this, &config, &tracker, cb](const std::string& _topic,
                                                  int _end) {
     gzmsg << "Subscribing End " << _end << " of " << config.modelName
-      << " to: " << _topic << std::endl;
+          << " to: " << _topic << std::endl;
     tracker.portSubs.emplace_back(this->node.CreateSubscriber(
-      _topic,
-      std::function<void(const gz::msgs::Boolean&,
-                         const gz::transport::MessageInfo&)>(
-          std::bind(cb, std::placeholders::_1, std::placeholders::_2, _end))));
+        _topic, std::function<void(const gz::msgs::Boolean&,
+                                   const gz::transport::MessageInfo&)>(
+                    std::bind(cb, std::placeholders::_1, std::placeholders::_2,
+                              _end))));
   };
 
   for (const auto& topic : allTopics) {

--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -152,7 +152,7 @@ void CableModeratorPlugin::Configure(
 
   this->creator = std::make_unique<SdfEntityCreator>(_ecm, _eventManager);
 
-  this->cableInsertionPub = this->node.Advertise<gz::msgs::StringMsg_V>(
+  this->cableInsertionPub = this->node.Advertise<gz::msgs::StringMsg>(
       "/cable_moderator/insertion_event");
 
   // Manual grasp subscribers for all cables
@@ -576,10 +576,10 @@ void CableModeratorPlugin::CreatePortSubscribers(size_t _cableIndex) {
       auto pos = _info.Topic().rfind("/");
       if (pos != std::string::npos)
         tracker.touchEventCallbackNamespace = _info.Topic().substr(0, pos);
-      gz::msgs::StringMsg_V pubMsg;
-      pubMsg.add_data(this->cableConfigs[_cableIndex].modelName);
-      pubMsg.add_data(std::to_string(end));
-      pubMsg.add_data(tracker.touchEventCallbackNamespace);
+      gz::msgs::StringMsg pubMsg;
+      pubMsg.set_data(this->cableConfigs[_cableIndex].modelName + "#" +
+                      std::to_string(end) + "#" +
+                      tracker.touchEventCallbackNamespace);
       this->cableInsertionPub.Publish(pubMsg);
     }
   };

--- a/aic_gazebo/src/CableModeratorPlugin.hh
+++ b/aic_gazebo/src/CableModeratorPlugin.hh
@@ -158,11 +158,11 @@ namespace aic_gazebo
 
     /// \brief Find a detachable joint created by an external plugin that
     /// connects any link in the given cable model to an external link.
-    /// \param[in] _cableModelEntity The cable model entity to check
+    /// \param[in] _tracker The cable tracker to check
     /// \param[in] _ecm Entity Component Manager
     /// \return Entity of the grasp joint if found, kNullEntity otherwise
     private: gz::sim::Entity FindExternalGraspJoint(
-        gz::sim::Entity _cableModelEntity,
+        const CableTracker& _tracker,
         const gz::sim::EntityComponentManager& _ecm) const;
 
     /// \brief Process any pending manual attach/detach requests

--- a/aic_gazebo/src/CableModeratorPlugin.hh
+++ b/aic_gazebo/src/CableModeratorPlugin.hh
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <unordered_set>
 #include <vector>
+#include <deque>
 #include <string>
 #include <memory>
 
@@ -204,7 +205,7 @@ namespace aic_gazebo
     private: std::vector<CableConfig> cableConfigs;
 
     /// \brief State trackers for the cable models
-    private: std::vector<std::unique_ptr<CableTracker>> cableTrackers;
+    private: std::deque<CableTracker> cableTrackers;
 
     /// \brief Index of the cable currently being manually tested
     private: int cableIndex{0};

--- a/aic_gazebo/src/CableModeratorPlugin.hh
+++ b/aic_gazebo/src/CableModeratorPlugin.hh
@@ -27,7 +27,7 @@
 #include <memory>
 
 #include <gz/transport/Node.hh>
-#include <gz/msgs/stringmsg_v.pb.h>
+#include <gz/msgs/stringmsg.pb.h>
 #include <gz/sim/EventManager.hh>
 #include <gz/sim/Model.hh>
 #include <gz/sim/SdfEntityCreator.hh>

--- a/aic_gazebo/src/CableModeratorPlugin.hh
+++ b/aic_gazebo/src/CableModeratorPlugin.hh
@@ -83,8 +83,8 @@ namespace aic_gazebo
     std::atomic<gz::sim::Entity> activeGraspJoint{gz::sim::kNullEntity};
     /// \brief Topic namespace from the touched port
     std::string touchEventCallbackNamespace;
-    /// \brief Which end was last identified as grasped (0, 1, or -1)
-    int lastGraspedEnd{-1};
+    /// \brief Which end was last identified as grasped (0, 1)
+    std::optional<int> lastGraspedEnd;
     /// \brief Cable connection port subscribers
     std::vector<gz::transport::Node::Subscriber> portSubs;
 
@@ -186,8 +186,9 @@ namespace aic_gazebo
     /// \param[in] _cableIndex The index of the cable
     /// \param[in] _graspJoint The entity of the detachable joint representing the grasp
     /// \param[in] _ecm Entity Component Manager
-    /// \return 0 for end 0, 1 for end 1, -1 if cannot be determined
-    private: int FindGraspedEnd(size_t _cableIndex, gz::sim::Entity _graspJoint,
+    /// \return 0 for end 0, 1 for end 1, std::nullopt if cannot be determined
+    private: std::optional<int> FindGraspedEnd(size_t _cableIndex,
+        gz::sim::Entity _graspJoint,
         const gz::sim::EntityComponentManager& _ecm) const;
 
     /// \brief Find Cable model entities based on their names


### PR DESCRIPTION
A few minor cleanups:

* Use `deque` so we don't need to change the cableTrackers to wrap pointers (they are guaranteed to not reallocate hence don't throw confusing compile errors when trying to wrap the struct that contains `std::atomic`)
* Refactor duplicated code for subscription creation into shared lambda.
* Early return for BFS algorithm since the first return should be the closest node.
* Remove `cableLinkSet` and just reuse the inner neighbors map that should contain all connected links.
* Only create port subscribers for the cable that has been grasped and cleanup on completion, to reduce the spurious printouts.
* Bumped `gz-math` because the new `gz-sim` requires new hydrodynamics APIs that are not included.

And a few actual logic issues fixed:

* We weren't checking if the right end of the cable was grasped when sending the insertion completion, which means that grasping end 0 but actually triggering a touch event on sc_port (the one for end 1) would have wrongly reported completion.
* Change return value of `FindGraspedEnd` to a `std::optional`. This fixed two potential issues:
  * Failing by returning -1 would actually have put us [in this code path](https://github.com/intrinsic-dev/aic/blob/81db9c44584271810c64e69b9c18e8bfe2b18c3a/aic_gazebo/src/CableModeratorPlugin.cc#L339) that would have triggered insertion success for end 1
  * If (for some reason) both ends are unreachable we would have ended up in [this code path](https://github.com/intrinsic-dev/aic/blob/81db9c44584271810c64e69b9c18e8bfe2b18c3a/aic_gazebo/src/CableModeratorPlugin.cc#L667), again resulting in insertion success for end 1.

I also found out that the `ros_gz_bridge` is unable to convert string vector messages because... There is no string vector message in ROS 2.
I just changed it to an ugly string with `#` as a separator, it's not great but it should work.