### PR TITLE
Cherry pick training utils into phase_1

### DIFF
--- a/aic_utils/aic_training_interfaces/CMakeLists.txt
+++ b/aic_utils/aic_training_interfaces/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.8)
+project(aic_training_interfaces)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+set(srv_files
+  "srv/ExpandXacro.srv"
+)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${srv_files}
+  ADD_LINTER_TESTS
+)
+
+ament_export_dependencies(rosidl_default_runtime)
+
+ament_package()

--- a/aic_utils/aic_training_interfaces/package.xml
+++ b/aic_utils/aic_training_interfaces/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>aic_training_interfaces</name>
+  <version>0.0.1</version>
+  <description>ROS 2 interfaces for training-oriented AI Challenge utilities</description>
+  <maintainer email="yadunund@intrinsic.ai">Yadunund Vijay</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/aic_utils/aic_training_interfaces/pixi.toml
+++ b/aic_utils/aic_training_interfaces/pixi.toml
@@ -1,0 +1,8 @@
+[package.build.backend]
+name = "pixi-build-ros"
+version = "==0.3.3.20260113.c8b6a54"
+channels = [
+  "https://prefix.dev/pixi-build-backends",
+  "robostack-kilted",
+  "conda-forge",
+]

--- a/aic_utils/aic_training_interfaces/srv/ExpandXacro.srv
+++ b/aic_utils/aic_training_interfaces/srv/ExpandXacro.srv
@@ -1,0 +1,7 @@
+string package_name
+string relative_path
+string[] xacro_arguments
+---
+bool success
+string xml
+string message

