### PR TITLE
Update phase 1 cable 

### DIFF
--- a/aic_assets/models/cable_base_c_rotated_phase_1/model.sdf
+++ b/aic_assets/models/cable_base_c_rotated_phase_1/model.sdf
@@ -1,11 +1,11 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" ?>
 <sdf version="1.9">
   <model name="cable">
     <link name='cable_end_0'>
       <pose>0 0 0 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.0</mass>
+        <mass>0</mass>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0</ixy>
@@ -55,11 +55,11 @@
       <enable_wind>false</enable_wind>
     </link>
     <joint name='joint_end_0' type='ball'>
-      <pose>-5.9292300000000002e-21 -8.0468100000000002e-20 -0.024 0.024762999999999993 1.7999999999999909e-05 -0.061838999999999998</pose>
+      <pose>1.28389e-18 -3.13932e-19 -0.024 0.024762999999999993 1.7999999999999909e-05 -0.061838999999999998</pose>
       <child>link_1</child>
       <parent>cable_end_0</parent>
       <axis>
-        <xyz>1.9813200181550693e-16 -1.5504091066549018e-17 1</xyz>
+        <xyz>1.4522293579821432e-16 -1.5504091066549018e-17 1</xyz>
         <limit>
           <lower>-inf</lower>
           <upper>inf</upper>
@@ -77,10 +77,10 @@
       </axis>
     </joint>
     <link name='link_1'>
-      <pose>0.014819747152165608 -0.0017399206733917372 0.018794240782019161 0.18667383890181891 0.64837595547957994 0.18627118492373859</pose>
+      <pose>0.0078134916863454862 0.00051765284508892284 0.022683822865585346 0.042602753232865519 0.32975013221664451 0.19707101302315977</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.0</mass>
+        <mass>0</mass>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0</ixy>
@@ -94,7 +94,7 @@
         <pose>0 0 0.0060000000000000001 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.036</length>
+            <length>0.035999999999999997</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -114,7 +114,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -129,14 +129,13 @@
           </pbr>
         </material>
       </visual>
-
       <enable_wind>false</enable_wind>
     </link>
     <link name='link_2'>
-      <pose>0.051217620240665118 -0.0045817848733566147 0.048027952526810774 0.71782103551369159 0.95497618826384267 0.76800844832658799</pose>
+      <pose>0.028028879973648335 0.0035540327033553587 0.065755721630058828 0.16745270084550051 0.53213272136736112 0.52192370786129749</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.0</mass>
+        <mass>0</mass>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0</ixy>
@@ -150,7 +149,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -170,7 +169,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -185,14 +184,13 @@
           </pbr>
         </material>
       </visual>
-
       <enable_wind>false</enable_wind>
     </link>
     <link name='link_3'>
-      <pose>0.096195168224190386 -0.0055586819898655049 0.063767101721349195 1.2411753795281291 0.81971398965310749 1.3311919485169077</pose>
+      <pose>0.055056711031383543 0.010030755332674723 0.10474588587727446 0.4021410132674037 0.56886956646351761 0.93271973906675187</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.0</mass>
+        <mass>0</mass>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0</ixy>
@@ -206,7 +204,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -226,7 +224,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -241,14 +239,13 @@
           </pbr>
         </material>
       </visual>
-
       <enable_wind>false</enable_wind>
     </link>
     <link name='link_4'>
-      <pose>0.14325005118936951 -0.0037154553753084019 0.072641729123881921 1.4025384617609209 0.47240662802222544 1.5660895369557621</pose>
+      <pose>0.086049955081371365 0.018697695591391061 0.1402378056050525 0.68208043247717098 0.43409571050972873 1.3730577939461655</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.0</mass>
+        <mass>0</mass>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0</ixy>
@@ -262,7 +259,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -282,7 +279,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -297,14 +294,13 @@
           </pbr>
         </material>
       </visual>
-
       <enable_wind>false</enable_wind>
     </link>
     <link name='link_5'>
-      <pose>0.19010418330564605 0.002044484465481694 0.080702087852424748 1.3825902243832859 0.027099831268072066 1.7382011710223997</pose>
+      <pose>0.1207673371511353 0.028584466245538176 0.17165651071190768 0.91509188685937548 0.10883122946918947 1.7626211973357853</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.0</mass>
+        <mass>0</mass>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0</ixy>
@@ -318,7 +314,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -338,7 +334,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -353,14 +349,13 @@
           </pbr>
         </material>
       </visual>
