### PR TITLE
Make cable dynamic on gripper contact

### DIFF
--- a/aic.repos
+++ b/aic.repos
@@ -95,7 +95,7 @@ repositories:
   gazebo/gz-sim:
     type: git
     url: https://github.com/gazebosim/gz-sim
-    version: 4ca1b44bcce5390bf5962d2af46db6b501907887
+    version: e675e2edd7bc232964d16ab9bf4b27b8755da365
   gazebo/gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui

--- a/aic_description/world/aic.sdf
+++ b/aic_description/world/aic.sdf
@@ -182,7 +182,7 @@
         <cable_connection_1_port>sc_port_base</cable_connection_1_port>
       </cable>
       <end_effector_model>ur5e</end_effector_model>
-      <end_effector_link>ati/tool_link</end_effector_link>
+      <end_effector_link>gripper/hande_finger_link_l</end_effector_link>
     </plugin>
 
 

--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -26,7 +26,10 @@
 #include <gz/sim/Util.hh>
 #include <gz/sim/components/CanonicalLink.hh>
 #include <gz/sim/components/ChildLinkName.hh>
+#include <gz/sim/components/Collision.hh>
+#include <gz/sim/components/ContactSensorData.hh>
 #include <gz/sim/components/DetachableJoint.hh>
+#include <gz/sim/components/JointType.hh>
 #include <gz/sim/components/Link.hh>
 #include <gz/sim/components/Model.hh>
 #include <gz/sim/components/Name.hh>
@@ -36,6 +39,7 @@
 #include <gz/sim/components/World.hh>
 #include <gz/sim/config.hh>
 #include <queue>
+#include <sdf/Joint.hh>
 #include <unordered_map>
 
 using namespace gz;
