### PR TITLE
Enable stripping of TF frame prefix and remapping of TF frame names

### DIFF
--- a/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge.proto
+++ b/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge.proto
@@ -40,6 +40,5 @@ message FlowstateRosBridgeConfig {
   int64 executive_update_rate_millis = 11;
   SensorPublisherConfig sensors = 12;
   repeated string strip_flowstate_tf_prefix = 13;
-  repeated string remap_tf_names = 14;
-  RobotControlBridgeConfig robot_control_bridge_config = 15;
+  RobotControlBridgeConfig robot_control_bridge_config = 14;
 }

--- a/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge.proto
+++ b/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge.proto
@@ -39,5 +39,7 @@ message FlowstateRosBridgeConfig {
   int64 executive_deadline_seconds = 10;
   int64 executive_update_rate_millis = 11;
   SensorPublisherConfig sensors = 12;
-  RobotControlBridgeConfig robot_control_bridge_config = 13;
+  string strip_flowstate_tf_prefix = 13;
+  repeated string remap_tf_names = 14;
+  RobotControlBridgeConfig robot_control_bridge_config = 15;
 }

--- a/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge.proto
+++ b/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge.proto
@@ -39,7 +39,7 @@ message FlowstateRosBridgeConfig {
   int64 executive_deadline_seconds = 10;
   int64 executive_update_rate_millis = 11;
   SensorPublisherConfig sensors = 12;
-  string strip_flowstate_tf_prefix = 13;
+  repeated string strip_flowstate_tf_prefix = 13;
   repeated string remap_tf_names = 14;
   RobotControlBridgeConfig robot_control_bridge_config = 15;
 }

--- a/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge_default_config.pbtxt
+++ b/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge_default_config.pbtxt
@@ -25,8 +25,8 @@
     enable_force_torque_topic: true
     robot_joint_state_topic: "/joint_states"
     force_torque_topic: "/fts_broadcaster/wrench"
-    robot_base_frame_id: "robot/robot/base_link"
-    force_torque_sensor_frame_id: "force_torque_sensor/force_torque_sensor/AtiForceTorqueSensor"
+    robot_base_frame_id: "base_link"
+    force_torque_sensor_frame_id: "ati/tool_link"
     robot_controller_instance: "robot_controller"
     throttle_robot_state_topic: false
     override_joint_names: [
@@ -42,7 +42,7 @@
     server_address: "istio-ingressgateway.app-ingress.svc.cluster.local:80"
     instance: "robot_controller"
     part_name: "arm"
-    ft_sensor_part_name: "ati_ft_sensor"
+    ft_sensor_part_name: "ati"
     task_settings_file: "config/default_task_settings.pbtxt"
     joint_task_settings_file: "config/default_joint_task_settings.pbtxt"
   },

--- a/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge_default_config.pbtxt
+++ b/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge_default_config.pbtxt
@@ -19,7 +19,6 @@
   executive_deadline_seconds: 5
   executive_update_rate_millis: 1000
   strip_flowstate_tf_prefix: ["robot/"]
-  remap_tf_names: ["robotiq_gripper/tool_frame", "gripper/tcp"]
   sensors: {
     enable_robot_joint_state_topic: true
     enable_force_torque_topic: true

--- a/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge_default_config.pbtxt
+++ b/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge_default_config.pbtxt
@@ -18,7 +18,7 @@
   ]
   executive_deadline_seconds: 5
   executive_update_rate_millis: 1000
-  strip_flowstate_tf_prefix: "robot/"
+  strip_flowstate_tf_prefix: ["robot/"]
   remap_tf_names: ["robotiq_gripper/tool_frame", "gripper/tcp"]
   sensors: {
     enable_robot_joint_state_topic: true

--- a/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge_default_config.pbtxt
+++ b/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge_default_config.pbtxt
@@ -18,6 +18,8 @@
   ]
   executive_deadline_seconds: 5
   executive_update_rate_millis: 1000