-
       <enable_wind>false</enable_wind>
     </link>
     <link name='link_6'>
-      <pose>0.23471464542253773 0.012878040629696885 0.093441657271720047 1.1755780259895565 -0.46057093362886986 2.0613586099848908</pose>
+      <pose>0.1593356119202014 0.038931578899454866 0.19790771033786281 1.0066381776470119 -0.41022954892401903 2.0688224191976543</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.0</mass>
+        <mass>0</mass>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0</ixy>
@@ -374,18 +369,18 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
         <surface>
           <friction>
             <torsional>
-              <coefficient>0.05</coefficient>
+              <coefficient>0.050000000000000003</coefficient>
             </torsional>
             <bullet>
-              <friction>0.05</friction>
-              <friction2>0.05</friction2>
+              <friction>0.050000000000000003</friction>
+              <friction2>0.050000000000000003</friction2>
             </bullet>
           </friction>
         </surface>
@@ -394,7 +389,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -409,14 +404,13 @@
           </pbr>
         </material>
       </visual>
-
       <enable_wind>false</enable_wind>
     </link>
     <link name='link_7'>
-      <pose>0.27273856429821186 0.028876552044857784 0.11613283463758543 0.61880592056634154 -0.7341233213716245 2.8322322035791392</pose>
+      <pose>0.19938672870614282 0.049617594193392289 0.2216916339207472 0.63735994234845061 -0.88980404940679414 2.6525929471470509</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.0</mass>
+        <mass>0</mass>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0</ixy>
@@ -430,7 +424,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -450,7 +444,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -465,14 +459,13 @@
           </pbr>
         </material>
       </visual>
-
       <enable_wind>false</enable_wind>
     </link>
     <link name='link_8'>
-      <pose>0.29639117909238588 0.048050174628466918 0.15100712317523862 0.22225871726667798 -0.4950676882834748 -2.6299292070296829</pose>
+      <pose>0.23338835770685118 0.061556054221673373 0.25177918612917172 -0.027375029122174648 -0.71212046087396486 -2.6736969870357399</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.0</mass>
+        <mass>0</mass>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0</ixy>
@@ -486,7 +479,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -506,7 +499,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -521,14 +514,13 @@
           </pbr>
         </material>
       </visual>
-
       <enable_wind>false</enable_wind>
     </link>
     <link name='link_9'>
-      <pose>0.29883494157350765 0.06604229984663601 0.19343356390563535 0.35289123975868442 -0.18854795280962855 -2.1511196256483762</pose>
+      <pose>0.24953717409648557 0.073542424153992203 0.29291253264804346 0.075486735064752092 -0.23932789136881108 -2.2236127392728777</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.0</mass>
+        <mass>0</mass>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0</ixy>
@@ -542,7 +534,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -562,7 +554,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -577,14 +569,13 @@
           </pbr>
         </material>
       </visual>
-
       <enable_wind>false</enable_wind>
     </link>
     <link name='link_10'>
-      <pose>0.28019441807568857 0.078906295380847286 0.23414893079513596 0.66792593646537202 -0.062195666117625718 -1.8242685532177023</pose>
+      <pose>0.23884007855107514 0.08146464928515379 0.33614492844639599 0.56612711533247062 0.063781444638215154 -1.8551309533122007</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.0</mass>
+        <mass>0</mass>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0</ixy>
@@ -598,7 +589,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -618,7 +609,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -633,14 +624,13 @@
           </pbr>
         </material>
       </visual>
-
       <enable_wind>false</enable_wind>
     </link>
     <link name='link_11'>
-      <pose>0.24608655512569744 0.085546207874769936 0.26574303981633546 0.9996926413854923 -0.091454028217593672 -1.6017398922236008</pose>
+      <pose>0.20396837596650674 0.082066612311800013 0.36497034780551035 1.1961737521851861 0.07975003109805083 -1.5234566228962416</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.0</mass>
+        <mass>0</mass>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0</ixy>
@@ -654,7 +644,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -674,7 +664,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -689,14 +679,13 @@
           </pbr>
         </material>
       </visual>
