### PR TITLE
Add lifecycle node transitions to insert_cable skill

### DIFF
--- a/flowstate/README.md
+++ b/flowstate/README.md
@@ -91,3 +91,58 @@ export INTRINSIC_CLUSTER="vmp-xxxx-xxxxxxx"
 
 > [!NOTE]
 > It is possible that first time you run `inctl asset install` it fails with error. In that case, please try again.
+
+---
+
+## 🛠️ Building the Skill
+
+We can use the `build_container.sh` and `build_bundle.sh` script from the intrinsic-ai/sdk-ros repository to build and package the skill bundle. The instructions below build and bundle the `insert_cable_skill`.
+
+---
+
+```bash
+cd ~/ws_aic_phase1
+
+# This command builds the insert_cable_skill, the Intrinsic SDK, and the necessary ROS dependencies into a tar image.
+./src/aic/flowstate/scripts/build_container.sh \
+  --skill_name insert_cable_skill \
+  --skill_package aic_flowstate_skills \
+  --manifest_path src/aic/flowstate/aic_flowstate_skills/insert_cable_skill/src/insert_cable_skill.manifest.textproto \
+  --dockerfile ./src/aic/flowstate/resources/Dockerfile.skill \
+  --ros_distro kilted
+
+# This command bundles the skill into a deployable tarball
+inbuild skill bundle \
+  --file_descriptor_set images/insert_cable_skill/insert_cable_skill.desc \
+  --manifest src/aic/flowstate/aic_flowstate_skills/insert_cable_skill/src/insert_cable_skill.manifest.textproto \
+  --oci_image images/insert_cable_skill/insert_cable_skill.tar \
+  --output images/insert_cable_skill/insert_cable_skill.bundle.tar
+```
+
+---
+
+## 📥 Installing skills to Flowstate
+
+After building, upload and install the skill into your solution context.
+
+---
+
+```bash
+
+# 1. Export path to side-loaded service bundle
+export SKILL_BUNDLE=~/ws_aic_phase1/images/insert_cable_skill/insert_cable_skill.bundle.tar
+
+# 2. Add Organization
+export INTRINSIC_ORGANIZATION="<ORG_NAME>"
+
+# 3. Add Cluster Endpoint
+export INTRINSIC_CLUSTER="vmp-xxxx-xxxxxxx"
+
+./inctl asset install \
+  --org $INTRINSIC_ORGANIZATION \
+  --cluster $INTRINSIC_CLUSTER \
+  $SKILL_BUNDLE
+
+```
+
+---

--- a/flowstate/aic_flowstate_ros_bridge/README.md
+++ b/flowstate/aic_flowstate_ros_bridge/README.md
@@ -9,14 +9,14 @@ A Flowstate-ROS bridge plugin that bridges the real-time controller service to R
 Set up the Docker engine:
 
 ```bash
-cd ~/ws_aic
+cd ~/ws_aic_phase1
 ./src/sdk-ros/scripts/setup_docker.sh
 ```
 
 Then, create the service bundle using the `build_service_bundle.sh` script.
 
 ```bash
-cd ~/ws_aic
+cd ~/ws_aic_phase1
 ./src/aic/flowstate/scripts/build_flowstate_ros_bridge.sh --ros_distro kilted
 ```
 