+  strip_flowstate_tf_prefix: "robot/"
+  remap_tf_names: ["robotiq_gripper/tool_frame", "gripper/tcp"]
   sensors: {
     enable_robot_joint_state_topic: true
     enable_force_torque_topic: true

--- a/flowstate/aic_flowstate_ros_bridge/launch/aic_flowstate_ros_bridge_launch.py
+++ b/flowstate/aic_flowstate_ros_bridge/launch/aic_flowstate_ros_bridge_launch.py
@@ -99,7 +99,7 @@ def generate_launch_description():
                             "flowstate_ros_bridge::ExecutiveBridge",
                             "flowstate_ros_bridge::WorldBridge",
                             "flowstate_ros_bridge::RobotControlBridge",
-                            # "flowstate_ros_bridge::AicCameraBridge",
+                            "flowstate_ros_bridge::AicCameraBridge",
                         ],
                         "server_address": LaunchConfiguration("server_address"),
                         "instance": LaunchConfiguration("instance"),
@@ -134,7 +134,6 @@ def generate_launch_description():
                             "wrist_3_joint",
                         ],
                         "strip_flowstate_tf_prefix": ["robot/"],
-                        "remap_tf_names": ["robotiq_gripper/tool_frame", "gripper/tcp"],
                     }
                 ],
             ),

--- a/flowstate/aic_flowstate_ros_bridge/launch/aic_flowstate_ros_bridge_launch.py
+++ b/flowstate/aic_flowstate_ros_bridge/launch/aic_flowstate_ros_bridge_launch.py
@@ -76,6 +76,16 @@ def generate_launch_description():
                 default_value="ati_ft_sensor",
                 description="F/T sensor part name",
             ),
+            DeclareLaunchArgument(
+                "strip_flowstate_tf_prefix",
+                default_value="robot/",
+                description="Strips the TF prefix from flowstate TF frames",
+            ),
+            DeclareLaunchArgument(
+                "use_sim_time",
+                default_value="true",
+                description="Use simulation clock if true",
+            ),
             LifecycleNode(
                 package="flowstate_ros_bridge",
                 executable="flowstate_ros_bridge",
@@ -84,6 +94,7 @@ def generate_launch_description():
                 output="screen",
                 parameters=[
                     {
+                        "use_sim_time": LaunchConfiguration("use_sim_time"),
                         "autostart": True,
                         "service_tunnel": LaunchConfiguration("service_tunnel"),
                         "flowstate_zenoh_router_address": LaunchConfiguration(
@@ -93,7 +104,7 @@ def generate_launch_description():
                             "flowstate_ros_bridge::ExecutiveBridge",
                             "flowstate_ros_bridge::WorldBridge",
                             "flowstate_ros_bridge::RobotControlBridge",
-                            "flowstate_ros_bridge::AicCameraBridge",
+                            # "flowstate_ros_bridge::AicCameraBridge",
                         ],
                         "server_address": LaunchConfiguration("server_address"),
                         "instance": LaunchConfiguration("instance"),
@@ -126,6 +137,12 @@ def generate_launch_description():
                             "wrist_1_joint",
                             "wrist_2_joint",
                             "wrist_3_joint",
+                        ],
+                        "strip_flowstate_tf_prefix": LaunchConfiguration(
+                            "strip_flowstate_tf_prefix"
+                        ),
+                        "remap_tf_names":  [
+                            "robotiq_gripper/tool_frame", "gripper/tcp"
                         ],
                     }
                 ],