-
       <enable_wind>false</enable_wind>
     </link>
     <link name='link_12'>
-      <pose>0.20287489352286281 0.086985596607584398 0.28442008764742138 1.317518732075605 -0.23865626183528538 -1.4938780196794386</pose>
+      <pose>0.15881275511750403 0.076031817512848821 0.36878899065770676 1.7773833845932527 -0.10819701101555762 -1.4091408868565591</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.0</mass>
+        <mass>0</mass>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0</ixy>
@@ -710,7 +699,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -730,7 +719,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -745,14 +734,13 @@
           </pbr>
         </material>
       </visual>
-
       <enable_wind>false</enable_wind>
     </link>
     <link name='link_13'>
-      <pose>0.15618997105147026 0.084697426921248237 0.28746919512180302 1.7024008950349943 -0.48041282097612337 -1.5495117244976766</pose>
+      <pose>0.11840149669338751 0.067258415076125289 0.34839611017696187 2.3218004002784913 -0.29853057061868082 -1.5860296031184538</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.0</mass>
+        <mass>0</mass>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0</ixy>
@@ -766,7 +754,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -786,7 +774,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -801,14 +789,13 @@
           </pbr>
         </material>
       </visual>
-
       <enable_wind>false</enable_wind>
     </link>
     <link name='link_14'>
-      <pose>0.11195389107540676 0.079182014482695323 0.27351702068747452 2.2450652421190944 -0.71752619639368909 -1.882468111688552</pose>
+      <pose>0.090070487175823999 0.059216904401895198 0.31201830153440918 2.7733809182172142 -0.34735685110811088 -1.9769757168263153</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.0</mass>
+        <mass>0</mass>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0</ixy>
@@ -822,7 +809,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -842,7 +829,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -857,14 +844,13 @@
           </pbr>
         </material>
       </visual>
-
       <enable_wind>false</enable_wind>
     </link>
     <link name='link_15'>
-      <pose>0.074470012931548091 0.070861155598836684 0.24598411243864993 2.8346842567993424 -0.77104715779046407 -2.439808815250486</pose>
+      <pose>0.071097842456990135 0.052536186016011732 0.26887622043573101 3.0081565931210794 -0.34793326964567106 -2.3972049745366157</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.0</mass>
+        <mass>0</mass>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0</ixy>
@@ -878,7 +864,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -898,7 +884,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -913,14 +899,13 @@
           </pbr>
         </material>
       </visual>
-
       <enable_wind>false</enable_wind>
     </link>
     <link name='link_16'>
-      <pose>0.043548977720494708 0.061318958805630347 0.21089491444488995 -3.0634429596784147 -0.66854836615188551 -2.9390402042338439</pose>
+      <pose>0.05493182624278603 0.046283603914522881 0.22425635404885502 -3.1324063749606426 -0.36901227963991989 -2.7974393984850758</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.0</mass>
+        <mass>0</mass>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0</ixy>
@@ -934,7 +919,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -954,7 +939,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -969,14 +954,13 @@
           </pbr>
         </material>
       </visual>
-
       <enable_wind>false</enable_wind>
     </link>
     <link name='link_17'>
-      <pose>0.017193029227812406 0.052931689669931198 0.17182799838632967 -2.8973817899317043 -0.509214211852966 2.9537288827374897</pose>
+      <pose>0.037772814144178435 0.041167453635452489 0.1798064729515188 -3.0389117721209162 -0.38599698781207287 3.0903519151384042</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.0</mass>
+        <mass>0</mass>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0</ixy>
@@ -990,7 +974,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -1010,7 +994,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -1025,14 +1009,13 @@
           </pbr>
         </material>
       </visual>
-
       <enable_wind>false</enable_wind>
     </link>
     <link name='link_18'>
-      <pose>-0.004224603850605968 0.047277245818884234 0.12944388362441953 -2.876163563677991 -0.30765329344395254 2.6324409242363034</pose>
+      <pose>0.019746618430843244 0.038721137119450466 0.13544088722379405 -2.9647726105530685 -0.34024499579073925 2.7006793187372184</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.0</mass>
+        <mass>0</mass>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0</ixy>
@@ -1046,7 +1029,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -1066,7 +1049,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -1081,14 +1064,13 @@
           </pbr>
         </material>
       </visual>