--- a/aic_utils/aic_training_utils/CMakeLists.txt
+++ b/aic_utils/aic_training_utils/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.8)
+project(aic_training_utils)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+
+install(
+  DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(PROGRAMS
+  scripts/xacro_expander.py
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+ament_package()

--- a/aic_utils/aic_training_utils/launch/aic_training_gz_bringup.launch.py
+++ b/aic_utils/aic_training_utils/launch/aic_training_gz_bringup.launch.py
@@ -1,0 +1,32 @@
+"""Training bringup for Gazebo-based AIC workflows."""
+
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+from launch.substitutions import PathJoinSubstitution
+
+
+def generate_launch_description() -> LaunchDescription:
+    """Launch the standard Gazebo bringup together with training-only tools."""
+    return LaunchDescription(
+        [
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(
+                    PathJoinSubstitution(
+                        [
+                            FindPackageShare("aic_bringup"),
+                            "launch",
+                            "aic_gz_bringup.launch.py",
+                        ]
+                    )
+                )
+            ),
+            Node(
+                package="aic_training_utils",
+                executable="xacro_expander.py",
+                parameters=[{"use_sim_time": True}],
+            ),
+        ]
+    )

--- a/aic_utils/aic_training_utils/package.xml
+++ b/aic_utils/aic_training_utils/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>aic_training_utils</name>
+  <version>0.0.1</version>
+  <description>Training-oriented bringup utilities for the AI Challenge</description>
+  <maintainer email="yadunund@intrinsic.ai">Yadunund Vijay</maintainer>
+  <author email="jennifer.e.buehler@gmail.com">Jennifer Buehler</author>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>aic_bringup</exec_depend>
+  <exec_depend>aic_training_interfaces</exec_depend>
+  <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>xacro</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/aic_utils/aic_training_utils/pixi.toml
+++ b/aic_utils/aic_training_utils/pixi.toml
@@ -1,0 +1,8 @@
+[package.build.backend]
+name = "pixi-build-ros"
+version = "==0.3.3.20260113.c8b6a54"
+channels = [
+  "https://prefix.dev/pixi-build-backends",
+  "robostack-kilted",
+  "conda-forge",
+]

--- a/aic_utils/aic_training_utils/scripts/xacro_expander.py
+++ b/aic_utils/aic_training_utils/scripts/xacro_expander.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""General-purpose xacro expansion service for AIC training workflows."""
+
+from pathlib import Path
+import subprocess
+
+from ament_index_python.packages import (
+    PackageNotFoundError,
+    get_package_share_directory,
+)
+from aic_training_interfaces.srv import ExpandXacro
+import rclpy
+from rclpy.node import Node
+
+
+class XacroExpanderNode(Node):
+    """Serve xacro expansion requests from the training bringup environment."""
+
+    def __init__(self) -> None:
+        super().__init__("xacro_expander")
+        self.create_service(ExpandXacro, "expand_xacro", self._handle_expand_xacro)
+
+    def _handle_expand_xacro(
+        self,
+        request: ExpandXacro.Request,
+        response: ExpandXacro.Response,
+    ) -> ExpandXacro.Response:
+        """Expand a xacro file in a package share directory into XML."""
+        package_name = request.package_name.strip()
+        relative_path = request.relative_path.strip()
+
+        if not package_name:
+            response.success = False
+            response.message = "package_name is required"
+            return response
+        if not relative_path:
+            response.success = False
+            response.message = "relative_path is required"
+            return response
+
+        try:
+            package_share = Path(get_package_share_directory(package_name)).resolve()
+        except PackageNotFoundError as exc:
+            response.success = False
+            response.message = str(exc)
+            return response
+
+        candidate = (package_share / relative_path).resolve()
+        try:
+            candidate.relative_to(package_share)
+        except ValueError:
+            response.success = False
+            response.message = (
+                "relative_path must stay within the package share directory"
+            )
+            return response
+
+        if not candidate.is_file():
+            response.success = False
+            response.message = f"xacro file not found: {candidate}"
+            return response
+
+        result = subprocess.run(
+            ["xacro", str(candidate), *list(request.xacro_arguments)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            response.success = False
+            response.message = (
+                result.stderr.strip() or f"xacro failed with code {result.returncode}"
+            )
+            return response
+
+        xml = result.stdout
+        if not xml.strip():
+            response.success = False
+            response.message = "xacro returned an empty XML string"
+            return response
+
+        response.success = True
+        response.xml = xml
+        response.message = "xacro expansion succeeded"
+        return response
+
+
+def main() -> None:
+    """Run the ROS 2 node until shutdown."""
+    rclpy.init()
+    node = XacroExpanderNode()
+    try:
+        rclpy.spin(node)
+    finally:
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/aic_interfaces.md
+++ b/docs/aic_interfaces.md
@@ -88,3 +88,4 @@ The Insertion Policy controls the robot by publishing to the following topics.
 | :--- | :--- | :--- |
 | `/aic_controller/change_target_mode` | `aic_control_interfaces/srv/ChangeTargetMode` | Select the target mode (Cartesian or joint) to define the expected input. The controller will subscribe to either `/aic_controller/pose_commands` or `/aic_controller/joint_commands` accordingly. |
 | `/aic_controller/tare_force_torque_sensor` | `std_srvs/srv/Trigger` | Service to tare the force/torque sensor. This service will be disabled during evaluation. The evaluation system will automatically call this service before the cable is spawned in the environment. |
+| `/expand_xacro` | `aic_training_interfaces/srv/ExpandXacro` | Expand a xacro file from an installed ROS package into XML. Returns the expanded XML string. Useful for programmatic entity spawning during training (e.g. task boards, cables) without requiring direct filesystem access to the eval environment.|

--- a/docs/scene_description.md
+++ b/docs/scene_description.md
@@ -111,6 +111,33 @@ cp /tmp/aic.sdf ~/training_scenarios/nic_slot_2.sdf
 cp /tmp/aic.sdf ~/training_scenarios/sc_right_rotated.sdf
 ```
 
+### Programmatic Entity Spawning
+
+For training workflows that need to spawn or respawn entities (task boards, cables), the `/expand_xacro` service lets you expand xacro templates from model-side code without direct filesystem access to the eval environment.
+The following launch file includes the standard `aic_bringup` Gazebo stack along with the training utils:
+
+```bash
+ros2 launch aic_training_utils aic_training_gz_bringup.launch.py
+
+# spawn the task board
+ros2 service call /expand_xacro aic_training_interfaces/srv/ExpandXacro \
+  "{package_name: 'aic_description', relative_path: 'urdf/task_board.urdf.xacro', \
+    xacro_arguments: ['ground_truth:=true', 'nic_card_mount_0_present:=true']}"
+```
+
+The returned XML can then be passed to `/gz_server/spawn_entity` to spawn entities at arbitrary poses. Combined with `/gz_server/delete_entity`, this enables per-episode scene randomization (varying task board poses, rail positions, cable types, etc.) entirely from your training code.
+
+Inside the eval container, this can be started with `distrobox enter`:
+```bash
+distrobox enter aic_eval -- bash -lc '
+  source /ws_aic/install/setup.bash &&
+  ros2 launch aic_training_utils aic_training_gz_bringup.launch.py \
+    spawn_task_board:=true \
+    spawn_cable:=true \
+    nic_card_mount_2_present:=true
+'
+```
+
 ### Teleoperation
 
 **Teleoperate the robot** in joint-space or Cartesian-space to:

--- a/pixi.lock
+++ b/pixi.lock
@@ -473,6 +473,8 @@ environments:
         build: hb0f4dca_0
       - conda: aic_utils/aic_teleoperation
         build: hb0f4dca_0
+      - conda: aic_utils/aic_training_interfaces
+        build: hb0f4dca_0
       - conda: aic_utils/lerobot_robot_aic
         build: hb0f4dca_0
       - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
@@ -968,6 +970,8 @@ environments:
       - conda: aic_model
         build: h60d57d3_0
       - conda: aic_utils/aic_teleoperation
+        build: h60d57d3_0
+      - conda: aic_utils/aic_training_interfaces
         build: h60d57d3_0
       - conda: aic_utils/lerobot_robot_aic
         build: h60d57d3_0
@@ -8183,6 +8187,38 @@ packages:
   - ros-kilted-aic-control-interfaces
   - ros-kilted-geometry-msgs
   - ros-kilted-rclpy
+  - ros2-distro-mutex
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - libgcc >=15
+  - libgcc >=15
+  - libstdcxx >=15
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: LicenseRef-Apache-2.0
+- conda: aic_utils/aic_training_interfaces
+  name: ros-kilted-aic-training-interfaces
+  version: 0.0.1
+  build: h60d57d3_0
+  subdir: osx-arm64
+  variants:
+    target_platform: osx-arm64
+  depends:
+  - ros-kilted-rosidl-default-runtime
+  - ros2-distro-mutex
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - libcxx >=22
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: LicenseRef-Apache-2.0
+- conda: aic_utils/aic_training_interfaces
+  name: ros-kilted-aic-training-interfaces
+  version: 0.0.1
+  build: hb0f4dca_0
+  subdir: linux-64
+  variants:
+    target_platform: linux-64
+  depends:
+  - ros-kilted-rosidl-default-runtime
   - ros2-distro-mutex
   - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - libgcc >=15

--- a/pixi.toml
+++ b/pixi.toml
@@ -22,6 +22,7 @@ ros-kilted-aic-model = { path = "aic_model" }
 ros-kilted-aic-model-interfaces = { path = "aic_interfaces/aic_model_interfaces" }
 ros-kilted-aic-task-interfaces = { path = "aic_interfaces/aic_task_interfaces" }
 ros-kilted-aic-teleoperation = { path = "aic_utils/aic_teleoperation" }
+ros-kilted-aic-training-interfaces = { path = "aic_utils/aic_training_interfaces" }
 ros-kilted-control-msgs = "*"                                                          # lerobot_robot_ros
 ros-kilted-geometry-msgs = "*"                                                         # lerobot_robot_ros
 ros-kilted-lerobot-robot-aic = { path = "aic_utils/lerobot_robot_aic" }


### PR DESCRIPTION
# PR Description: Add xacro expansion service for training

This PR cherry-picks the `ExpandXacro` service and related training utilities to the `phase_1` branch.

## Key Changes:
*   Added **`ExpandXacro`** ROS 2 service in `aic_utils/aic_training_interfaces`.
*   This service allows model-side code to request xacro-to-XML expansion without requiring direct filesystem access to the eval workspace's package share directories.
*   Added `xacro_expander.py` script and related launch files in `aic_utils/aic_training_utils`.

## Motivation:
To support training workflows where model-side code needs to dynamically expand Xacro files.