--- a/flowstate/aic_flowstate_ros_bridge/launch/aic_flowstate_ros_bridge_launch.py
+++ b/flowstate/aic_flowstate_ros_bridge/launch/aic_flowstate_ros_bridge_launch.py
@@ -63,17 +63,17 @@ def generate_launch_description():
             ),
             DeclareLaunchArgument(
                 "robot_base_frame_id",
-                default_value="robot/robot/base_link",
+                default_value="base_link",
                 description="Frame ID of robot base to be used in robot_joint_state_topic",
             ),
             DeclareLaunchArgument(
                 "force_torque_sensor_frame_id",
-                default_value="force_torque_sensor/force_torque_sensor/AtiForceTorqueSensor",
+                default_value="ati/tool_link",
                 description="Frame ID of F/T sensor to be used in force_torque_topic",
             ),
             DeclareLaunchArgument(
                 "ft_sensor_part_name",
-                default_value="ati_ft_sensor",
+                default_value="ati",
                 description="F/T sensor part name",
             ),
             DeclareLaunchArgument(

--- a/flowstate/aic_flowstate_ros_bridge/launch/aic_flowstate_ros_bridge_launch.py
+++ b/flowstate/aic_flowstate_ros_bridge/launch/aic_flowstate_ros_bridge_launch.py
@@ -77,11 +77,6 @@ def generate_launch_description():
                 description="F/T sensor part name",
             ),
             DeclareLaunchArgument(
-                "strip_flowstate_tf_prefix",
-                default_value="robot/",
-                description="Strips the TF prefix from flowstate TF frames",
-            ),
-            DeclareLaunchArgument(
                 "use_sim_time",
                 default_value="true",
                 description="Use simulation clock if true",
@@ -138,9 +133,7 @@ def generate_launch_description():
                             "wrist_2_joint",
                             "wrist_3_joint",
                         ],
-                        "strip_flowstate_tf_prefix": LaunchConfiguration(
-                            "strip_flowstate_tf_prefix"
-                        ),
+                        "strip_flowstate_tf_prefix": ["robot/"],
                         "remap_tf_names": ["robotiq_gripper/tool_frame", "gripper/tcp"],
                     }
                 ],

--- a/flowstate/aic_flowstate_ros_bridge/launch/aic_flowstate_ros_bridge_launch.py
+++ b/flowstate/aic_flowstate_ros_bridge/launch/aic_flowstate_ros_bridge_launch.py
@@ -141,9 +141,7 @@ def generate_launch_description():
                         "strip_flowstate_tf_prefix": LaunchConfiguration(
                             "strip_flowstate_tf_prefix"
                         ),
-                        "remap_tf_names":  [
-                            "robotiq_gripper/tool_frame", "gripper/tcp"
-                        ],
+                        "remap_tf_names": ["robotiq_gripper/tool_frame", "gripper/tcp"],
                     }
                 ],
             ),

--- a/flowstate/aic_flowstate_ros_bridge/src/aic_flowstate_ros_bridge_main.cpp
+++ b/flowstate/aic_flowstate_ros_bridge/src/aic_flowstate_ros_bridge_main.cpp
@@ -91,13 +91,18 @@ int main(int argc, char* argv[]) {
                                        bridge_plugins_proto.end());
   rclcpp::Parameter bridge_plugins_param("bridge_plugins", plugin_list);
   params.push_back(std::move(bridge_plugins_param));
-  params.emplace_back("strip_flowstate_tf_prefix",
-                      ros_config.strip_flowstate_tf_prefix());
+  const auto& strip_flowstate_tf_prefix_proto =
+      ros_config.strip_flowstate_tf_prefix();
+  std::vector<std::string> strip_flowstate_tf_prefix_list(
+      strip_flowstate_tf_prefix_proto.begin(),
+      strip_flowstate_tf_prefix_proto.end());
+  params.push_back(std::move(rclcpp::Parameter(
+      "strip_flowstate_tf_prefix", std::move(strip_flowstate_tf_prefix_list))));
   const auto& remap_tf_names_proto = ros_config.remap_tf_names();
   std::vector<std::string> remap_tf_names_list(remap_tf_names_proto.begin(),
                                                remap_tf_names_proto.end());
-  rclcpp::Parameter remap_tf_names_param("remap_tf_names", remap_tf_names_list);
-  params.push_back(std::move(remap_tf_names_param));
+  params.push_back(std::move(
+      rclcpp::Parameter("remap_tf_names", std::move(remap_tf_names_list))));
 
   const auto& s = ros_config.sensors();
   params.emplace_back("enable_robot_joint_state_topic",

--- a/flowstate/aic_flowstate_ros_bridge/src/aic_flowstate_ros_bridge_main.cpp
+++ b/flowstate/aic_flowstate_ros_bridge/src/aic_flowstate_ros_bridge_main.cpp
@@ -95,7 +95,7 @@ int main(int argc, char* argv[]) {
                       ros_config.strip_flowstate_tf_prefix());
   const auto& remap_tf_names_proto = ros_config.remap_tf_names();
   std::vector<std::string> remap_tf_names_list(remap_tf_names_proto.begin(),
-                                       remap_tf_names_proto.end());
+                                               remap_tf_names_proto.end());
   rclcpp::Parameter remap_tf_names_param("remap_tf_names", remap_tf_names_list);
   params.push_back(std::move(remap_tf_names_param));
 

