### PR TITLE
Configure transitions in lifecycle_transition_skill as enums

### DIFF
--- a/flowstate/aic_flowstate_skills/lifecycle_transition_skill/CMakeLists.txt
+++ b/flowstate/aic_flowstate_skills/lifecycle_transition_skill/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Generate the skill's protobuf files, protobuf library, and descriptor set file.
 intrinsic_sdk_protobuf_generate(
   NAME lifecycle_transition_skill
-  SOURCES src/lifecycle_transition_skill.proto
+  SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/lifecycle_transition_skill.proto"
   TARGET lifecycle_transition_skill_protos
   DESCRIPTOR_SET_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/lifecycle_transition_skill_protos.desc"
 )

--- a/flowstate/aic_flowstate_skills/lifecycle_transition_skill/src/lifecycle_transition_skill.cc
+++ b/flowstate/aic_flowstate_skills/lifecycle_transition_skill/src/lifecycle_transition_skill.cc
@@ -20,11 +20,15 @@
 #include <chrono>
 
 #include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
 #include "lifecycle_msgs/srv/change_state.hpp"
+#include "lifecycle_msgs/srv/get_state.hpp"
 #include "lifecycle_transition_skill.pb.h"
 #include "rclcpp/rclcpp.hpp"
 
 namespace {
+
+constexpr double kDefaultTimeoutMs = 60000.0;
 
 class InitRos {
  public:
@@ -64,6 +68,33 @@ class LifecycleClientNode : public rclcpp::Node {
     auto response = future.get();
     return response->success;
   }
+
+  absl::StatusOr<uint8_t> GetState(const std::string& node_name,
+                                   double timeout_ms) {
+    std::string service_name = "/" + node_name + "/get_state";
+    auto client =
+        this->create_client<lifecycle_msgs::srv::GetState>(service_name);
+
+    if (!client->wait_for_service(std::chrono::seconds(5))) {
+      return absl::UnavailableError("Service '" + service_name +
+                                    "' not available");
+    }
+
+    auto request = std::make_shared<lifecycle_msgs::srv::GetState::Request>();
+
+    auto future = client->async_send_request(request);
+
+    if (rclcpp::spin_until_future_complete(
+            this->get_node_base_interface(), future,
+            std::chrono::milliseconds(static_cast<int>(timeout_ms))) !=
+        rclcpp::FutureReturnCode::SUCCESS) {
+      return absl::DeadlineExceededError(
+          "Timed out waiting for get_state response");
+    }
+
+    auto response = future.get();
+    return response->current_state.id;
+  }
 };
 
 InitRos init;
@@ -95,10 +126,54 @@ LifecycleTransitionSkill::Execute(
               "Transitioning node %s to transition %d",
               params.node_name().c_str(), params.transition());
 
-  uint8_t transition_id = static_cast<uint8_t>(params.transition());
+  uint8_t transition_id = 0;
+  switch (static_cast<int>(params.transition())) {
+    case 0:  // create
+      transition_id = 0;
+      break;
+    case 1:  // configure
+      transition_id = 1;
+      break;
+    case 2:  // cleanup
+      transition_id = 2;
+      break;
+    case 3:  // activate
+      transition_id = 3;
+      break;
+    case 4:  // deactivate
+      transition_id = 4;
+      break;
+    case 5:  // shutdown
+    {
+      auto state_or_err = client_node_.GetState(params.node_name(), 5000.0);
+      if (!state_or_err.ok()) {
+        return state_or_err.status();
+      }
+      uint8_t current_state = state_or_err.value();
+      if (current_state == 1) {         // PRIMARY_STATE_UNCONFIGURED
+        transition_id = 5;              // TRANSITION_UNCONFIGURED_SHUTDOWN
+      } else if (current_state == 2) {  // PRIMARY_STATE_INACTIVE
+        transition_id = 6;              // TRANSITION_INACTIVE_SHUTDOWN
+      } else if (current_state == 3) {  // PRIMARY_STATE_ACTIVE
+        transition_id = 7;              // TRANSITION_ACTIVE_SHUTDOWN
+      } else {
+        return absl::FailedPreconditionError(
+            "Cannot shutdown node from current state");
+      }
+    } break;
+    case 6:  // destroy
+      transition_id = 8;
+      break;
+    default:
+      return absl::InvalidArgumentError(
+          absl::StrCat("!!! Unknown transition value: ",
+                       static_cast<int>(params.transition()), " !!!"));
+  }
 
+  double timeout_ms =
+      params.timeout() > 0.0 ? params.timeout() * 1000.0 : kDefaultTimeoutMs;
   auto status_or_success =
-      client_node_.ChangeState(params.node_name(), transition_id, 10000.0);
+      client_node_.ChangeState(params.node_name(), transition_id, timeout_ms);
 
   if (!status_or_success.ok()) {
     return status_or_success.status();

--- a/flowstate/aic_flowstate_skills/lifecycle_transition_skill/src/lifecycle_transition_skill.cc
+++ b/flowstate/aic_flowstate_skills/lifecycle_transition_skill/src/lifecycle_transition_skill.cc
@@ -126,49 +126,13 @@ LifecycleTransitionSkill::Execute(
               "Transitioning node %s to transition %d",
               params.node_name().c_str(), params.transition());
 
-  uint8_t transition_id = 0;
-  switch (static_cast<int>(params.transition())) {
-    case 0:  // create
-      transition_id = 0;
-      break;
-    case 1:  // configure
-      transition_id = 1;
-      break;
-    case 2:  // cleanup
-      transition_id = 2;
-      break;
-    case 3:  // activate
-      transition_id = 3;
-      break;
-    case 4:  // deactivate
-      transition_id = 4;
-      break;
-    case 5:  // shutdown
-    {
-      auto state_or_err = client_node_.GetState(params.node_name(), 5000.0);
-      if (!state_or_err.ok()) {
-        return state_or_err.status();
-      }
-      uint8_t current_state = state_or_err.value();
-      if (current_state == 1) {         // PRIMARY_STATE_UNCONFIGURED
-        transition_id = 5;              // TRANSITION_UNCONFIGURED_SHUTDOWN
-      } else if (current_state == 2) {  // PRIMARY_STATE_INACTIVE
-        transition_id = 6;              // TRANSITION_INACTIVE_SHUTDOWN
-      } else if (current_state == 3) {  // PRIMARY_STATE_ACTIVE
-        transition_id = 7;              // TRANSITION_ACTIVE_SHUTDOWN
-      } else {
-        return absl::FailedPreconditionError(
-            "Cannot shutdown node from current state");
-      }
-    } break;
-    case 6:  // destroy
-      transition_id = 8;
-      break;
-    default:
-      return absl::InvalidArgumentError(
-          absl::StrCat("!!! Unknown transition value: ",
-                       static_cast<int>(params.transition()), " !!!"));
+  if (!ai::flowstate::LifecycleTransitionSkillParams_Transition_IsValid(
+          params.transition())) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("!!! Unknown transition value: ",
+                     static_cast<int>(params.transition()), " !!!"));
   }
+  uint8_t transition_id = static_cast<uint8_t>(params.transition());
 
   double timeout_ms =
       params.timeout() > 0.0 ? params.timeout() * 1000.0 : kDefaultTimeoutMs;

--- a/flowstate/aic_flowstate_skills/lifecycle_transition_skill/src/lifecycle_transition_skill.cc
+++ b/flowstate/aic_flowstate_skills/lifecycle_transition_skill/src/lifecycle_transition_skill.cc
@@ -128,9 +128,9 @@ LifecycleTransitionSkill::Execute(
 
   if (!ai::flowstate::LifecycleTransitionSkillParams_Transition_IsValid(
           params.transition())) {
-    return absl::InvalidArgumentError(
-        absl::StrCat("!!! Unknown transition value: ",
-                     static_cast<int>(params.transition()), " !!!"));
+    return absl::InvalidArgumentError(absl::StrCat(
+        "!!! Unknown transition value: ", static_cast<int>(params.transition()),
+        " !!!"));
   }
   uint8_t transition_id = static_cast<uint8_t>(params.transition());
 

--- a/flowstate/aic_flowstate_skills/lifecycle_transition_skill/src/lifecycle_transition_skill.manifest.textproto
+++ b/flowstate/aic_flowstate_skills/lifecycle_transition_skill/src/lifecycle_transition_skill.manifest.textproto
@@ -9,8 +9,17 @@ vendor {
 documentation {
   description: "Skill that triggers lifecycle transitions for a specified node."
 }
+options {
+  supports_cancellation: false
+  cc_config {
+    create_skill: "::LifecycleTransitionSkill::CreateSkill"
+  }
+}
 parameter {
   message_full_name: "ai.flowstate.LifecycleTransitionSkillParams"
+  default_value: {
+    type_url: "type.googleapis.com/ai.flowstate.LifecycleTransitionSkillParams"
+  }
 }
 return_type {
   message_full_name: "ai.flowstate.LifecycleTransitionSkillResult"

--- a/flowstate/aic_flowstate_skills/lifecycle_transition_skill/src/lifecycle_transition_skill.proto
+++ b/flowstate/aic_flowstate_skills/lifecycle_transition_skill/src/lifecycle_transition_skill.proto
@@ -7,16 +7,16 @@ message LifecycleTransitionSkillParams {
   Transition transition = 2;
 
   enum Transition {
-    TRANSITION_CREATE = 0;
-    TRANSITION_CONFIGURE = 1;
-    TRANSITION_CLEANUP = 2;
-    TRANSITION_ACTIVATE = 3;
-    TRANSITION_DEACTIVATE = 4;
-    TRANSITION_UNCONFIGURED_SHUTDOWN = 5;
-    TRANSITION_INACTIVE_SHUTDOWN = 6;
-    TRANSITION_ACTIVE_SHUTDOWN = 7;
-    TRANSITION_DESTROY = 8;
+    create = 0;
+    configure = 1;
+    cleanup = 2;
+    activate = 3;
+    deactivate = 4;
+    shutdown = 5;
+    destroy = 6;
   }
+
+  double timeout = 3;
 }
 
 message LifecycleTransitionSkillResult {

--- a/flowstate/aic_flowstate_skills/lifecycle_transition_skill/src/lifecycle_transition_skill.proto
+++ b/flowstate/aic_flowstate_skills/lifecycle_transition_skill/src/lifecycle_transition_skill.proto
@@ -6,14 +6,18 @@ message LifecycleTransitionSkillParams {
   string node_name = 1;
   Transition transition = 2;
 
+  // Enum values must match the ROS 2 lifecycle transition definitions in
+  // https://docs.ros.org/en/kilted/p/lifecycle_msgs/msg/Transition.html
   enum Transition {
     create = 0;
     configure = 1;
     cleanup = 2;
     activate = 3;
     deactivate = 4;
-    shutdown = 5;
-    destroy = 6;
+    unconfigured_shutdown = 5;
+    inactive_shutdown = 6;
+    active_shutdown = 7;
+    destroy = 8;
   }
 
   double timeout = 3;

--- a/flowstate/aic_flowstate_skills/package.xml
+++ b/flowstate/aic_flowstate_skills/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>aic_flowstate_skills</name>
-  <version>0.0.1</version>
+  <version>0.0.2</version>
   <description>Flowstate skills for AIC execution</description>
   <maintainer email="kbalasundar@google.com">kbalasundar</maintainer>
   <license>Apache-2.0</license>
@@ -15,6 +15,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
   <depend>std_srvs</depend>
+  <depend>lifecycle_msgs</depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
* Use state transition enums so they can be chosen from the UI in flowstate (`create`, `configure`, `cleanup`, `activate`, `deactivate`, `shutdown`, `destroy`). 
* Set `kDefaultTimeoutMs` to 60 seconds  if the timeout parameter is left unset or set to 0.0. This is consistent with quals. 
* Integrated `GetState` service calls to handle the multi-path shutdown transition.
* Before invoking a shutdown, the skill queries the target node's current primary state. It then dynamically requests the correct transition depending on whether the node is:
`unconfigured` $\rightarrow$ `TRANSITION_UNCONFIGURED_SHUTDOWN` (5)
`inactive` $\rightarrow$ `TRANSITION_INACTIVE_SHUTDOWN `(6)
`active` $\rightarrow$ `TRANSITION_ACTIVE_SHUTDOWN` (7)
* Rejects the shutdown request with `FailedPreconditionError` if the node is already finalized or in an unrecognized state.
* Added `lifecycle_msgs` to the dependency declarations in `package.xml` and linked the target dependencies inside `CMakeLists.txt`.