-
       <enable_wind>false</enable_wind>
     </link>
     <link name='link_19'>
-      <pose>-0.016731545993425412 0.040756431993467651 0.084032587722441932 -2.9107842690624079 0.033749791185127644 2.3574664764618625</pose>
+      <pose>0.0048992346838327983 0.035543491748658507 0.090082572290301866 -2.8841674563714594 -0.09785593495190667 2.3575874569021074</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.0</mass>
+        <mass>0</mass>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0</ixy>
@@ -1102,7 +1084,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -1122,7 +1104,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -1137,14 +1119,13 @@
           </pbr>
         </material>
       </visual>
-
       <enable_wind>false</enable_wind>
     </link>
     <link name='link_20'>
-      <pose>-0.019105099661882896 0.021072618098588264 0.042173558124603744 -2.8379086168062377 0.6292671281148251 2.1220102744151093</pose>
+      <pose>-0.0049466280374985683 0.018935247682981105 0.047811714425291973 -2.6604309455594977 0.44763575613071077 2.1737710302230981</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.0</mass>
+        <mass>0</mass>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0</ixy>
@@ -1158,7 +1139,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -1178,7 +1159,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048</length>
+            <length>0.048000000000000001</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>
@@ -1193,11 +1174,10 @@
           </pbr>
         </material>
       </visual>
-
       <enable_wind>false</enable_wind>
     </link>
     <joint name='joint_1' type='ball'>
-      <pose>-1.0842e-19 8.6736199999999997e-19 -0.024 0.057665000000000015 -0.0035260000000000005 -0.14366599999999999</pose>
+      <pose>-6.9388900000000004e-18 2.6020900000000001e-18 -0.024 0.057665000000000015 -0.0035260000000000005 -0.14366599999999999</pose>
       <parent>link_1</parent>
       <child>link_2</child>
       <axis>
@@ -1219,11 +1199,11 @@
       </axis>
     </joint>
     <joint name='joint_2' type='ball'>
-      <pose>8.6736199999999997e-19 1.73472e-18 -0.024 0.072919999999999971 -0.015119999999999996 -0.18287300000000001</pose>
+      <pose>-6.9388900000000004e-18 -3.4694499999999997e-18 -0.024 0.072919999999999971 -0.015119999999999996 -0.18287300000000001</pose>
       <parent>link_2</parent>
       <child>link_3</child>
       <axis>
-        <xyz>-4.336808689942141e-19 6.2558465352413594e-17 1</xyz>
+        <xyz>4.1199682554449156e-17 9.0314040968042507e-17 1</xyz>
         <limit>
           <lower>-inf</lower>
           <upper>inf</upper>
@@ -1241,7 +1221,7 @@
       </axis>
     </joint>
     <joint name='joint_3' type='ball'>
-      <pose>0 0 -0.024 0.09283799999999999 -0.037758000000000028 -0.23843600000000004</pose>
+      <pose>0 6.9388900000000004e-18 -0.024 0.09283799999999999 -0.037758000000000028 -0.23843600000000004</pose>
       <parent>link_3</parent>
       <child>link_4</child>
       <axis>
@@ -1263,7 +1243,7 @@
       </axis>
     </joint>
     <joint name='joint_4' type='ball'>
-      <pose>-1.3877799999999999e-17 -3.1224999999999998e-17 -0.024 0.11562100000000003 -0.082796999999999996 -0.31582500000000002</pose>
+      <pose>3.46945e-17 -6.2449999999999997e-17 -0.024 0.11562100000000003 -0.082796999999999996 -0.31582500000000002</pose>
       <parent>link_4</parent>
       <child>link_5</child>
       <axis>
@@ -1285,11 +1265,11 @@
       </axis>
     </joint>
     <joint name='joint_5' type='ball'>
-      <pose>2.7755599999999997e-17 6.9388900000000004e-18 -0.024 0.12748000000000004 -0.17044200000000007 -0.41081300000000026</pose>
+      <pose>6.2449999999999997e-17 0 -0.024 0.12748000000000004 -0.17044200000000007 -0.41081300000000026</pose>
       <parent>link_5</parent>
       <child>link_6</child>
       <axis>