--- a/flowstate/aic_flowstate_ros_bridge/src/aic_flowstate_ros_bridge_main.cpp
+++ b/flowstate/aic_flowstate_ros_bridge/src/aic_flowstate_ros_bridge_main.cpp
@@ -91,6 +91,13 @@ int main(int argc, char* argv[]) {
                                        bridge_plugins_proto.end());
   rclcpp::Parameter bridge_plugins_param("bridge_plugins", plugin_list);
   params.push_back(std::move(bridge_plugins_param));
+  params.emplace_back("strip_flowstate_tf_prefix",
+                      ros_config.strip_flowstate_tf_prefix());
+  const auto& remap_tf_names_proto = ros_config.remap_tf_names();
+  std::vector<std::string> remap_tf_names_list(remap_tf_names_proto.begin(),
+                                       remap_tf_names_proto.end());
+  rclcpp::Parameter remap_tf_names_param("remap_tf_names", remap_tf_names_list);
+  params.push_back(std::move(remap_tf_names_param));
 
   const auto& s = ros_config.sensors();
   params.emplace_back("enable_robot_joint_state_topic",

--- a/flowstate/aic_flowstate_ros_bridge/src/aic_flowstate_ros_bridge_main.cpp
+++ b/flowstate/aic_flowstate_ros_bridge/src/aic_flowstate_ros_bridge_main.cpp
@@ -98,11 +98,6 @@ int main(int argc, char* argv[]) {
       strip_flowstate_tf_prefix_proto.end());
   params.push_back(std::move(rclcpp::Parameter(
       "strip_flowstate_tf_prefix", std::move(strip_flowstate_tf_prefix_list))));
-  const auto& remap_tf_names_proto = ros_config.remap_tf_names();
-  std::vector<std::string> remap_tf_names_list(remap_tf_names_proto.begin(),
-                                               remap_tf_names_proto.end());
-  params.push_back(std::move(
-      rclcpp::Parameter("remap_tf_names", std::move(remap_tf_names_list))));
 
   const auto& s = ros_config.sensors();
   params.emplace_back("enable_robot_joint_state_topic",

--- a/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.cpp
+++ b/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.cpp
@@ -532,20 +532,6 @@ void RobotControlBridge::RobotStateCallback(
     LOG(WARNING) << "Backwards time jump detected for controller server "
                     "timestamp, indicating a reset.";
     data_->connected_to_controller_ = false;
-
-    for (int i = 0; i < data_->restart_connection_retries_; ++i) {
-      data_->connected_to_controller_ = restartControllerBridge();
-      if (data_->connected_to_controller_) {
-        break;
-      }
-      if (i < data_->restart_connection_retries_ - 1) {
-        LOG(INFO)
-            << "Failed to restart controller bridge. Retrying in 500ms...";
-        // todo(johntgz): This sleep currently blocks the bridge. Investigate
-        // the use of threads for non-blocking behaviour.
-        rclcpp::sleep_for(std::chrono::milliseconds(500));
-      }
-    }
   }
   data_->last_part_status_timestamp_ns_ = current_timestamp_ns;
 }

--- a/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.cpp
+++ b/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.cpp
@@ -333,8 +333,7 @@ bool RobotControlBridge::initialize(
       break;
     }
     if (i < data_->restart_connection_retries_ - 1) {
-      LOG(INFO)
-          << "Failed to restart controller bridge. Retrying in 500ms...";
+      LOG(INFO) << "Failed to restart controller bridge. Retrying in 500ms...";
       // todo(johntgz): This sleep currently blocks the bridge. Investigate
       // the use of threads for non-blocking behaviour.
       rclcpp::sleep_for(std::chrono::milliseconds(500));

--- a/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.cpp
+++ b/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.cpp
@@ -76,7 +76,7 @@ void RobotControlBridge::declare_ros_parameters(
   param_interface->declare_parameter(kAgentBridgeJointTaskSettingsFileParamName,
                                      rclcpp::ParameterValue{""});
   param_interface->declare_parameter(kRestartConnectionRetriesParamName,
-                                     rclcpp::ParameterValue{6});
+                                     rclcpp::ParameterValue{10});
 }
 
 ///=============================================================================
@@ -327,10 +327,18 @@ bool RobotControlBridge::initialize(
             << ", instance: " << data_->instance_
             << ", part: " << data_->part_name_;
 
-  data_->connected_to_controller_ = restartControllerBridge();
-  if (!data_->connected_to_controller_) {
-    LOG(ERROR) << "Failed to connect to controller bridge.";
-    // todo(johntgz) add retry mechanism
+  for (int i = 0; i < data_->restart_connection_retries_; ++i) {
+    data_->connected_to_controller_ = restartControllerBridge();
+    if (data_->connected_to_controller_) {
+      break;
+    }
+    if (i < data_->restart_connection_retries_ - 1) {
+      LOG(INFO)
+          << "Failed to restart controller bridge. Retrying in 500ms...";
+      // todo(johntgz): This sleep currently blocks the bridge. Investigate
+      // the use of threads for non-blocking behaviour.
+      rclcpp::sleep_for(std::chrono::milliseconds(500));
+    }
   }
 
   LOG(INFO) << "Initialized RobotControlBridge.";
@@ -524,6 +532,20 @@ void RobotControlBridge::RobotStateCallback(
     LOG(WARNING) << "Backwards time jump detected for controller server "
                     "timestamp, indicating a reset.";
     data_->connected_to_controller_ = false;
+
+    for (int i = 0; i < data_->restart_connection_retries_; ++i) {
+      data_->connected_to_controller_ = restartControllerBridge();
+      if (data_->connected_to_controller_) {
+        break;
+      }
+      if (i < data_->restart_connection_retries_ - 1) {
+        LOG(INFO)
+            << "Failed to restart controller bridge. Retrying in 500ms...";
+        // todo(johntgz): This sleep currently blocks the bridge. Investigate
+        // the use of threads for non-blocking behaviour.
+        rclcpp::sleep_for(std::chrono::milliseconds(500));
+      }
+    }
   }
   data_->last_part_status_timestamp_ns_ = current_timestamp_ns;
 }

--- a/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.cpp
+++ b/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.cpp
@@ -327,17 +327,10 @@ bool RobotControlBridge::initialize(
             << ", instance: " << data_->instance_
             << ", part: " << data_->part_name_;
 
-  for (int i = 0; i < data_->restart_connection_retries_; ++i) {
-    data_->connected_to_controller_ = restartControllerBridge();
-    if (data_->connected_to_controller_) {
-      break;
-    }
-    if (i < data_->restart_connection_retries_ - 1) {
-      LOG(INFO) << "Failed to restart controller bridge. Retrying in 500ms...";
-      // todo(johntgz): This sleep currently blocks the bridge. Investigate
-      // the use of threads for non-blocking behaviour.
-      rclcpp::sleep_for(std::chrono::milliseconds(500));
-    }
+  data_->connected_to_controller_ = restartControllerBridge();
+  if (!data_->connected_to_controller_) {
+    LOG(ERROR) << "Failed to connect to controller bridge.";
+    // todo(johntgz) add retry mechanism
   }
 
   LOG(INFO) << "Initialized RobotControlBridge.";


### PR DESCRIPTION
This PR depends on the [jt/strip-tf-prefix branch of sdk-ros](https://github.com/intrinsic-ai/sdk-ros/tree/jt/strip-tf-prefix).
It adds the parameters `strip_flowstate_tf_prefix` and `remap_tf_names` which are used by the `flowstate_ros_bridge` in the  

This is required for:
- Stripping of the `robot/` prefix from the Flowstate TF frames via the `strip_flowstate_tf_prefix` parameter
- Remapping the frame  `robotiq_gripper/tool_frame` to `gripper/tcp`  via the  `remap_tf_names` param. 