### PR TITLE
Fix nondeterministic trial-to-trial homing race by deferring reset acknowledgment and guarding controller reactivation

### DIFF
--- a/aic_engine/src/aic_engine.cpp
+++ b/aic_engine/src/aic_engine.cpp
@@ -1697,6 +1697,11 @@ bool Engine::home_robot() {
     return false;
   }
 
+  // Allow at least a few physics steps for the joint reset to propagate
+  // through the simulation pipeline (Update + PostUpdate) before reactivating
+  // the controller, which reads hardware state on activation.
+  node_->get_clock()->sleep_for(rclcpp::Duration::from_seconds(0.01));
+
   // Activate aic_controller & resume simulation
   if (!switch_controllers({"aic_controller"}, {})) {
     RCLCPP_ERROR(node_->get_logger(), "Failed to activate aic_controller.");

--- a/aic_gazebo/src/ResetJointsPlugin.cc
+++ b/aic_gazebo/src/ResetJointsPlugin.cc
@@ -28,6 +28,7 @@
 GZ_ADD_PLUGIN(aic_gazebo::ResetJointsPlugin, gz::sim::System,
               aic_gazebo::ResetJointsPlugin::ISystemConfigure,
               aic_gazebo::ResetJointsPlugin::ISystemPreUpdate,
+              aic_gazebo::ResetJointsPlugin::ISystemPostUpdate,
               aic_gazebo::ResetJointsPlugin::ISystemReset)
 
 namespace aic_gazebo {
@@ -150,12 +151,28 @@ void ResetJointsPlugin::PreUpdate(const gz::sim::UpdateInfo& _info,
           << " reset to initial position: " << initialPosition << std::endl;
   }
 
+  this->requestedJoints_.clear();
+  this->reset_pending_ = true;
+}
+
+//////////////////////////////////////////////////
+void ResetJointsPlugin::PostUpdate(
+    const gz::sim::UpdateInfo& /*_info*/,
+    const gz::sim::EntityComponentManager& /*_ecm*/) {
+  std::lock_guard<std::mutex> lock(this->mutex_);
+  if (!this->reset_pending_) {
+    return;
+  }
+
+  // Resolve the promise AFTER physics has processed the JointPositionReset
+  // and JointVelocityReset components (Update runs between PreUpdate and
+  // PostUpdate).  This ensures that when the service caller receives the
+  // response, the hardware state interfaces reflect the new joint positions.
   aic_engine_interfaces::srv::ResetJoints::Response response;
   response.success = true;
   this->reset_promise_->set_value(response);
-
-  this->requestedJoints_.clear();
   this->reset_promise_ = nullptr;
+  this->reset_pending_ = false;
 }
 
 //////////////////////////////////////////////////

--- a/aic_gazebo/src/ResetJointsPlugin.hh
+++ b/aic_gazebo/src/ResetJointsPlugin.hh
@@ -31,6 +31,7 @@ namespace aic_gazebo {
 class ResetJointsPlugin : public gz::sim::System,
                           public gz::sim::ISystemConfigure,
                           public gz::sim::ISystemPreUpdate,
+                          public gz::sim::ISystemPostUpdate,
                           public gz::sim::ISystemReset {
   // Documentation inherited
  public:
@@ -43,6 +44,11 @@ class ResetJointsPlugin : public gz::sim::System,
  public:
   void PreUpdate(const gz::sim::UpdateInfo& _info,
                  gz::sim::EntityComponentManager& _ecm) override;
+
+  // Documentation inherited
+ public:
+  void PostUpdate(const gz::sim::UpdateInfo& _info,
+                  const gz::sim::EntityComponentManager& _ecm) override;
 
   // Documentation inherited
  public:
@@ -78,6 +84,11 @@ class ResetJointsPlugin : public gz::sim::System,
   /// \brief Mutex to prevent overwriting joint requests.
  private:
   std::mutex mutex_;
+
+  /// \brief Flag indicating reset components were applied in PreUpdate and
+  /// the promise should be resolved in PostUpdate (after physics processes).
+ private:
+  bool reset_pending_{false};
 
   /// \brief Thread to spin ROS 2 node.
  private:


### PR DESCRIPTION
Robot in scene n+1 moves to last position of trial n. This PR fixes an intermittent issue where, at the beginning of a new trial, the robot could move toward the previous trial’s end pose instead of holding home.