@@ -258,6 +262,7 @@ void CableModeratorPlugin::ProcessManualGraspRequests(
 void CableModeratorPlugin::MakeCableStatic(
     size_t _cableIndex, gz::sim::EntityComponentManager& _ecm) {
   auto& tracker = this->cableTrackers[_cableIndex];
+  tracker.isDynamic = false;
 #if (GZ_SIM_MAJOR_VERSION == 9 && GZ_SIM_MINOR_VERSION >= 6) ||  \
     (GZ_SIM_MAJOR_VERSION == 10 && GZ_SIM_MINOR_VERSION >= 3) || \
     (GZ_SIM_MAJOR_VERSION > 10)
@@ -284,10 +289,11 @@ void CableModeratorPlugin::MakeCableStatic(
 //////////////////////////////////////////////////
 void CableModeratorPlugin::MakeCableDynamic(
     size_t _cableIndex, gz::sim::EntityComponentManager& _ecm) {
+  auto& tracker = this->cableTrackers[_cableIndex];
+  tracker.isDynamic = true;
 #if (GZ_SIM_MAJOR_VERSION == 9 && GZ_SIM_MINOR_VERSION >= 6) ||  \
     (GZ_SIM_MAJOR_VERSION == 10 && GZ_SIM_MINOR_VERSION >= 3) || \
     (GZ_SIM_MAJOR_VERSION > 10)
-  auto& tracker = this->cableTrackers[_cableIndex];
   Model(tracker.modelEntity).SetStatic(_ecm, false);
 #else
   static bool warnedOnce = false;
@@ -296,7 +302,6 @@ void CableModeratorPlugin::MakeCableDynamic(
            << GZ_SIM_VERSION_FULL << std::endl;
     warnedOnce = true;
   }
-  (void)_cableIndex;
   (void)_ecm;
 #endif
 }
@@ -329,65 +334,135 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
   for (size_t i = 0; i < this->cableTrackers.size(); ++i) {
     auto& tracker = this->cableTrackers[i];
     if (!tracker.found || tracker.isCompleted) continue;
-    Entity graspJoint = this->FindExternalGraspJoint(tracker, _ecm);
-    if (graspJoint != kNullEntity) {
-      // Create subscribers if they weren't already.
-      if (tracker.portSubs.empty()) this->CreatePortSubscribers(i);
 
-      auto closerEnd = this->FindGraspedEnd(i, graspJoint, _ecm);
-      if (!closerEnd.has_value()) {
-        gzwarn << "Grasped end not found. Report this" << std::endl;
-        continue;
-      }
-      if (tracker.activeGraspJoint.load() == kNullEntity ||
-          closerEnd != tracker.lastGraspedEnd) {
-        gzmsg << "Cable " << this->cableConfigs[i].modelName
-              << " grasp confirmed near End " << *closerEnd
-              << " (joint: " << graspJoint << ")" << std::endl;
-        tracker.lastGraspedEnd = closerEnd;
-        if (tracker.activeGraspJoint.load() == kNullEntity)
-          this->MakeCableDynamic(i, _ecm);
-      }
-
-      if (closerEnd == 0) {
-        // Grasping near End 0: Unfreeze End 0 (if not inserted), Ensure End 1
-        // is frozen
-        if (!tracker.end0Inserted &&
-            tracker.detachableJointStatic0Entity != kNullEntity) {
-          _ecm.RequestRemoveEntity(tracker.detachableJointStatic0Entity);
-          tracker.detachableJointStatic0Entity = kNullEntity;
-          gzmsg << "Unfreezing End 0 for manipulation." << std::endl;
+    // Helper lambda: check if a contact involves a gripper/finger link
+    auto hasGripperContact =
+        [&](Entity collisionEnt,
+            const std::unordered_set<Entity>& ownCollisions) -> bool {
+      auto contactComp =
+          _ecm.Component<components::ContactSensorData>(collisionEnt);
+      if (!contactComp) return false;
+      for (const auto& contact : contactComp->Data().contact()) {
+        // Determine which collision in the pair is the "other" (not ours)
+        Entity otherCollision = kNullEntity;
+        Entity c1 = contact.collision1().id();
+        Entity c2 = contact.collision2().id();
+        if (ownCollisions.count(c1) > 0) {
+          otherCollision = c2;
+        } else if (ownCollisions.count(c2) > 0) {
+          otherCollision = c1;
+        } else {
+          continue;
         }
-        if (!tracker.end1Inserted &&
-            tracker.detachableJointStatic1Entity == kNullEntity) {
-          tracker.detachableJointStatic1Entity =
-              this->MakeStatic(tracker.connection1LinkEntity, true, _ecm);
-          gzdbg << "Locking End 1. Resulting joint: "
-                << tracker.detachableJointStatic1Entity << std::endl;
+        // Walk up to the parent link of the other collision
+        auto parentComp =
+            _ecm.Component<components::ParentEntity>(otherCollision);
+        if (!parentComp) continue;
+        auto nameComp = _ecm.Component<components::Name>(parentComp->Data());
+        if (!nameComp) continue;
+        const std::string& linkName = nameComp->Data();
+        if (linkName.find(this->endEffectorLinkName) != std::string::npos) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    bool skipContactCheck =
+        tracker.isDynamic && (tracker.activeGraspJoint.load() != kNullEntity);
+
+    bool end0InContact = false;
+    bool end1InContact = false;
+    int currentContactEnd = -1;
+
+    if (!skipContactCheck) {
+      for (Entity collisionEnt : tracker.end0CollisionEntities) {
+        if (hasGripperContact(collisionEnt, tracker.end0CollisionEntities)) {
+          end0InContact = true;
+          break;
+        }
+      }
+
+      for (Entity collisionEnt : tracker.end1CollisionEntities) {
+        if (hasGripperContact(collisionEnt, tracker.end1CollisionEntities)) {
+          end1InContact = true;
+          break;
+        }
+      }
+
+      if (end0InContact) {
+        currentContactEnd = 0;
+      } else if (end1InContact) {
+        currentContactEnd = 1;
+      }
+
+      if (currentContactEnd != -1) {
+        // Create subscribers if they weren't already.
+        if (tracker.portSubs.empty()) this->CreatePortSubscribers(i);
+
+        int prevContactEnd = tracker.activeContactEnd.load();
+        if (prevContactEnd == -1 || prevContactEnd != currentContactEnd) {
+          gzmsg << "Cable " << this->cableConfigs[i].modelName
+                << " contact confirmed near End " << currentContactEnd
+                << std::endl;
+          tracker.activeContactEnd.store(currentContactEnd);
+          if (prevContactEnd == -1) {
+            this->MakeCableDynamic(i, _ecm);
+          }
+        }
+
+        if (currentContactEnd == 0) {
+          // Grasping near End 0: Unfreeze End 0 (if not inserted), Ensure End 1
+          // is frozen
+          if (!tracker.end0Inserted &&
+              tracker.detachableJointStatic0Entity != kNullEntity) {
+            _ecm.RequestRemoveEntity(tracker.detachableJointStatic0Entity);
+            tracker.detachableJointStatic0Entity = kNullEntity;
+            gzmsg << "Unfreezing End 0 for manipulation." << std::endl;
+          }
+          if (!tracker.end1Inserted &&
+              tracker.detachableJointStatic1Entity == kNullEntity) {
+            tracker.detachableJointStatic1Entity =
+                this->MakeStatic(tracker.connection1LinkEntity, true, _ecm);
+            gzdbg << "Locking End 1. Resulting joint: "
+                  << tracker.detachableJointStatic1Entity << std::endl;
+          }
+        } else {
+          // Grasping near End 1: Unfreeze End 1 (if not inserted), Ensure End 0
+          // is frozen
+          if (!tracker.end1Inserted &&
+              tracker.detachableJointStatic1Entity != kNullEntity) {
+            _ecm.RequestRemoveEntity(tracker.detachableJointStatic1Entity);
+            tracker.detachableJointStatic1Entity = kNullEntity;
+            gzmsg << "Unfreezing End 1 for manipulation." << std::endl;
+          }
+          if (!tracker.end0Inserted &&
+              tracker.detachableJointStatic0Entity == kNullEntity) {
+            tracker.detachableJointStatic0Entity =
+                this->MakeStatic(tracker.connection0LinkEntity, true, _ecm);
+            gzdbg << "Locking End 0. Resulting joint: "
+                  << tracker.detachableJointStatic0Entity << std::endl;
+          }
         }
       } else {
-        // Grasping near End 1: Unfreeze End 1 (if not inserted), Ensure End 0
-        // is frozen
-        if (!tracker.end1Inserted &&
-            tracker.detachableJointStatic1Entity != kNullEntity) {
-          _ecm.RequestRemoveEntity(tracker.detachableJointStatic1Entity);
-          tracker.detachableJointStatic1Entity = kNullEntity;
-          gzmsg << "Unfreezing End 1 for manipulation." << std::endl;
-        }
-        if (!tracker.end0Inserted &&
-            tracker.detachableJointStatic0Entity == kNullEntity) {
-          tracker.detachableJointStatic0Entity =
-              this->MakeStatic(tracker.connection0LinkEntity, true, _ecm);
-          gzdbg << "Locking End 0. Resulting joint: "
-                << tracker.detachableJointStatic0Entity << std::endl;
-        }
+        // Dynamic State Persistence: once made dynamic, keep it dynamic even
+        // without active contact.
+        tracker.activeContactEnd.store(-1);
       }
-      tracker.activeGraspJoint.store(graspJoint);
-    } else {
-      if (tracker.activeGraspJoint.exchange(kNullEntity) != kNullEntity) {
-        this->MakeCableStatic(i, _ecm);
+    }
+
+    if (tracker.isDynamic) {
+      Entity graspJoint = this->FindExternalGraspJoint(tracker, _ecm);
+      if (graspJoint != kNullEntity) {
+        auto closerEnd = this->FindGraspedEnd(i, graspJoint, _ecm);
+        if (closerEnd.has_value()) {
+          tracker.lastGraspedEnd = closerEnd;
+        }
+        tracker.activeGraspJoint.store(graspJoint);
+      } else {
+        tracker.activeGraspJoint.store(kNullEntity);
+        tracker.lastGraspedEnd = std::nullopt;
       }
-      tracker.lastGraspedEnd = std::nullopt;
     }
 
     if (tracker.end0Inserted &&
@@ -501,7 +576,8 @@ Entity CableModeratorPlugin::FindGripperJoint(
 
 //////////////////////////////////////////////////
 Entity CableModeratorPlugin::FindExternalGraspJoint(
-    const CableTracker& _tracker, const EntityComponentManager& _ecm) const {
+    const CableTracker& _tracker,
+    const gz::sim::EntityComponentManager& _ecm) const {
   Entity result = kNullEntity;
   _ecm.Each<components::DetachableJoint>(
       [&](const Entity& _entity,
@@ -518,8 +594,9 @@ Entity CableModeratorPlugin::FindExternalGraspJoint(
             auto modelName =
                 _ecm.Component<components::Name>(parentEnt->Data());
             if (modelName &&
-                modelName->Data().find("__static__") != std::string::npos)
+                modelName->Data().find("__static__") != std::string::npos) {
               return true;
+            }
           }
           result = _entity;
           return false;
@@ -530,7 +607,7 @@ Entity CableModeratorPlugin::FindExternalGraspJoint(
 }
 
 //////////////////////////////////////////////////
-void CableModeratorPlugin::FindCableModels(const EntityComponentManager& _ecm) {
+void CableModeratorPlugin::FindCableModels(EntityComponentManager& _ecm) {
   for (size_t i = 0; i < this->cableConfigs.size(); ++i) {
     if (!this->cableTrackers[i].found) {
       auto entitiesMatchingName =
@@ -559,7 +636,83 @@ void CableModeratorPlugin::FindCableModels(const EntityComponentManager& _ecm) {
           }
         }
 
-        this->MakeCableStatic(i, const_cast<EntityComponentManager&>(_ecm));
+        // Initialize monitored links (connection links and their immediate
+        // fixed neighbors)
+        auto& tracker = this->cableTrackers[i];
+        tracker.end0MonitoredLinks.insert(tracker.connection0LinkEntity);
+        tracker.end1MonitoredLinks.insert(tracker.connection1LinkEntity);
+
+        for (Entity jointEnt : model.Joints(_ecm)) {
+          auto jointTypeComp = _ecm.Component<components::JointType>(jointEnt);
+          if (jointTypeComp && jointTypeComp->Data() == sdf::JointType::FIXED) {
+            auto pName = _ecm.Component<components::ParentLinkName>(jointEnt);
+            auto cName = _ecm.Component<components::ChildLinkName>(jointEnt);
+            if (pName && cName) {
+              Entity pEnt = model.LinkByName(_ecm, pName->Data());
+              Entity cEnt = model.LinkByName(_ecm, cName->Data());
+              if (pEnt != kNullEntity && cEnt != kNullEntity) {
+                if (pEnt == tracker.connection0LinkEntity) {
+                  tracker.end0MonitoredLinks.insert(cEnt);
+                } else if (cEnt == tracker.connection0LinkEntity) {
+                  tracker.end0MonitoredLinks.insert(pEnt);
+                }
+
+                if (pEnt == tracker.connection1LinkEntity) {
+                  tracker.end1MonitoredLinks.insert(cEnt);
+                } else if (cEnt == tracker.connection1LinkEntity) {
+                  tracker.end1MonitoredLinks.insert(pEnt);
+                }
+              }
+            }
+          }
+        }
+
+        // Discover and register collision entities for monitored links
+        _ecm.Each<components::Collision, components::ParentEntity>(
+            [&](const Entity& _collisionEntity, const components::Collision*,
+                const components::ParentEntity* _parentLinkComp) -> bool {
+              Entity linkEntity = _parentLinkComp->Data();
+              if (tracker.end0MonitoredLinks.count(linkEntity) > 0) {
+                tracker.end0CollisionEntities.insert(_collisionEntity);
+                if (!_ecm.EntityHasComponentType(
+                        _collisionEntity,
+                        components::ContactSensorData::typeId)) {
+                  _ecm.CreateComponent(_collisionEntity,
+                                      components::ContactSensorData());
+                  std::string collisionName = std::to_string(_collisionEntity);
+                  if (auto nameComp = _ecm.Component<components::Name>(_collisionEntity)) {
+                    collisionName = nameComp->Data();
+                  }
+                  std::string parentName = std::to_string(linkEntity);
+                  if (auto parentNameComp = _ecm.Component<components::Name>(linkEntity)) {
+                    parentName = parentNameComp->Data();
+                  }
+                  gzdbg << "Enabled contact tracking on End 0 collision: "
+                        << collisionName << " (parent: " << parentName << ")" << std::endl;
+                }
+              } else if (tracker.end1MonitoredLinks.count(linkEntity) > 0) {
+                tracker.end1CollisionEntities.insert(_collisionEntity);
+                if (!_ecm.EntityHasComponentType(
+                        _collisionEntity,
+                        components::ContactSensorData::typeId)) {
+                  _ecm.CreateComponent(_collisionEntity,
+                                      components::ContactSensorData());
+                  std::string collisionName = std::to_string(_collisionEntity);
+                  if (auto nameComp = _ecm.Component<components::Name>(_collisionEntity)) {
+                    collisionName = nameComp->Data();
+                  }
+                  std::string parentName = std::to_string(linkEntity);
+                  if (auto parentNameComp = _ecm.Component<components::Name>(linkEntity)) {
+                    parentName = parentNameComp->Data();
+                  }
+                  gzdbg << "Enabled contact tracking on End 1 collision: "
+                        << collisionName << " (parent: " << parentName << ")" << std::endl;
+                }
+              }
+              return true;
+            });
+
+        this->MakeCableStatic(i, _ecm);
         gzmsg << "Found cable model: " << this->cableConfigs[i].modelName
               << std::endl;
       }

--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -368,87 +368,82 @@ void CableModeratorPlugin::PreUpdate(const gz::sim::UpdateInfo& /*_info*/,
       return false;
     };
 
-    bool skipContactCheck =
-        tracker.isDynamic && (tracker.activeGraspJoint.load() != kNullEntity);
-
     bool end0InContact = false;
     bool end1InContact = false;
     int currentContactEnd = -1;
 
-    if (!skipContactCheck) {
-      for (Entity collisionEnt : tracker.end0CollisionEntities) {
-        if (hasGripperContact(collisionEnt, tracker.end0CollisionEntities)) {
-          end0InContact = true;
-          break;
+    for (Entity collisionEnt : tracker.end0CollisionEntities) {
+      if (hasGripperContact(collisionEnt, tracker.end0CollisionEntities)) {
+        end0InContact = true;
+        break;
+      }
+    }
+
+    for (Entity collisionEnt : tracker.end1CollisionEntities) {
+      if (hasGripperContact(collisionEnt, tracker.end1CollisionEntities)) {
+        end1InContact = true;
+        break;
+      }
+    }
+
+    if (end0InContact) {
+      currentContactEnd = 0;
+    } else if (end1InContact) {
+      currentContactEnd = 1;
+    }
+
+    if (currentContactEnd != -1) {
+      // Create subscribers if they weren't already.
+      if (tracker.portSubs.empty()) this->CreatePortSubscribers(i);
+
+      int prevContactEnd = tracker.activeContactEnd.load();
+      if (prevContactEnd == -1 || prevContactEnd != currentContactEnd) {
+        gzmsg << "Cable " << this->cableConfigs[i].modelName
+              << " contact confirmed near End " << currentContactEnd
+              << std::endl;
+        tracker.activeContactEnd.store(currentContactEnd);
+        if (prevContactEnd == -1) {
+          this->MakeCableDynamic(i, _ecm);
         }
       }
 
-      for (Entity collisionEnt : tracker.end1CollisionEntities) {
-        if (hasGripperContact(collisionEnt, tracker.end1CollisionEntities)) {
-          end1InContact = true;
-          break;
+      if (currentContactEnd == 0) {
+        // Grasping near End 0: Unfreeze End 0 (if not inserted), Ensure End 1
+        // is frozen
+        if (!tracker.end0Inserted &&
+            tracker.detachableJointStatic0Entity != kNullEntity) {
+          _ecm.RequestRemoveEntity(tracker.detachableJointStatic0Entity);
+          tracker.detachableJointStatic0Entity = kNullEntity;
+          gzmsg << "Unfreezing End 0 for manipulation." << std::endl;
         }
-      }
-
-      if (end0InContact) {
-        currentContactEnd = 0;
-      } else if (end1InContact) {
-        currentContactEnd = 1;
-      }
-
-      if (currentContactEnd != -1) {
-        // Create subscribers if they weren't already.
-        if (tracker.portSubs.empty()) this->CreatePortSubscribers(i);
-
-        int prevContactEnd = tracker.activeContactEnd.load();
-        if (prevContactEnd == -1 || prevContactEnd != currentContactEnd) {
-          gzmsg << "Cable " << this->cableConfigs[i].modelName
-                << " contact confirmed near End " << currentContactEnd
-                << std::endl;
-          tracker.activeContactEnd.store(currentContactEnd);
-          if (prevContactEnd == -1) {
-            this->MakeCableDynamic(i, _ecm);
-          }
-        }
-
-        if (currentContactEnd == 0) {
-          // Grasping near End 0: Unfreeze End 0 (if not inserted), Ensure End 1
-          // is frozen
-          if (!tracker.end0Inserted &&
-              tracker.detachableJointStatic0Entity != kNullEntity) {
-            _ecm.RequestRemoveEntity(tracker.detachableJointStatic0Entity);
-            tracker.detachableJointStatic0Entity = kNullEntity;
-            gzmsg << "Unfreezing End 0 for manipulation." << std::endl;
-          }
-          if (!tracker.end1Inserted &&
-              tracker.detachableJointStatic1Entity == kNullEntity) {
-            tracker.detachableJointStatic1Entity =
-                this->MakeStatic(tracker.connection1LinkEntity, true, _ecm);
-            gzdbg << "Locking End 1. Resulting joint: "
-                  << tracker.detachableJointStatic1Entity << std::endl;
-          }
-        } else {
-          // Grasping near End 1: Unfreeze End 1 (if not inserted), Ensure End 0
-          // is frozen
-          if (!tracker.end1Inserted &&
-              tracker.detachableJointStatic1Entity != kNullEntity) {
-            _ecm.RequestRemoveEntity(tracker.detachableJointStatic1Entity);
-            tracker.detachableJointStatic1Entity = kNullEntity;
-            gzmsg << "Unfreezing End 1 for manipulation." << std::endl;
-          }
-          if (!tracker.end0Inserted &&
-              tracker.detachableJointStatic0Entity == kNullEntity) {
-            tracker.detachableJointStatic0Entity =
-                this->MakeStatic(tracker.connection0LinkEntity, true, _ecm);
-            gzdbg << "Locking End 0. Resulting joint: "
-                  << tracker.detachableJointStatic0Entity << std::endl;
-          }
+        if (!tracker.end1Inserted &&
+            tracker.detachableJointStatic1Entity == kNullEntity) {
+          tracker.detachableJointStatic1Entity =
+              this->MakeStatic(tracker.connection1LinkEntity, true, _ecm);
+          gzdbg << "Locking End 1. Resulting joint: "
+                << tracker.detachableJointStatic1Entity << std::endl;
         }
       } else {
-        // Dynamic State Persistence: once made dynamic, keep it dynamic even
-        // without active contact.
-        tracker.activeContactEnd.store(-1);
+        // Grasping near End 1: Unfreeze End 1 (if not inserted), Ensure End 0
+        // is frozen
+        if (!tracker.end1Inserted &&
+            tracker.detachableJointStatic1Entity != kNullEntity) {
+          _ecm.RequestRemoveEntity(tracker.detachableJointStatic1Entity);
+          tracker.detachableJointStatic1Entity = kNullEntity;
+          gzmsg << "Unfreezing End 1 for manipulation." << std::endl;
+        }
+        if (!tracker.end0Inserted &&
+            tracker.detachableJointStatic0Entity == kNullEntity) {
+          tracker.detachableJointStatic0Entity =
+              this->MakeStatic(tracker.connection0LinkEntity, true, _ecm);
+          gzdbg << "Locking End 0. Resulting joint: "
+                << tracker.detachableJointStatic0Entity << std::endl;
+        }
       }
+    } else {
+      // Dynamic State Persistence: once made dynamic, keep it dynamic even
+      // without active contact.
+      tracker.activeContactEnd.store(-1);
     }
 
     if (tracker.isDynamic) {

--- a/aic_gazebo/src/CableModeratorPlugin.cc
+++ b/aic_gazebo/src/CableModeratorPlugin.cc
@@ -673,17 +673,20 @@ void CableModeratorPlugin::FindCableModels(EntityComponentManager& _ecm) {
                         _collisionEntity,
                         components::ContactSensorData::typeId)) {
                   _ecm.CreateComponent(_collisionEntity,
-                                      components::ContactSensorData());
+                                       components::ContactSensorData());
                   std::string collisionName = std::to_string(_collisionEntity);
-                  if (auto nameComp = _ecm.Component<components::Name>(_collisionEntity)) {
+                  if (auto nameComp =
+                          _ecm.Component<components::Name>(_collisionEntity)) {
                     collisionName = nameComp->Data();
                   }
                   std::string parentName = std::to_string(linkEntity);
-                  if (auto parentNameComp = _ecm.Component<components::Name>(linkEntity)) {
+                  if (auto parentNameComp =
+                          _ecm.Component<components::Name>(linkEntity)) {
                     parentName = parentNameComp->Data();
                   }
                   gzdbg << "Enabled contact tracking on End 0 collision: "
-                        << collisionName << " (parent: " << parentName << ")" << std::endl;
+                        << collisionName << " (parent: " << parentName << ")"
+                        << std::endl;
                 }
               } else if (tracker.end1MonitoredLinks.count(linkEntity) > 0) {
                 tracker.end1CollisionEntities.insert(_collisionEntity);
@@ -691,17 +694,20 @@ void CableModeratorPlugin::FindCableModels(EntityComponentManager& _ecm) {
                         _collisionEntity,
                         components::ContactSensorData::typeId)) {
                   _ecm.CreateComponent(_collisionEntity,
-                                      components::ContactSensorData());
+                                       components::ContactSensorData());
                   std::string collisionName = std::to_string(_collisionEntity);
-                  if (auto nameComp = _ecm.Component<components::Name>(_collisionEntity)) {
+                  if (auto nameComp =
+                          _ecm.Component<components::Name>(_collisionEntity)) {
                     collisionName = nameComp->Data();
                   }
                   std::string parentName = std::to_string(linkEntity);
-                  if (auto parentNameComp = _ecm.Component<components::Name>(linkEntity)) {
+                  if (auto parentNameComp =
+                          _ecm.Component<components::Name>(linkEntity)) {
                     parentName = parentNameComp->Data();
                   }
                   gzdbg << "Enabled contact tracking on End 1 collision: "
-                        << collisionName << " (parent: " << parentName << ")" << std::endl;
+                        << collisionName << " (parent: " << parentName << ")"
+                        << std::endl;
                 }
               }
               return true;

--- a/aic_gazebo/src/CableModeratorPlugin.hh
+++ b/aic_gazebo/src/CableModeratorPlugin.hh
@@ -79,12 +79,29 @@ namespace aic_gazebo
     bool end1Published{false};
     /// \brief Whether the cable task is completed
     bool isCompleted{false};
-    /// \brief Entity of the detachable joint found while waiting for grasp
+    /// \brief Thread-safe tracker of the active contact end
+    /// (-1 = none, 0 = End 0, 1 = End 1)
+    std::atomic<int> activeContactEnd{-1};
+    /// \brief Thread-safe tracker of the active grasp joint
     std::atomic<gz::sim::Entity> activeGraspJoint{gz::sim::kNullEntity};
+    /// \brief Cached indicator of which end of the cable is currently grasped
+    std::optional<int> lastGraspedEnd{std::nullopt};
+    /// \brief Flag indicating if the cable is active/dynamic
+    bool isDynamic{false};
     /// \brief Topic namespace from the touched port
     std::string touchEventCallbackNamespace;
-    /// \brief Which end was last identified as grasped (0, 1)
-    std::optional<int> lastGraspedEnd;
+
+    /// \brief Monitored link entities for end 0
+    /// (including connection0LinkEntity and its immediate fixed neighbors)
+    std::unordered_set<gz::sim::Entity> end0MonitoredLinks;
+    /// \brief Monitored link entities for end 1
+    /// (including connection1LinkEntity and its immediate fixed neighbors)
+    std::unordered_set<gz::sim::Entity> end1MonitoredLinks;
+
+    /// \brief Collision entities monitored for End 0
+    std::unordered_set<gz::sim::Entity> end0CollisionEntities;
+    /// \brief Collision entities monitored for End 1
+    std::unordered_set<gz::sim::Entity> end1CollisionEntities;
     /// \brief Cable connection port subscribers
     std::vector<gz::transport::Node::Subscriber> portSubs;
 
@@ -156,11 +173,11 @@ namespace aic_gazebo
         gz::sim::Entity _connectionLinkEntity,
         const gz::sim::EntityComponentManager& _ecm) const;
 
-    /// \brief Find a detachable joint created by an external plugin that
-    /// connects any link in the given cable model to an external link.
-    /// \param[in] _tracker The cable tracker to check
+    /// \brief Find the external detachable joint connecting the end effector
+    /// to any link of the cable.
+    /// \param[in] _tracker The tracker of the cable to check
     /// \param[in] _ecm Entity Component Manager
-    /// \return Entity of the grasp joint if found, kNullEntity otherwise
+    /// \return Entity of the external grasp joint if found, kNullEntity otherwise
     private: gz::sim::Entity FindExternalGraspJoint(
         const CableTracker& _tracker,
         const gz::sim::EntityComponentManager& _ecm) const;
@@ -193,7 +210,7 @@ namespace aic_gazebo
 
     /// \brief Find Cable model entities based on their names
     /// \param[in] _ecm Entity Component Manager
-    private: void FindCableModels(const gz::sim::EntityComponentManager& _ecm);
+    private: void FindCableModels(gz::sim::EntityComponentManager& _ecm);
 
     /// \brief Initialize port contact subscribers for the given cable
     /// \param[in] _cableIndex The index of the cable to subscribe for


### PR DESCRIPTION
Previously the cables are made dynamic when an external grasp joint plugin was detected. This PR changes the CableModeratorPlugin to make a cable dynamic when the plugs come into contact with collisions in the gripper link. 

Reason for this change is that the gripper in flowstate does not grasp anything that is static.

 To test

Note: make sure to first update the gz-sim repo to the new commit so that the plugin can use the new SetStatic API.

1. Launch sim with cable **not** attached to gripper

    ```
    ros2 launch aic_bringup aic_gz_bringup.launch.py ground_truth:=false spawn_cable:=false attach_cable_to_gripper:=false spawn_task_board:=true nic_card_mount_0_present:=true sc_port_0_present:=true sc_port_1_present:=true launch_rviz:=false  sfp_mount_rail_0_present:=true sc_mount_rail_0_present:=true
    ```

1. The cable should initially be static. The SFP module should be very close to the gripper. Use the transform control tool to move it so that it is in contact with the left gripper finger.  Verify that the cable becomes dynamic with the other end (SC plug) still being held in place by a detachable joint.
    * Note I had to remove the ApplyWrench gui plugin in gazebo as sometimes the client crashes when moving the cable with backtrace pointing to this plugin.

1. Insertion events should continue to work. In a separate terminal, monitor the insertion event:

    ```
    gz topic -e -t /cable_moderator/insertion_event
    ````

   Fake events to attach the cable to gripper, insert into port, then detach

    ```
    gz topic -t "/cable_0/attach_end_0" -m gz.msgs.Empty -p " "
    gz topic -t "/nic_card_mount_0/sfp_port_0/touched" -m gz.msgs.Boolean -p "data: true"
    gz topic -t "/cable_0/detach_end_0" -m gz.msgs.Empty -p " 
    ````

    You should see an insertion event in the other terminal

    ```
    data: "cable_0"
    data: "0"
    data: "/nic_card_mount_0/sfp_port_0"
    ```

1. Now test contact between gripper and the SC plugin. The challenge is to use the transform control tool to move so that the SC plug touches the gripper. Once in contact, the SC plug should now falls because the detachable joint is removed.