### PR TITLE
Optionally align camera timestamps in aic_adapter

### DIFF
--- a/aic_adapter/include/aic_adapter/aic_adapter.hpp
+++ b/aic_adapter/include/aic_adapter/aic_adapter.hpp
@@ -91,6 +91,7 @@ class AicAdapterNode : public rclcpp::Node {
   std::unordered_map<std::string, size_t> joint_sort_order_;
   bool include_gripper_in_joint_state_;
   double image_time_tolerance_ = 0.001;
+  bool align_camera_timestamps_ = false;
 };
 
 }  // namespace aic

--- a/aic_adapter/src/aic_adapter.cpp
+++ b/aic_adapter/src/aic_adapter.cpp
@@ -60,6 +60,8 @@ AicAdapterNode::AicAdapterNode() : Node("aic_adapter_node") {
       this->declare_parameter("include_gripper_in_joint_state", true);
   image_time_tolerance_ =
       this->declare_parameter("image_time_tolerance", 0.001);
+  align_camera_timestamps_ =
+      this->declare_parameter("align_camera_timestamps", false);
 
   tf_buffer_ = std::make_unique<tf2_ros::Buffer>(this->get_clock());
   tf_listener_ = std::make_unique<tf2_ros::TransformListener>(*tf_buffer_);
@@ -163,6 +165,14 @@ void AicAdapterNode::image_callback(size_t camera_idx,
   observation_msg->left_image = std::move(*images_[kLeftCameraIndex]);
   observation_msg->center_image = std::move(*images_[kCenterCameraIndex]);
   observation_msg->right_image = std::move(*images_[kRightCameraIndex]);
+
+  // Optionally force all camera timestamps to be exactly aligned
+  if (align_camera_timestamps_) {
+    observation_msg->left_image.header.stamp =
+        observation_msg->center_image.header.stamp;
+    observation_msg->right_image.header.stamp =
+        observation_msg->center_image.header.stamp;
+  }
 
   images_[kLeftCameraIndex].reset();
   images_[kCenterCameraIndex].reset();

--- a/flowstate/services/aic_adapter/Dockerfile.service
+++ b/flowstate/services/aic_adapter/Dockerfile.service
@@ -34,7 +34,7 @@ ZENOH_CONFIG_OVERRIDE='connect/endpoints=["tcp/'"$AIC_ROUTER_ADDR"'"]'
 ZENOH_CONFIG_OVERRIDE+=';transport/shared_memory/enabled=false'
 export ZENOH_CONFIG_OVERRIDE
 
-exec ros2 run aic_adapter aic_adapter --ros-args -p include_gripper_in_joint_state:=false -p image_time_tolerance:=0.1
+exec ros2 run aic_adapter aic_adapter --ros-args -p include_gripper_in_joint_state:=false -p image_time_tolerance:=0.1 -p align_camera_timestamps:=true
 EOF
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Optionally align camera timestamps by copying the center camera timestamps to the left and right camera timestamps in `aic_adapter`. This behavior is `false` by default, but is enabled when building the Flowstate service container of `aic_adapter`.