### PR TITLE
Update SDF with correct finger collision and link names

### DIFF
--- a/aic_assets/models/Robotiq Hand-E/model.sdf
+++ b/aic_assets/models/Robotiq Hand-E/model.sdf
@@ -2,7 +2,18 @@
 <sdf version="1.9">
   <model name="Robotiq Hand-E">
 
-    <link name="hande_base_link">
+    <link name="gripper_body">
+      <inertial>
+        <mass>1</mass>
+        <inertia>
+          <ixx>0.1</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.1</iyy>
+          <iyz>0</iyz>
+          <izz>0.1</izz>
+        </inertia>
+      </inertial>
       <visual name="hande_base_visual">
         <geometry>
           <mesh>
@@ -30,7 +41,18 @@
       </collision>
     </link>
 
-    <link name="hande_finger_link_r">
+    <link name="gripper_finger1">
+      <inertial>
+        <mass>0.2</mass>
+        <inertia>
+          <ixx>0.0001</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.00009</iyy>
+          <iyz>0</iyz>
+          <izz>0.00003</izz>
+        </inertia>
+      </inertial>
       <visual name="hande_finger_visual">
         <geometry>
           <mesh>
@@ -72,9 +94,20 @@
       </collision>
     </link>
 
-    <link name="hande_finger_link_l">
-      <pose>0 0 0 0 0 3.14159</pose>
+    <link name="gripper_finger2">
+      <inertial>
+        <mass>0.2</mass>
+        <inertia>
+          <ixx>0.0001</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.00009</iyy>
+          <iyz>0</iyz>
+          <izz>0.00003</izz>
+        </inertia>
+      </inertial>
       <visual name="hande_finger_visual">
+        <pose>0 0 0 0 0 3.14159</pose>
         <geometry>
           <mesh>
             <uri>hande_finger_visual.glb</uri>
@@ -82,7 +115,7 @@
         </geometry>
       </visual>
       <collision name="finger_collider_box">
-        <pose>0.032595 -1e-05 0.138138 0.0 0.0 0.0</pose>
+        <pose>-0.032595 -1e-05 0.138138 0.0 0.0 0.0</pose>
         <geometry>
           <box>
             <size>0.007839 0.021 0.028622</size>
@@ -90,7 +123,7 @@
         </geometry>
       </collision>
       <collision name="finger_collider_box.001">
-        <pose>0.028 -1e-05 0.16145 0.0 0.0 0.0</pose>
+        <pose>-0.028 -1e-05 0.16145 0.0 0.0 0.0</pose>
         <geometry>
           <box>
             <size>0.006 0.021 0.021498</size>
@@ -98,7 +131,7 @@
         </geometry>
       </collision>
       <collision name="finger_collider_box.002">
-        <pose>0.014354 -0.015 0.124725 0.0 0.0 0.0</pose>
+        <pose>-0.014354 0.015 0.124725 0.0 0.0 0.0</pose>
         <geometry>
           <box>
             <size>0.044319 0.0075 0.003949</size>
@@ -106,7 +139,7 @@
         </geometry>
       </collision>
       <collision name="finger_collider_box.003">
-        <pose>0.027046 -0.00954 0.129064 0.0 0.0 0.0</pose>
+        <pose>-0.027046 0.00954 0.129064 0.0 0.0 0.0</pose>
         <geometry>
           <box>
             <size>0.017387 0.018419 0.009271</size>
@@ -115,5 +148,32 @@
       </collision>
     </link>
 
+    <joint name="finger1" type="prismatic">
+      <parent>gripper_body</parent>
+      <child>gripper_finger1</child>
+      <pose>0 0 0 0 0 0</pose>
+      <axis>
+        <xyz>-1 0 0</xyz>
+        <limit>
+          <lower>0</lower>
+          <upper>0.025</upper>
+        </limit>
+       </axis>
+    </joint>
+    <joint name="finger2" type="prismatic">
+      <parent>gripper_body</parent>
+      <child>gripper_finger2</child>
+      <pose>0 0 0 0 0 0</pose>
+      <axis>
+        <xyz>1 0 0</xyz>
+        <limit>
+          <lower>0</lower>
+          <upper>0.025</upper>
+        </limit>
+       </axis>
+    </joint>
+    <frame name='tool_frame' attached_to='gripper_body' intrinsic:create_entity='true'>
+      <pose>0 0 0.172 0 0 0</pose>
+    </frame>
   </model>
 </sdf>


### PR DESCRIPTION
Resolves inconsistencies between the gripper's `model.sdf` and `.xacro` files to ensure full alignment between the Qualification Phase and Phase 1.

### Key Changes
* **Meshes:** Updated the visual and collision meshes for the gripper in the SDF.
* **Link Names:** Update gripper link names for Phase 1.
* **Tool Frame:** Updated the `tool_frame` location to align with Qualification Phase specifications.

<img width="656" height="690" alt="Screenshot 2026-05-21 at 6 25 49 PM" src="https://github.com/user-attachments/assets/a56770b2-fe17-4bc9-a53a-29e29b50cb1d" />