-        <xyz>-2.0816681711721636e-17 1.1102230246251565e-16 1</xyz>
+        <xyz>-2.081668171172163e-17 -1.3684555315672042e-48 1</xyz>
         <limit>
           <lower>-inf</lower>
           <upper>inf</upper>
@@ -1307,7 +1287,7 @@
       </axis>
     </joint>
     <joint name='joint_6' type='ball'>
-      <pose>0 -1.3877799999999999e-17 -0.024 0.077454999999999954 -0.3108280000000001 -0.47354099999999982</pose>
+      <pose>0 -2.0816700000000001e-17 -0.024 0.077454999999999954 -0.3108280000000001 -0.47354099999999982</pose>
       <parent>link_6</parent>
       <child>link_7</child>
       <axis>
@@ -1329,7 +1309,7 @@
       </axis>
     </joint>
     <joint name='joint_7' type='ball'>
-      <pose>-2.7755599999999997e-17 0 -0.024 -0.099142999999999981 -0.40827100000000011 -0.39838499999999988</pose>
+      <pose>-5.5511199999999995e-17 0 -0.024 -0.099142999999999981 -0.40827100000000011 -0.39838499999999988</pose>
       <parent>link_7</parent>
       <child>link_8</child>
       <axis>
@@ -1351,7 +1331,7 @@
       </axis>
     </joint>
     <joint name='joint_8' type='ball'>
-      <pose>-5.5511199999999995e-17 -5.5511199999999995e-17 -0.024 -0.25860899999999998 -0.32846800000000009 -0.24861</pose>
+      <pose>-1.11022e-16 -5.5511199999999995e-17 -0.024 -0.25860899999999998 -0.32846800000000009 -0.24861</pose>
       <parent>link_8</parent>
       <child>link_9</child>
       <axis>
@@ -1395,11 +1375,11 @@
       </axis>
     </joint>
     <joint name='joint_10' type='ball'>
-      <pose>0 0 -0.024 -0.2767980000000001 -0.13009000000000007 -0.12658500000000003</pose>
+      <pose>-1.3877799999999999e-17 5.5511199999999995e-17 -0.024 -0.2767980000000001 -0.13009000000000007 -0.12658500000000003</pose>
       <parent>link_10</parent>
       <child>link_11</child>
       <axis>
-        <xyz>-1.7347234759768117e-17 -8.3266726846886716e-17 1</xyz>
+        <xyz>-1.7347234759768123e-17 -2.7755575615628889e-17 1</xyz>
         <limit>
           <lower>-inf</lower>
           <upper>inf</upper>
@@ -1417,7 +1397,7 @@
       </axis>
     </joint>
     <joint name='joint_11' type='ball'>
-      <pose>-6.9388900000000004e-18 0 -0.024 -0.31800899999999988 -0.097124000000000016 -0.12714500000000001</pose>
+      <pose>0 0 -0.024 -0.31800899999999988 -0.097124000000000016 -0.12714500000000001</pose>
       <parent>link_11</parent>
       <child>link_12</child>
       <axis>
@@ -1439,7 +1419,7 @@
       </axis>
     </joint>
     <joint name='joint_12' type='ball'>
-      <pose>4.3368099999999998e-19 0 -0.024 -0.41514299999999998 -0.064825000000000021 -0.15662800000000004</pose>
+      <pose>-2.7755599999999997e-17 0 -0.024 -0.41514299999999998 -0.064825000000000021 -0.15662800000000004</pose>
       <parent>link_12</parent>
       <child>link_13</child>
       <axis>
@@ -1461,11 +1441,11 @@
       </axis>
     </joint>
     <joint name='joint_13' type='ball'>
-      <pose>0 2.7755599999999997e-17 -0.024 -0.47514499999999982 0.00481899999999999 -0.19548199999999996</pose>
+      <pose>2.7755599999999997e-17 2.7755599999999997e-17 -0.024 -0.47514499999999982 0.00481899999999999 -0.19548199999999996</pose>
       <parent>link_13</parent>
       <child>link_14</child>
       <axis>
-        <xyz>4.157915331481907e-17 -5.5511151231257815e-17 1</xyz>
+        <xyz>1.3823577699190157e-17 -5.5511151231257815e-17 1</xyz>
         <limit>
           <lower>-inf</lower>
           <upper>inf</upper>