@@ -24,7 +24,7 @@ cd ~/ws_aic
 
 ```bash
 # 1. Export path to side-loaded service bundle
-export SERVICE_BUNDLE=~/ws_aic/images/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge.bundle.tar
+export SERVICE_BUNDLE=~/ws_aic_phase1/images/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge.bundle.tar
 
 # 2. Add Organization
 export INTRINSIC_ORGANIZATION="<ORG_NAME>"

--- a/flowstate/aic_flowstate_skills/CMakeLists.txt
+++ b/flowstate/aic_flowstate_skills/CMakeLists.txt
@@ -18,5 +18,6 @@ find_package(rclcpp_action REQUIRED)
 
 
 add_subdirectory(insert_cable_skill)
+add_subdirectory(lifecycle_transition_skill)
 
 ament_package()

--- a/flowstate/aic_flowstate_skills/insert_cable_skill/CMakeLists.txt
+++ b/flowstate/aic_flowstate_skills/insert_cable_skill/CMakeLists.txt
@@ -3,7 +3,7 @@ intrinsic_sdk_protobuf_generate(
   NAME insert_cable_skill
   SOURCES src/insert_cable_skill.proto
   TARGET insert_cable_skill_protos
-  DESCRIPTOR_SET_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill.desc"
+  DESCRIPTOR_SET_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_protos.desc"
 )
 
 # Generate the skill config file.
@@ -11,7 +11,7 @@ intrinsic_sdk_generate_skill_config(
   TARGET insert_cable_skill_config
   SKILL_NAME insert_cable_skill
   MANIFEST src/insert_cable_skill.manifest.textproto
-  PROTO_DESCRIPTOR_FILE "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill.desc"
+  PROTO_DESCRIPTOR_FILE "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_protos.desc"
   SKILL_CONFIG_FILE_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_config.pbbin"
 )
 
@@ -19,6 +19,7 @@ install(
   FILES
     src/insert_cable_skill.manifest.textproto
     "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_config.pbbin"
+    "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_protos.desc"
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/flowstate/aic_flowstate_skills/insert_cable_skill/CMakeLists.txt
+++ b/flowstate/aic_flowstate_skills/insert_cable_skill/CMakeLists.txt
@@ -46,10 +46,13 @@ target_include_directories(insert_cable_skill_main
 target_link_libraries(insert_cable_skill_main
   intrinsic_sdk_cmake::intrinsic_sdk_cmake
   insert_cable_skill_protos
-  rclcpp::rclcpp
-  rclcpp_action::rclcpp_action
-  lifecycle_msgs::lifecycle_msgs
-  ${aic_task_interfaces_TARGETS}
+)
+
+ament_target_dependencies(insert_cable_skill_main
+  rclcpp
+  rclcpp_action
+  lifecycle_msgs
+  aic_task_interfaces
 )
 
 add_dependencies(insert_cable_skill_main insert_cable_skill_config)

--- a/flowstate/aic_flowstate_skills/insert_cable_skill/CMakeLists.txt
+++ b/flowstate/aic_flowstate_skills/insert_cable_skill/CMakeLists.txt
@@ -29,6 +29,8 @@ intrinsic_sdk_generate_skill_main_cc(
   MAIN_FILE_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_main.cc"
 )
 
+find_package(lifecycle_msgs REQUIRED)
+
 add_executable(insert_cable_skill_main
   src/insert_cable_skill.cc
   ${CMAKE_CURRENT_BINARY_DIR}/insert_cable_skill_main.cc
@@ -46,6 +48,7 @@ target_link_libraries(insert_cable_skill_main
   insert_cable_skill_protos
   rclcpp::rclcpp
   rclcpp_action::rclcpp_action
+  lifecycle_msgs::lifecycle_msgs
   ${aic_task_interfaces_TARGETS}
 )
 

--- a/flowstate/aic_flowstate_skills/insert_cable_skill/src/insert_cable_skill.cc
+++ b/flowstate/aic_flowstate_skills/insert_cable_skill/src/insert_cable_skill.cc
@@ -22,10 +22,10 @@
 #include "absl/status/statusor.h"
 #include "aic_task_interfaces/action/insert_cable.hpp"
 #include "insert_cable_skill.pb.h"
-#include "lifecycle_msgs/srv/change_state.hpp"
-#include "lifecycle_msgs/srv/get_state.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "lifecycle_msgs/msg/transition.hpp"
+#include "lifecycle_msgs/srv/change_state.hpp"
+#include "lifecycle_msgs/srv/get_state.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 
@@ -52,9 +52,10 @@ class InsertCableClientNode : public rclcpp::Node {
     client_ =
         rclcpp_action::create_client<InsertCableAction>(this, "/insert_cable");
     change_state_client_ =
-        this->create_client<lifecycle_msgs::srv::ChangeState>("/aic_model/change_state");
-    get_state_client_ =
-        this->create_client<lifecycle_msgs::srv::GetState>("/aic_model/get_state");
+        this->create_client<lifecycle_msgs::srv::ChangeState>(
+            "/aic_model/change_state");
+    get_state_client_ = this->create_client<lifecycle_msgs::srv::GetState>(
+        "/aic_model/get_state");
   }
 
   absl::StatusOr<InsertCableAction::Result::SharedPtr> SendAction(
@@ -154,11 +155,12 @@ class InsertCableClientNode : public rclcpp::Node {
           "Service '/aic_model/change_state' not available");
     }
 
-    auto request = std::make_shared<lifecycle_msgs::srv::ChangeState::Request>();
+    auto request =
+        std::make_shared<lifecycle_msgs::srv::ChangeState::Request>();
     request->transition.id = transition;
 
     auto future = change_state_client_->async_send_request(request);
-    
+
     if (rclcpp::spin_until_future_complete(
             this->get_node_base_interface(), future,
             std::chrono::milliseconds(static_cast<int>(timeout_ms))) !=
@@ -180,7 +182,7 @@ class InsertCableClientNode : public rclcpp::Node {
     auto request = std::make_shared<lifecycle_msgs::srv::GetState::Request>();
 
     auto future = get_state_client_->async_send_request(request);
-    
+
     if (rclcpp::spin_until_future_complete(
             this->get_node_base_interface(), future,
             std::chrono::milliseconds(static_cast<int>(timeout_ms))) !=
@@ -194,7 +196,8 @@ class InsertCableClientNode : public rclcpp::Node {
   }
 
   rclcpp_action::Client<InsertCableAction>::SharedPtr client_;
-  rclcpp::Client<lifecycle_msgs::srv::ChangeState>::SharedPtr change_state_client_;
+  rclcpp::Client<lifecycle_msgs::srv::ChangeState>::SharedPtr
+      change_state_client_;
   rclcpp::Client<lifecycle_msgs::srv::GetState>::SharedPtr get_state_client_;
 };
 
@@ -257,7 +260,8 @@ InsertCableSkill::Execute(const intrinsic::skills::ExecuteRequest& request,
   }
 
   uint8_t current_state = status_or_state.value();
-  RCLCPP_INFO(client_node_.get_logger(), "Current state of aic_model: %u", current_state);
+  RCLCPP_INFO(client_node_.get_logger(), "Current state of aic_model: %u",
+              current_state);
 
   if (current_state == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED) {
     RCLCPP_INFO(client_node_.get_logger(), "Configuring aic_model...");

--- a/flowstate/aic_flowstate_skills/insert_cable_skill/src/insert_cable_skill.cc
+++ b/flowstate/aic_flowstate_skills/insert_cable_skill/src/insert_cable_skill.cc
@@ -22,6 +22,10 @@
 #include "absl/status/statusor.h"
 #include "aic_task_interfaces/action/insert_cable.hpp"
 #include "insert_cable_skill.pb.h"
+#include "lifecycle_msgs/srv/change_state.hpp"
+#include "lifecycle_msgs/srv/get_state.hpp"
+#include "lifecycle_msgs/msg/state.hpp"
+#include "lifecycle_msgs/msg/transition.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 
@@ -47,6 +51,10 @@ class InsertCableClientNode : public rclcpp::Node {
   InsertCableClientNode() : Node("insert_cable_skill_node") {
     client_ =
         rclcpp_action::create_client<InsertCableAction>(this, "/insert_cable");
+    change_state_client_ =
+        this->create_client<lifecycle_msgs::srv::ChangeState>("/aic_model/change_state");
+    get_state_client_ =
+        this->create_client<lifecycle_msgs::srv::GetState>("/aic_model/get_state");
   }
 
   absl::StatusOr<InsertCableAction::Result::SharedPtr> SendAction(
@@ -140,7 +148,54 @@ class InsertCableClientNode : public rclcpp::Node {
     return result_wrapper.result;
   }
 
+  absl::StatusOr<bool> ChangeState(uint8_t transition, double timeout_ms) {
+    if (!change_state_client_->wait_for_service(std::chrono::seconds(5))) {
+      return absl::UnavailableError(
+          "Service '/aic_model/change_state' not available");
+    }
+
+    auto request = std::make_shared<lifecycle_msgs::srv::ChangeState::Request>();
+    request->transition.id = transition;
+
+    auto future = change_state_client_->async_send_request(request);
+    
+    if (rclcpp::spin_until_future_complete(
+            this->get_node_base_interface(), future,
+            std::chrono::milliseconds(static_cast<int>(timeout_ms))) !=
+        rclcpp::FutureReturnCode::SUCCESS) {
+      return absl::DeadlineExceededError(
+          "Timed out waiting for change_state response");
+    }
+
+    auto response = future.get();
+    return response->success;
+  }
+
+  absl::StatusOr<uint8_t> GetState(double timeout_ms) {
+    if (!get_state_client_->wait_for_service(std::chrono::seconds(5))) {
+      return absl::UnavailableError(
+          "Service '/aic_model/get_state' not available");
+    }
+
+    auto request = std::make_shared<lifecycle_msgs::srv::GetState::Request>();
+
+    auto future = get_state_client_->async_send_request(request);
+    
+    if (rclcpp::spin_until_future_complete(
+            this->get_node_base_interface(), future,
+            std::chrono::milliseconds(static_cast<int>(timeout_ms))) !=
+        rclcpp::FutureReturnCode::SUCCESS) {
+      return absl::DeadlineExceededError(
+          "Timed out waiting for get_state response");
+    }
+
+    auto response = future.get();
+    return response->current_state.id;
+  }
+
   rclcpp_action::Client<InsertCableAction>::SharedPtr client_;
+  rclcpp::Client<lifecycle_msgs::srv::ChangeState>::SharedPtr change_state_client_;
+  rclcpp::Client<lifecycle_msgs::srv::GetState>::SharedPtr get_state_client_;
 };
 
 InitRos init;
@@ -194,6 +249,39 @@ InsertCableSkill::Execute(const intrinsic::skills::ExecuteRequest& request,
 
   RCLCPP_INFO(client_node_.get_logger(), "Sending goal for task ID: %s",
               goal_msg.task.id.c_str());
+
+  // Check state of aic_model
+  auto status_or_state = client_node_.GetState(5000.0);
+  if (!status_or_state.ok()) {
+    return absl::InternalError("Failed to get state of aic_model");
+  }
+
+  uint8_t current_state = status_or_state.value();
+  RCLCPP_INFO(client_node_.get_logger(), "Current state of aic_model: %u", current_state);
+
+  if (current_state == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED) {
+    RCLCPP_INFO(client_node_.get_logger(), "Configuring aic_model...");
+    auto status_or_success = client_node_.ChangeState(
+        lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE, 10000.0);
+    if (!status_or_success.ok() || !status_or_success.value()) {
+      return absl::InternalError("Failed to configure aic_model");
+    }
+    current_state = lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE;
+  }
+
+  if (current_state == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
+    RCLCPP_INFO(client_node_.get_logger(), "Activating aic_model...");
+    auto status_or_success = client_node_.ChangeState(
+        lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE, 10000.0);
+    if (!status_or_success.ok() || !status_or_success.value()) {
+      return absl::InternalError("Failed to activate aic_model");
+    }
+    current_state = lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE;
+  }
+
+  if (current_state != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
+    return absl::InternalError("aic_model is not in active state");
+  }
 
   auto status_or_result =
       client_node_.SendAction(goal_msg, params.time_limit() * 1000.0);

--- a/flowstate/aic_flowstate_skills/lifecycle_transition_skill/CMakeLists.txt
+++ b/flowstate/aic_flowstate_skills/lifecycle_transition_skill/CMakeLists.txt
@@ -1,0 +1,63 @@
+# Generate the skill's protobuf files, protobuf library, and descriptor set file.
+intrinsic_sdk_protobuf_generate(
+  NAME lifecycle_transition_skill
+  SOURCES src/lifecycle_transition_skill.proto
+  TARGET lifecycle_transition_skill_protos
+  DESCRIPTOR_SET_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/lifecycle_transition_skill_protos.desc"
+)
+
+# Generate the skill config file.
+intrinsic_sdk_generate_skill_config(
+  TARGET lifecycle_transition_skill_config
+  SKILL_NAME lifecycle_transition_skill
+  MANIFEST src/lifecycle_transition_skill.manifest.textproto
+  PROTO_DESCRIPTOR_FILE "${CMAKE_CURRENT_BINARY_DIR}/lifecycle_transition_skill_protos.desc"
+  SKILL_CONFIG_FILE_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/lifecycle_transition_skill_config.pbbin"
+)
+
+install(
+  FILES
+    src/lifecycle_transition_skill.manifest.textproto
+    "${CMAKE_CURRENT_BINARY_DIR}/lifecycle_transition_skill_config.pbbin"
+    "${CMAKE_CURRENT_BINARY_DIR}/lifecycle_transition_skill_protos.desc"
+  DESTINATION share/${PROJECT_NAME}
+)
+
+# Generate the c++ main file for the skill.
+intrinsic_sdk_generate_skill_main_cc(
+  MANIFEST src/lifecycle_transition_skill.manifest.textproto
+  HEADER_FILES src/lifecycle_transition_skill.h
+  MAIN_FILE_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/lifecycle_transition_skill_main.cc"
+)
+
+find_package(lifecycle_msgs REQUIRED)
+
+add_executable(lifecycle_transition_skill_main
+  src/lifecycle_transition_skill.cc
+  ${CMAKE_CURRENT_BINARY_DIR}/lifecycle_transition_skill_main.cc
+)
+
+target_include_directories(lifecycle_transition_skill_main
+  PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_BINARY_DIR}
+  ${CMAKE_CURRENT_BINARY_DIR}/src
+)
+
+target_link_libraries(lifecycle_transition_skill_main
+  intrinsic_sdk_cmake::intrinsic_sdk_cmake
+  lifecycle_transition_skill_protos
+)
+
+ament_target_dependencies(lifecycle_transition_skill_main
+  rclcpp
+  lifecycle_msgs
+)
+
+add_dependencies(lifecycle_transition_skill_main lifecycle_transition_skill_config)
+add_dependencies(lifecycle_transition_skill_main lifecycle_transition_skill_protos)
+
+install(
+  TARGETS lifecycle_transition_skill_main
+  DESTINATION lib/${PROJECT_NAME}
+)

--- a/flowstate/aic_flowstate_skills/lifecycle_transition_skill/src/lifecycle_transition_skill.cc
+++ b/flowstate/aic_flowstate_skills/lifecycle_transition_skill/src/lifecycle_transition_skill.cc
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2026 Intrinsic Innovation LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "lifecycle_transition_skill.h"
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "google/protobuf/message.h"
+#include "lifecycle_transition_skill.pb.h"
+#include "intrinsic/skills/cc/skill_interface.h"
+#include "intrinsic/skills/proto/skill_service.pb.h"
+#include "lifecycle_msgs/msg/transition.hpp"
+#include "lifecycle_msgs/srv/change_state.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+// Assuming INTR_ASSIGN_OR_RETURN is available via some included header or transitively.
+// If not, we might need to include "intrinsic/util/status/status_macros.h" if it exists.
+
+namespace {
+
+class InitRos {
+ public:
+  InitRos() { rclcpp::init(0, nullptr); }
+  ~InitRos() { rclcpp::shutdown(); }
+};
+
+InitRos init;
+
+class LifecycleTransitionClientNode : public rclcpp::Node {
+ public:
+  LifecycleTransitionClientNode() : Node("lifecycle_transition_skill_node") {}
+};
+
+std::shared_ptr<LifecycleTransitionClientNode> client_node_;
+
+std::shared_ptr<LifecycleTransitionClientNode> GetClientNode() {
+  if (!client_node_) {
+    client_node_ = std::make_shared<LifecycleTransitionClientNode>();
+  }
+  return client_node_;
+}
+
+uint8_t TransitionStringToId(const std::string& transition) {
+  if (transition == "configure") {
+    return lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE;
+  } else if (transition == "cleanup") {
+    return lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP;
+  } else if (transition == "activate") {
+    return lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE;
+  } else if (transition == "deactivate") {
+    return lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE;
+  } else if (transition == "active_shutdown") {
+    return lifecycle_msgs::msg::Transition::TRANSITION_ACTIVE_SHUTDOWN;
+  } else if (transition == "inactive_shutdown") {
+    return lifecycle_msgs::msg::Transition::TRANSITION_INACTIVE_SHUTDOWN;
+  } else if (transition == "unconfigured_shutdown") {
+    return lifecycle_msgs::msg::Transition::TRANSITION_UNCONFIGURED_SHUTDOWN;
+  }
+  return 0; // Unknown
+}
+
+}  // namespace
+
+std::unique_ptr<intrinsic::skills::SkillInterface>
+LifecycleTransitionSkill::CreateSkill() {
+  return std::make_unique<LifecycleTransitionSkill>();
+}
+
+absl::StatusOr<std::unique_ptr<google::protobuf::Message>>
+LifecycleTransitionSkill::Preview(const intrinsic::skills::PreviewRequest& /*request*/,
+                                  intrinsic::skills::PreviewContext& /*context*/) {
+  return absl::UnimplementedError("Skill has not implemented `Preview`.");
+}
+
+absl::StatusOr<std::unique_ptr<google::protobuf::Message>>
+LifecycleTransitionSkill::Execute(const intrinsic::skills::ExecuteRequest& request,
+                                  intrinsic::skills::ExecuteContext& /*context*/) {
+  auto node = GetClientNode();
+  RCLCPP_INFO(node->get_logger(), "LifecycleTransitionSkill::Execute");
+
+  // We use a manual approach if INTR_ASSIGN_OR_RETURN fails to compile,
+  // but let's try to use it assuming it works like in insert_cable_skill.cc.
+  
+  auto params_or = request.params<ai::flowstate::LifecycleTransitionParams>();
+  if (!params_or.ok()) {
+    return params_or.status();
+  }
+  auto params = params_or.value();
+
+  const std::string& node_name = params.node_name();
+  const std::string& target_state = params.target_state();
+
+  RCLCPP_INFO(node->get_logger(), "Transitioning node %s to %s",
+              node_name.c_str(), target_state.c_str());
+
+  uint8_t transition_id = TransitionStringToId(target_state);
+  if (transition_id == 0) {
+    return absl::InvalidArgumentError("Unknown transition: " + target_state);
+  }
+
+  std::string service_name = node_name + "/change_state";
+  auto client = node->create_client<lifecycle_msgs::srv::ChangeState>(service_name);
+
+  auto timeout_sec = params.timeout();
+  if (timeout_sec == 0) {
+      timeout_sec = 5; // Default timeout
+  }
+
+  if (!client->wait_for_service(std::chrono::seconds(timeout_sec))) {
+    return absl::UnavailableError("Service not available: " + service_name);
+  }
+
+  auto srv_request = std::make_shared<lifecycle_msgs::srv::ChangeState::Request>();
+  srv_request->transition.id = transition_id;
+  srv_request->transition.label = target_state;
+
+  auto future = client->async_send_request(srv_request);
+
+  if (rclcpp::spin_until_future_complete(
+          node->get_node_base_interface(), future,
+          std::chrono::seconds(timeout_sec)) !=
+      rclcpp::FutureReturnCode::SUCCESS) {
+    return absl::DeadlineExceededError("Timed out waiting for change_state response");
+  }
+
+  auto response = future.get();
+  if (!response->success) {
+    return absl::InternalError("Lifecycle transition failed for node " + node_name);
+  }
+
+  RCLCPP_INFO(node->get_logger(), "Successfully transitioned node %s", node_name.c_str());
+
+  auto result = std::make_unique<ai::flowstate::LifecycleTransitionResult>();
+  result->set_success(true);
+  result->set_message("Successfully transitioned node " + node_name);
+
+  return result;
+}

--- a/flowstate/aic_flowstate_skills/lifecycle_transition_skill/src/lifecycle_transition_skill.h
+++ b/flowstate/aic_flowstate_skills/lifecycle_transition_skill/src/lifecycle_transition_skill.h
@@ -1,0 +1,33 @@
+#ifndef LIFECYCLE_TRANSITION_SKILL_H_
+#define LIFECYCLE_TRANSITION_SKILL_H_
+
+#include <memory>
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "intrinsic/skills/cc/skill_interface.h"
+#include "intrinsic/skills/proto/skill_service.pb.h"
+
+class LifecycleTransitionSkill final : public intrinsic::skills::SkillInterface {
+ public:
+  /**
+   * @copydoc intrinsic::skills::SkillInterface:: CreateSkill
+   */
+  static std::unique_ptr<intrinsic::skills::SkillInterface> CreateSkill();
+
+  /**
+   * @copydoc intrinsic::skills::SkillInterface:: Preview
+   */
+  absl::StatusOr<std::unique_ptr<google::protobuf::Message>> Preview(
+      const intrinsic::skills::PreviewRequest& request,
+      intrinsic::skills::PreviewContext& context) override;
+
+  /**
+   * @copydoc intrinsic::skills::SkillInterface:: Execute
+   */
+  absl::StatusOr<std::unique_ptr<google::protobuf::Message>> Execute(
+      const intrinsic::skills::ExecuteRequest& request,
+      intrinsic::skills::ExecuteContext& context) override;
+};
+
+#endif  // LIFECYCLE_TRANSITION_SKILL_H_

--- a/flowstate/aic_flowstate_skills/lifecycle_transition_skill/src/lifecycle_transition_skill.manifest.textproto
+++ b/flowstate/aic_flowstate_skills/lifecycle_transition_skill/src/lifecycle_transition_skill.manifest.textproto
@@ -1,0 +1,28 @@
+id {
+  package: "ai.flowstate"
+  name: "lifecycle_transition_skill"
+}
+display_name: "Lifecycle Transition Skill"
+vendor {
+  display_name: "Intrinsic"
+}
+documentation {
+  description: "Generic skill to trigger lifecycle transitions for ROS 2 nodes."
+}
+options {
+  supports_cancellation: false
+  cc_config {
+    create_skill: "::LifecycleTransitionSkill::CreateSkill"
+  }
+}
+dependencies {
+}
+parameter {
+  message_full_name: "ai.flowstate.LifecycleTransitionParams"
+  default_value: {
+    type_url: "type.googleapis.com/ai.flowstate.LifecycleTransitionParams"
+  }
+}
+return_type {
+  message_full_name: "ai.flowstate.LifecycleTransitionResult"
+}

--- a/flowstate/aic_flowstate_skills/lifecycle_transition_skill/src/lifecycle_transition_skill.proto
+++ b/flowstate/aic_flowstate_skills/lifecycle_transition_skill/src/lifecycle_transition_skill.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package ai.flowstate;
+
+message LifecycleTransitionParams {
+  // The name of the lifecycle node.
+  string node_name = 1;
+  // The target state or transition label (e.g., "configure", "activate").
+  string target_state = 2;
+  // Timeout for the transition in seconds.
+  uint64 timeout = 3;
+}
+
+message LifecycleTransitionResult {
+  // True if the task succeeded.
+  bool success = 1;
+  // A message if the task succeeded or failed.
+  string message = 2;
+}

--- a/flowstate/resources/Dockerfile.skill
+++ b/flowstate/resources/Dockerfile.skill
@@ -1,0 +1,114 @@
+# Build up the skill with these stages:
+#   - base (ros:jazzy + settings) ->
+#   - underlay (dependencies) ->
+#   - overlay (user code) ->
+#   - result (base + copied install folder of underlay and overlay)
+
+ARG ROS_DISTRO=jazzy
+
+# base stage: ros:jazzy + configs
+FROM ros:${ROS_DISTRO} AS base
+
+WORKDIR /opt/ros/underlay
+
+ENV ROS_HOME=/tmp
+ENV RMW_IMPLEMENTATION=rmw_zenoh_cpp
+
+# underlay stage: base + dependencies built
+FROM base AS underlay
+
+ADD src/sdk-ros /opt/ros/underlay/src/sdk-ros
+
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
+    && apt-get update \
+    && rosdep update \
+    && rosdep install --from-paths src --ignore-src -r -y \
+    && apt install -y ros-${ROS_DISTRO}-ament-cmake-vendor-package \
+    && colcon build \
+        --continue-on-error \
+        --cmake-args -DCMAKE_BUILD_TYPE=Release \
+        --event-handlers=console_direct+ \
+        --merge-install \
+        --packages-up-to intrinsic_sdk
+
+# overlay stage: underlay + skill code built
+FROM underlay AS overlay
+
+ARG SKILL_PACKAGE
+ARG DEPENDENCIES
+
+ARG ROS_DISTRO=jazzy
+RUN apt-get update \
+    && apt install -y ros-${ROS_DISTRO}-rmw-zenoh-cpp python3-protobuf ${DEPENDENCIES} \
+    && rm -rf /var/lib/apt/lists/*
+
+ADD src /opt/ros/overlay/src
+
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
+    && . /opt/ros/underlay/install/setup.sh \
+    && cd /opt/ros/overlay \
+    && colcon build \
+      --cmake-args -DCMAKE_BUILD_TYPE=Release \
+      --event-handlers=console_direct+ \
+      --merge-install \
+      --packages-up-to=${SKILL_PACKAGE} \
+      --packages-skip intrinsic_sdk grpc_vendor
+
+# result stage: base + copied install folders from the overlay + skill setup
+FROM base
+
+ARG SKILL_PACKAGE
+ARG SKILL_NAME
+ARG SKILL_EXECUTABLE_NAME
+ARG DEPENDENCIES
+
+ARG ROS_DISTRO=jazzy
+RUN apt-get update \
+    && apt-get install -y ros-${ROS_DISTRO}-rmw-zenoh-cpp \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=overlay /opt/ros/underlay/install /opt/ros/underlay/install
+COPY --from=overlay /opt/ros/overlay/install /opt/ros/overlay/install
+
+# The reverse domain name for the organization in the asset-id label.
+ARG SKILL_ASSET_ID_ORG="ai.intrinsic"
+ENV ENTRYPOINT="ros2 run ${SKILL_PACKAGE} ${SKILL_EXECUTABLE_NAME}"
+ENV SKILL_CONFIG=share/${SKILL_PACKAGE}/${SKILL_NAME}_config.pbbin
+
+# Create linkable bash script to run the ENTRYPOINT executable
+RUN echo -e "#!/bin/bash\nexec $ENTRYPOINT \"\$@\"" > /run_skill.sh \
+    && chmod +x /run_skill.sh
+
+RUN set -x \
+    && mkdir -p /skills \
+    && ln -sf /run_skill.sh /skills/skill_service \
+    && ln -sf /opt/ros/overlay/install/$SKILL_CONFIG /skills/skill_service_config.proto.bin \
+    && sed --in-place \
+        --expression '$isource "/opt/ros/overlay/install/setup.bash"' \
+        /ros_entrypoint.sh \
+    && sed --in-place \
+        --expression '$iexport RMW_IMPLEMENTATION=rmw_zenoh_cpp' \
+        /ros_entrypoint.sh \
+    && sed --in-place \
+        --expression '$iexport ROS_HOME=/tmp' \
+        /ros_entrypoint.sh \
+    && sed --in-place \
+        --expression '$iexport ZENOH_CONFIG_OVERRIDE='\'connect/endpoints=[\"tcp/zenoh-router.app-intrinsic-base.svc.cluster.local:7447\"]\''' \
+        /ros_entrypoint.sh
+
+# Set some labels used by Flowstate.
+LABEL "ai.intrinsic.asset-id"="${SKILL_ASSET_ID_ORG}.${SKILL_PACKAGE}"
+LABEL "ai.intrinsic.skill-image-name"="${SKILL_PACKAGE}"
+
+# Build arguments are not substituted in the CMD command and hence we set environemnt variables
+# which can be substituted instead.
+ENV SKILL_PACKAGE=${SKILL_PACKAGE}
+ENV SKILL_NAME=${SKILL_NAME}
+ENV SKILL_EXECUTABLE_NAME=${SKILL_EXECUTABLE_NAME}
+ENV ENTRYPOINT=${ENTRYPOINT}
+ENV ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+
+# Execute the skill main by default, but note that Flowstate will likely override this statement.
+CMD [ \
+    "/skills/skill_service", \
+    "--skill_service_config_filename=/skills/skill_service_config.proto.bin"]

--- a/flowstate/scripts/build_container.sh
+++ b/flowstate/scripts/build_container.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+IMAGES_DIR=./images
+BUILDER_NAME=container-builder
+ROS_DISTRO=jazzy
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --images_dir)
+      IMAGES_DIR="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --builder_name)
+      BUILDER_NAME="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --service_name)
+      SERVICE_NAME="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --service_package)
+      SERVICE_PACKAGE="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --skill_name)
+      SKILL_NAME="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --skill_package)
+      SKILL_PACKAGE="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --dockerfile)
+      CUSTOM_DOCKERFILE="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --manifest_path)
+      MANIFEST_PATH="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --dependencies)
+      DEPENDENCIES="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --ros_distro)
+      ROS_DISTRO="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+  esac
+done
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+if [[ -n "$SERVICE_NAME" && -n "$SERVICE_PACKAGE" ]]; then
+  mkdir -p $IMAGES_DIR/$SERVICE_NAME
+
+  if [[ -n "$CUSTOM_DOCKERFILE" ]]; then
+    DOCKERFILE="$CUSTOM_DOCKERFILE"
+  else
+    DOCKERFILE="$SCRIPT_DIR/../resources/Dockerfile.service"
+  fi
+
+  docker buildx build -t $SERVICE_PACKAGE:$SERVICE_NAME \
+      --builder="$BUILDER_NAME" \
+      --output="\
+        type=docker,\
+        dest=$IMAGES_DIR/$SERVICE_NAME/$SERVICE_NAME.tar,\
+        compression=zstd,\
+        push=false,\
+        name=$SERVICE_PACKAGE:$SERVICE_NAME" \
+      --file $DOCKERFILE \
+      --build-arg="SERVICE_PACKAGE=$SERVICE_PACKAGE" \
+      --build-arg="SERVICE_NAME=$SERVICE_NAME" \
+      --build-arg="DEPENDENCIES=$DEPENDENCIES" \
+      --build-arg="SERVICE_EXECUTABLE_NAME=${SERVICE_NAME}_main" \
+      --build-arg="ROS_DISTRO=$ROS_DISTRO" \
+      .
+elif [[ -n "$SKILL_NAME" && -n "$SKILL_PACKAGE" ]]; then
+  mkdir -p $IMAGES_DIR/$SKILL_NAME
+
+  if [[ -n "$CUSTOM_DOCKERFILE" ]]; then
+    DOCKERFILE="$CUSTOM_DOCKERFILE"
+  else
+    DOCKERFILE="$SCRIPT_DIR/../resources/Dockerfile.skill"
+  fi
+
+  docker buildx build -t $SKILL_PACKAGE:$SKILL_NAME \
+      --builder="$BUILDER_NAME" \
+      --output="\
+        type=docker,\
+        dest=$IMAGES_DIR/$SKILL_NAME/$SKILL_NAME.tar,\
+        compression=zstd,\
+        push=false,\
+        name=$SKILL_PACKAGE:$SKILL_NAME" \
+      --file $DOCKERFILE \
+      --build-arg="SKILL_PACKAGE=$SKILL_PACKAGE" \
+      --build-arg="SKILL_NAME=$SKILL_NAME" \
+      --build-arg="SKILL_EXECUTABLE_NAME=${SKILL_NAME}_main" \
+      --build-arg="ROS_DISTRO=$ROS_DISTRO" \
+      .
+
+  if [[ -n "$MANIFEST_PATH" ]]; then
+    # Parse the SDK_VERSION from sdk_version.json
+    SDK_VERSION_FILE="$SCRIPT_DIR/../intrinsic_sdk_cmake/cmake/sdk_version.json"
+    SDK_VERSION=$(grep -oP '"sdk_version": "\K[^"]+' "$SDK_VERSION_FILE")
+
+    # Download the 'inbuild' tool if it doesn't exist
+    if [ ! -f ./inbuild ]; then
+        echo "INFO: Downloading inbuild tool version ${SDK_VERSION}..."
+        wget "https://github.com/intrinsic-ai/sdk/releases/download/${SDK_VERSION}/inbuild-linux-amd64" -O inbuild \
+          && chmod +x inbuild
+    fi
+
+    echo "INFO: Loading newly built image into local daemon..."
+    docker load -i "images/${SKILL_NAME}/${SKILL_NAME}.tar"
+
+    echo "INFO: Extracting descriptor set from container..."
+    docker create --name temp_container "$SKILL_PACKAGE:$SKILL_NAME"
+    docker cp "temp_container:/opt/ros/overlay/install/share/${SKILL_PACKAGE}/${SKILL_NAME}_protos.desc" \
+     "images/${SKILL_NAME}/${SKILL_NAME}_protos.desc"
+    docker rm -f temp_container
+
+    echo "INFO: Building the skill bundle..."
+    ./inbuild skill bundle \
+      --file_descriptor_set "images/${SKILL_NAME}/${SKILL_NAME}_protos.desc" \
+      --manifest "${MANIFEST_PATH}" \
+      --oci_image "images/${SKILL_NAME}/${SKILL_NAME}.tar" \
+      --output "images/${SKILL_NAME}/${SKILL_NAME}.bundle.tar"
+  fi
+fi


### PR DESCRIPTION
## Add conditional lifecycle management and fix build for insert_cable_skill

### Summary
This PR introduces updates to the insert_cable_skill to handle the lifecycle of the aic_model node more robustly. It also fixes issues in the skill's CMakeLists.txt that prevented the descriptor set from being correctly generated and packaged into the skill bundle.

### Detailed Changes

`insert_cable_skill.cc`: Added logic to query the state of the aic_model lifecycle node via /aic_model/get_state. The skill now conditionally triggers `CONFIGURE` and `ACTIVATE` transitions only if the node is not already in the desired state, preventing errors from redundant transition requests.

`CMakeLists.txt`:
Added lifecycle_msgs as a required dependency.
Refactored library linking to use ament_target_dependencies for standard ROS 2 packages (`rclcpp`, `rclcpp_action`, `lifecycle_msgs`, `aic_task_interfaces`).
Updated the descriptor file output name to `insert_cable_skill_protos.desc` to align with script expectations.
