### PR TITLE
Re-enable more collisions in the SFP-SC plug

### DIFF
--- a/aic_assets/models/sfp_sc_cable_phase_1/model.sdf
+++ b/aic_assets/models/sfp_sc_cable_phase_1/model.sdf
@@ -34,18 +34,6 @@
       <uri>model://cable_base_c_rotated_phase_1</uri>
     </include>
     <include merge="true">
-      <!--
-         Some collisions in LC Plug intersect with gripper fingers on startup
-         Workaround this by removing those collisions.
-      -->
-      <experimental:params>
-        <collision element_id="lc_plug_link::1af02-003-ma2_collider_cylinder" action="remove"/>
-        <collision element_id="lc_plug_link::1af02-003-ma2001_collider_cylinder" action="remove"/>
-        <collision element_id="lc_plug_link::cube_collider_box.002" action="remove"/>
-        <collision element_id="lc_plug_link::cube_collider_box.003" action="remove"/>
-        <collision element_id="lc_plug_link::cube001_collider_box.002" action="remove"/>
-        <collision element_id="lc_plug_link::cube001_collider_box.003" action="remove"/>
-      </experimental:params>
       <uri>model://LC Plug</uri>
       <pose relative_to="cable_connection_0">-0.041 0 0 0 0 1.57079</pose>
     </include>
@@ -55,8 +43,7 @@
     </include>
     <include merge="true">
       <!--
-         Some collisions in SFP Module intersect with gripper fingers on startup
-         Workaround this by removing those collisions.
+         Remove collisions that are not necessary for grasping.
       -->
       <experimental:params>
         <collision element_id="sfp_module_link::port_collider_box" action="remove"/>
@@ -67,14 +54,6 @@
         <collision element_id="sfp_module_link::port_collider_box.005" action="remove"/>
         <collision element_id="sfp_module_link::port_collider_box.006" action="remove"/>
         <collision element_id="sfp_module_link::port_collider_box.007" action="remove"/>
-        <collision element_id="sfp_module_link::latch_collider_box" action="remove"/>
-        <collision element_id="sfp_module_link::latch_collider_box.001" action="remove"/>
-        <collision element_id="sfp_module_link::latch_collider_box.002" action="remove"/>
-        <collision element_id="sfp_module_link::latch_collider_box.003" action="remove"/>
-        <collision element_id="sfp_module_link::head_collider_box" action="remove"/>
-        <collision element_id="sfp_module_link::head_collider_box.001" action="remove"/>
-        <collision element_id="sfp_module_link::head_collider_box.002" action="remove"/>
-        <collision element_id="sfp_module_link::head_collider_box.003" action="remove"/>
       </experimental:params>
       <uri>model://SFP Module</uri>
       <pose relative_to="lc_plug_link">0 0.0384 0 0 3.14159 3.14159</pose>


### PR DESCRIPTION
Cable grasping in phase 1 relies on contact. So we need to bring back more collisions so that the gripper is able to grasp it. The collisions were disabled in quals to avoid colliding with the gripper on startup.

Before: The top portion of the plug does not have collisions (orange visualization)
<img width="656" height="599" alt="Screenshot from 2026-05-21 09-59-44" src="https://github.com/user-attachments/assets/c7a8d99d-6866-4a81-9ebb-bc9a29eb0ce2" />

After: More collisions are now available
<img width="656" height="599" alt="Screenshot from 2026-05-21 10-07-17" src="https://github.com/user-attachments/assets/442cafea-850c-401c-a9ed-59aa4164843a" />