@@ -1483,11 +1463,11 @@
       </axis>
     </joint>
     <joint name='joint_14' type='ball'>
-      <pose>1.3877799999999999e-17 -5.5511199999999995e-17 -0.024 -0.37640199999999963 0.076180000000000053 -0.18553599999999995</pose>
+      <pose>1.3877799999999999e-17 -4.1633400000000002e-17 -0.024 -0.37640199999999963 0.076180000000000053 -0.18553599999999995</pose>
       <parent>link_14</parent>
       <child>link_15</child>
       <axis>
-        <xyz>5.5511151231257815e-17 7.6327832942979512e-17 1</xyz>
+        <xyz>1.3877787807814444e-17 7.6327832942979512e-17 1</xyz>
         <limit>
           <lower>-inf</lower>
           <upper>inf</upper>
@@ -1505,11 +1485,11 @@
       </axis>
     </joint>
     <joint name='joint_15' type='ball'>
-      <pose>1.73472e-17 -9.7144500000000003e-17 -0.024 -0.23104200000000003 0.090075999999999989 -0.13426600000000005</pose>
+      <pose>1.3877799999999999e-17 -9.0205599999999994e-17 -0.024 -0.23104200000000003 0.090075999999999989 -0.13426600000000005</pose>
       <parent>link_15</parent>
       <child>link_16</child>
       <axis>
-        <xyz>5.2041704279304201e-17 -8.3266726846886728e-17 1</xyz>
+        <xyz>4.5102810375396972e-17 -8.3266726846886728e-17 1</xyz>
         <limit>
           <lower>-inf</lower>
           <upper>inf</upper>
@@ -1527,11 +1507,11 @@
       </axis>
     </joint>
     <joint name='joint_16' type='ball'>
-      <pose>3.4694499999999997e-18 -5.5511199999999995e-17 -0.024 -0.13905600000000001 0.075479000000000004 -0.092463999999999991</pose>
+      <pose>1.3877799999999999e-17 -6.5919499999999998e-17 -0.024 -0.13905600000000001 0.075479000000000004 -0.092463999999999991</pose>
       <parent>link_16</parent>
       <child>link_17</child>
       <axis>
-        <xyz>1.3877787807814444e-17 -2.7755575615628907e-17 1</xyz>
+        <xyz>1.1058862159352133e-17 -2.7755575615628907e-17 1</xyz>
         <limit>
           <lower>-inf</lower>
           <upper>inf</upper>
@@ -1549,11 +1529,11 @@
       </axis>
     </joint>
     <joint name='joint_17' type='ball'>
-      <pose>-1.04083e-17 6.9388900000000004e-18 -0.024 -0.089686000000000002 0.059461 -0.066655000000000006</pose>
+      <pose>-2.7755599999999997e-17 3.4694499999999997e-18 -0.024 -0.089686000000000002 0.059461 -0.066655000000000006</pose>
       <parent>link_17</parent>
       <child>link_18</child>
       <axis>
-        <xyz>1.6653345369377343e-16 -2.775557561562892e-17 1</xyz>
+        <xyz>1.7867651802561108e-16 -1.387778780781446e-17 1</xyz>
         <limit>
           <lower>-inf</lower>
           <upper>inf</upper>
@@ -1571,11 +1551,11 @@
       </axis>
     </joint>
     <joint name='joint_18' type='ball'>
-      <pose>-3.4694499999999997e-18 -2.7755599999999997e-17 -0.024 -0.062118000000000013 0.047213000000000012 -0.050650000000000014</pose>
+      <pose>-6.9388900000000004e-18 -1.3877799999999999e-17 -0.024 -0.062118000000000013 0.047213000000000012 -0.050650000000000014</pose>
       <parent>link_18</parent>
       <child>link_19</child>
       <axis>
-        <xyz>4.4408920985006262e-16 9.6277152916712794e-17 1</xyz>
+        <xyz>4.3715031594615539e-16 9.6277152916712744e-17 1</xyz>
         <limit>
           <lower>-inf</lower>
           <upper>inf</upper>
@@ -1593,11 +1573,11 @@
       </axis>
     </joint>
     <joint name='joint_19' type='ball'>
