### PR TITLE
Add computation for TCP pose error

### DIFF
--- a/flowstate/aic_flowstate_ros_bridge/CMakeLists.txt
+++ b/flowstate/aic_flowstate_ros_bridge/CMakeLists.txt
@@ -20,6 +20,7 @@ set(dep_pkgs
   aic_control_interfaces
   ament_index_cpp
   flowstate_ros_bridge
+  pinocchio
   pluginlib
   rclcpp
   std_srvs
@@ -28,6 +29,7 @@ foreach(pkg ${dep_pkgs})
   find_package(${pkg} REQUIRED)
 endforeach()
 
+find_package(Eigen3 REQUIRED NO_MODULE)
 find_package(Protobuf REQUIRED)
 
 #==================================
@@ -54,7 +56,9 @@ target_link_libraries(robot_control_bridge
   absl::time
   agent_bridge_proto
   ament_index_cpp::ament_index_cpp
+  Eigen3::Eigen
   flowstate_ros_bridge::flowstate_ros_builtin_bridges
+  pinocchio::pinocchio
   pluginlib::pluginlib
   rclcpp::rclcpp
   ${aic_control_interfaces_TARGETS}

--- a/flowstate/aic_flowstate_ros_bridge/package.xml
+++ b/flowstate/aic_flowstate_ros_bridge/package.xml
@@ -11,7 +11,9 @@
 
   <depend>aic_control_interfaces</depend>
   <depend>ament_index_cpp</depend>
+  <depend>eigen</depend>
   <depend>flowstate_ros_bridge</depend>
+  <depend>pinocchio</depend>
   <depend>rclcpp</depend>
   <depend>pluginlib</depend>
   <depend>std_srvs</depend>

--- a/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.cpp
+++ b/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.cpp
@@ -17,7 +17,9 @@
 
 #include "robot_control_bridge.hpp"
 
+#include <Eigen/Dense>
 #include <filesystem>
+#include <pinocchio/spatial/explog.hpp>
 #include <string>
 #include <utility>
 
@@ -421,10 +423,28 @@ void RobotControlBridge::agentBridgeOutputStreamCallback(
             last_update.reference_pose(6);
       }
 
-      for (int i = 0; i < 6 && i < ab_status_proto.pose_error_integrated_size();
-           ++i) {
-        data_->controller_state_.tcp_error[i] =
-            ab_status_proto.pose_error_integrated(i);
+      Eigen::VectorXd current_tcp_pose(7);
+      current_tcp_pose << data_->controller_state_.tcp_pose.position.x,
+          data_->controller_state_.tcp_pose.position.y,
+          data_->controller_state_.tcp_pose.position.z,
+          data_->controller_state_.tcp_pose.orientation.x,
+          data_->controller_state_.tcp_pose.orientation.y,
+          data_->controller_state_.tcp_pose.orientation.z,
+          data_->controller_state_.tcp_pose.orientation.w;
+      Eigen::VectorXd reference_tcp_pose(7);
+      reference_tcp_pose
+          << data_->controller_state_.reference_tcp_pose.position.x,
+          data_->controller_state_.reference_tcp_pose.position.y,
+          data_->controller_state_.reference_tcp_pose.position.z,
+          data_->controller_state_.reference_tcp_pose.orientation.x,
+          data_->controller_state_.reference_tcp_pose.orientation.y,
+          data_->controller_state_.reference_tcp_pose.orientation.z,
+          data_->controller_state_.reference_tcp_pose.orientation.w;
+      Eigen::Matrix<double, 6, 1> tcp_pose_error;
+
+      calculatePoseError(current_tcp_pose, reference_tcp_pose, tcp_pose_error);
+      for (int i = 0; i < 6; ++i) {
+        data_->controller_state_.tcp_error[i] = tcp_pose_error(i);
       }
 
       break;
@@ -473,6 +493,37 @@ void RobotControlBridge::agentBridgeOutputStreamCallback(
   LOG_EVERY_N(INFO, 5000) << absl::StrFormat(
       "AgentBridge output stream translation time: %.3f ms",
       1000.0 * elapsed.seconds());
+}
+
+///=============================================================================
+void RobotControlBridge::calculatePoseError(
+    const Eigen::VectorXd& pose_a, const Eigen::VectorXd& pose_b,
+    Eigen::Matrix<double, 6, 1>& pose_delta) {
+  // Adapted from the KinematicsInterfacePinocchio::calculate_frame_difference
+  // method of the kinematics_interface library Compute translation
+  const Eigen::Vector3d t_a = pose_a.head<3>();
+  const Eigen::Vector3d t_b = pose_b.head<3>();
+
+  // Quaterniond Constructor takes in arguemnts in the order (w,x,y,z)
+  Eigen::Quaterniond q_a(pose_a(6), pose_a(3), pose_a(4), pose_a(5));
+  Eigen::Quaterniond q_b(pose_b(6), pose_b(3), pose_b(4), pose_b(5));
+
+  q_a.normalize();
+  q_b.normalize();
+
+  const Eigen::Matrix3d R_a = q_a.toRotationMatrix();
+  const Eigen::Matrix3d R_b = q_b.toRotationMatrix();
+
+  // - linear part: simple difference of positions
+  const Eigen::Vector3d linear_delta = (t_b - t_a);
+
+  const Eigen::Matrix3d R_rel = R_a.transpose() * R_b;
+  // - angular part: log3(R_a^T * R_b) (axis-angle vector)
+  const Eigen::Vector3d angular_delta =
+      pinocchio::log3(R_rel);  // 3-vector (axis * angle)
+
+  pose_delta.head<3>() = linear_delta;
+  pose_delta.tail<3>() = angular_delta;
 }
 
 ///=============================================================================

--- a/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.hpp
+++ b/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.hpp
@@ -67,6 +67,9 @@ class RobotControlBridge : public BridgeInterface {
                   std::shared_ptr<World> world_client) final;
 
  private:
+  void calculatePoseError(const Eigen::VectorXd& pose_a,
+                          const Eigen::VectorXd& pose_b,
+                          Eigen::Matrix<double, 6, 1>& pose_delta);
   void MotionUpdateCallback(
       const aic_control_interfaces::msg::MotionUpdate::SharedPtr msg);
 


### PR DESCRIPTION
This PR adds computation of the TCP pose error and updates it within the `aic_controller/controller_state` message.
The routine used to calculate the error is similar to the `aic_controller` from phase Q. 