### PR TITLE
Add if block to verify inbuild binary is executable

### DIFF
--- a/flowstate/scripts/build_aic_adapter.sh
+++ b/flowstate/scripts/build_aic_adapter.sh
@@ -85,6 +85,13 @@ if [ ! -f ./inbuild ]; then
   && chmod +x inbuild
 fi
 
+# Ensure the 'inbuild' tool is executable
+if [ -f ./inbuild ] && [ ! -x ./inbuild ]; then
+  echo "INFO: Making inbuild tool executable..."
+  chmod +x ./inbuild
+fi
+
+
 echo "INFO: Bundling service using inbuild..."
 ./inbuild service bundle \
   --manifest "$SERVICE_DIR/aic_adapter.manifest.textproto" \

--- a/flowstate/scripts/build_aic_engine.sh
+++ b/flowstate/scripts/build_aic_engine.sh
@@ -80,6 +80,13 @@ if [ ! -f ./inbuild ]; then
   && chmod +x inbuild
 fi
 
+# Ensure the 'inbuild' tool is executable
+if [ -f ./inbuild ] && [ ! -x ./inbuild ]; then
+  echo "INFO: Making inbuild tool executable..."
+  chmod +x ./inbuild
+fi
+
+
 echo "INFO: Bundling service using inbuild..."
 ./inbuild service bundle \
   --manifest "$SERVICE_DIR/aic_engine.manifest.textproto" \

--- a/flowstate/scripts/build_aic_model.sh
+++ b/flowstate/scripts/build_aic_model.sh
@@ -96,6 +96,13 @@ if [ ! -f ./inbuild ]; then
   && chmod +x inbuild
 fi
 
+# Ensure the 'inbuild' tool is executable
+if [ -f ./inbuild ] && [ ! -x ./inbuild ]; then
+  echo "INFO: Making inbuild tool executable..."
+  chmod +x ./inbuild
+fi
+
+
 echo "INFO: Bundling service using inbuild..."
 ./inbuild service bundle \
   --manifest "$SERVICE_DIR/aic_model.manifest.textproto" \

--- a/flowstate/scripts/build_container.sh
+++ b/flowstate/scripts/build_container.sh
@@ -123,6 +123,13 @@ elif [[ -n "$SKILL_NAME" && -n "$SKILL_PACKAGE" ]]; then
           && chmod +x inbuild
     fi
 
+    # Ensure the 'inbuild' tool is executable
+    if [ -f ./inbuild ] && [ ! -x ./inbuild ]; then
+      echo "INFO: Making inbuild tool executable..."
+      chmod +x ./inbuild
+    fi
+
+
     echo "INFO: Loading newly built image into local daemon..."
     docker load -i "$IMAGES_DIR/${SKILL_NAME}/${SKILL_NAME}.tar"
 

--- a/flowstate/scripts/build_flowstate_ros_bridge.sh
+++ b/flowstate/scripts/build_flowstate_ros_bridge.sh
@@ -45,6 +45,13 @@ if [ ! -f ./inbuild ]; then
     && chmod +x inbuild
 fi
 
+# Ensure the 'inbuild' tool is executable
+if [ -f ./inbuild ] && [ ! -x ./inbuild ]; then
+  echo "INFO: Making inbuild tool executable..."
+  chmod +x ./inbuild
+fi
+
+
 src/aic/flowstate/scripts/build_container.sh \
   --ros_distro "$ROS_DISTRO" \
   --service_name aic_flowstate_ros_bridge \


### PR DESCRIPTION
Had faced this issue couple of times where the `inbuild` binary was downloaded but lacked permission for execution. Included an additional if block to verify `inbuild` binary is present and is executable. 