-      <pose>-6.9388900000000004e-18 -6.9388900000000004e-18 -0.024 -0.045549999999999986 0.038313000000000014 -0.040162000000000003</pose>
+      <pose>-1.5612499999999999e-17 -6.9388900000000004e-18 -0.024 -0.045549999999999986 0.038313000000000014 -0.040162000000000003</pose>
       <parent>link_19</parent>
       <child>link_20</child>
       <axis>
-        <xyz>1.8735013540549514e-16 2.7755575615628914e-16 1</xyz>
+        <xyz>1.8735013540549514e-16 2.2204460492503131e-16 1</xyz>
         <limit>
           <lower>-inf</lower>
           <upper>inf</upper>
@@ -1619,15 +1599,15 @@
         <pose>0 0 0 0 0 0</pose>
         <mass>0.01</mass>
         <inertia>
-          <ixx>1e-03</ixx>
+          <ixx>0.001</ixx>
           <ixy>0</ixy>
           <ixz>0</ixz>
-          <iyy>1e-03</iyy>
+          <iyy>0.001</iyy>
           <iyz>0</iyz>
-          <izz>1e-03</izz>
+          <izz>0.001</izz>
         </inertia>
       </inertial>
-      <pose>1.7161193510695227e-07 -2.0317050514195856e-08 -2.0573089890008056e-07 -0.21237071140616082 -0.63195479276709987 0.038809485418558186</pose>
+      <pose>-2.0783723853057268e-08 1.9280348984018758e-08 1.152382576030675e-07 -0.14045842295202995 -0.29539946358940405 -0.070233626809208499</pose>
       <collision name='collision_0'>
         <pose>-0.0018027756377319948 0.002 0 0.5880026035475675 1.57079 0</pose>
         <geometry>
@@ -1649,7 +1629,7 @@
         </surface>
       </collision>
       <visual name='visual_0'>
-        <pose>-0.0018027756377319948 0.002 0 0.58800260356095158 1.5707900000278763 1.7547982117249351e-11</pose>
+        <pose>-0.0018027756377319948 0.002 0 0.58800260356095169 1.5707900000629724 8.7740640661759428e-12</pose>
         <geometry>
           <cylinder>
             <radius>0.001</radius>
@@ -1688,7 +1668,7 @@
         </surface>
       </collision>
       <visual name='visual_1'>
-        <pose>-0.0018027756377319948 -0.002 0 -0.58800260356095158 1.5707900000278763 -1.7547982117249351e-11</pose>
+        <pose>-0.0018027756377319948 -0.002 0 -0.58800260356095169 1.5707900000629724 -8.7740640661759428e-12</pose>
         <geometry>
           <cylinder>
             <radius>0.001</radius>
@@ -1713,17 +1693,17 @@
         <pose>0 0 0 0 0 0</pose>
         <mass>0.01</mass>
         <inertia>
-          <ixx>1e-03</ixx>
+          <ixx>0.001</ixx>
           <ixy>0</ixy>
           <ixz>0</ixz>
-          <iyy>1e-03</iyy>
+          <iyy>0.001</iyy>
           <iyz>0</iyz>
-          <izz>1e-03</izz>
+          <izz>0.001</izz>
         </inertia>
       </inertial>
-      <pose>-0.01816015053220843 0.0058330576729706263 0.023660684305841895 -1.3618622312557218 0.60947104933035079 -3.1086968029674726</pose>
+      <pose>-0.0088725525483208667 0.0050531156657257492 0.028635283405178624 -1.4312720714569662 0.2726322333658332 3.0680136224815051</pose>
       <collision name='collision_0'>
-        <pose>0.0036763602924631857 -0.0042500000000000003 0 0.61629693740774327 1.5707900000629724 0</pose>
+        <pose>0.0036763602924631857 -0.0042500000000000003 0 0.61629693740218705 1.570790000115617 8.7740884023540984e-12</pose>
         <geometry>
           <cylinder>
             <radius>0.001</radius>
@@ -1743,7 +1723,7 @@
         </surface>
       </collision>
       <visual name='visual_0'>
-        <pose>0.0036763602924631857 -0.0042500000000000003 0 0.61629693740774327 1.5707900000629724 0</pose>
+        <pose>0.0036763602924631857 -0.0042500000000000003 0 0.61629693740218705 1.570790000115617 8.7740884023540984e-12</pose>
         <geometry>
           <cylinder>
             <radius>0.001</radius>
@@ -1762,7 +1742,7 @@
         </material>
       </visual>
       <collision name='collision_1'>
-        <pose>0.0036763602924631857 0.0042500000000000003 0 -0.61629693740774327 1.5707900000629724 0</pose>
+        <pose>0.0036763602924631857 0.0042500000000000003 0 -0.61629693740218705 1.570790000115617 -8.7740884023540984e-12</pose>
         <geometry>
           <cylinder>
             <radius>0.001</radius>
@@ -1782,7 +1762,7 @@
         </surface>
       </collision>
       <visual name='visual_1'>
-        <pose>0.0036763602924631857 0.0042500000000000003 0 -0.61629693740774327 1.5707900000629724 0</pose>
+        <pose>0.0036763602924631857 0.0042500000000000003 0 -0.61629693740218705 1.570790000115617 -8.7740884023540984e-12</pose>
         <geometry>
           <cylinder>
             <radius>0.001</radius>
@@ -1803,11 +1783,11 @@
       <enable_wind>false</enable_wind>
     </link>
     <joint name='joint_connection_end_0' type='ball'>
-      <pose>0 0 0 0 0 0</pose>
+      <pose>5.6248300000000003e-23 0 -5.2939599999999994e-23 2.6331099999999998e-35 1.5178800000000001e-17 3.4694499999999997e-18</pose>
       <parent>cable_end_0</parent>
       <child>cable_connection_0</child>
       <axis>
-        <xyz>1.3108744620427266e-16 -2.0816681711721685e-17 1</xyz>
+        <xyz>1.4626627661906972e-16 -2.0816681711721685e-17 1</xyz>
         <limit>
           <lower>-inf</lower>
           <upper>inf</upper>
@@ -1825,11 +1805,11 @@
       </axis>
     </joint>
     <joint name='joint_connection_end_1' type='ball'>
-      <pose>2.1684e-19 -1.3877799999999999e-17 -1.04083e-17 -0.026259000000000015 0.023921000000000012 0.76093299999999986</pose>
+      <pose>9.5409799999999993e-18 -3.46945e-17 -2.2551399999999999e-17 -0.026259000000000015 0.023921000000000012 0.76093299999999986</pose>
       <parent>link_20</parent>
       <child>cable_connection_1</child>
       <axis>
-        <xyz>-1.3877787807814475e-17 -5.8113236445223062e-17 1</xyz>
+        <xyz>-1.3877787807814475e-17 5.2909066017292592e-17 1</xyz>
         <limit>
           <lower>-inf</lower>
           <upper>inf</upper>


### PR DESCRIPTION
Updated the cable so that the body of the cable which forms the loop is no longer that high up in the air. This is to avoid colliding with  the arm and other cables during manipulation.


To test:

Launch sim with the new cable. Note the cable now needs to be spawned at a slightly different pose (mainly orientation changes)

```sh
#spawn at new cable pose: <pose>0.0076318969950079918 -0.093769878149032593 1.2291415929794312 -2.8109849472880506 -1.0522176487631258 2.9173976825173753</pose>
ros2 launch aic_bringup aic_gz_bringup.launch.py ground_truth:=false spawn_cable:=true attach_cable_to_gripper:=false spawn_task_board:=true nic_card_mount_0_present:=true sc_port_0_present:=true launch_rviz:=false  sfp_mount_rail_0_present:=true sc_mount_rail_0_present:=true cable_type:=sfp_sc_cable_phase_1 cable_x:=0.0076318969950079918 cable_y:=-0.093769878149032593 cable_z:=1.2291415929794312 cable_roll:=-2.8109849472880506 cable_pitch:=-1.0522176487631258 cable_yaw:=2.9173976825173753
```

New cable configuration:

<img width="646" height="660" alt="Screenshot from 2026-05-22 17-38-41" src="https://github.com/user-attachments/assets/19d72d1b-74a5-4a81-a963-1384acb4cc96" />

See https://github.com/intrinsic-dev/aic/pull/502 for a screenshot of the current cable configuration