### PR TITLE
Fix NIC Card Mount SFP port contact collision pose

### DIFF
--- a/aic_assets/models/NIC Card Mount 0/model.sdf
+++ b/aic_assets/models/NIC Card Mount 0/model.sdf
@@ -643,6 +643,42 @@
           </friction>
         </surface>
       </collision>
+
+      <collision name="contact_collision_01">
+        <pose>0.012963 -0.0305 0.002845 3.128092 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.008112 0.00025 0.0025</size>
+          </box>
+        </geometry>
+      </collision>
+
+      <collision name="contact_collision_02">
+        <pose>-0.010237 -0.0305 0.002845 3.128092 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.008112 0.00025 0.0025</size>
+          </box>
+        </geometry>
+      </collision>
+
+      <collision name="contact_collision_01_holder">
+        <pose>0.012963 -0.030 0.008 3.128092 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.008112 0.00025 0.002</size>
+          </box>
+        </geometry>
+      </collision>
+
+      <collision name="contact_collision_02_holder">
+        <pose>-0.010237 -0.030 0.008 3.128092 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.008112 0.00025 0.002</size>
+          </box>
+        </geometry>
+      </collision>
     </link>
 
     <joint name="card_joint" type="fixed">
@@ -652,22 +688,6 @@
 
     <link name="sfp_port_0_link">
       <pose relative_to="nic_card_link">0.01295 -0.031572 0.00501 4.69895 0 0</pose>
-      <collision name="contact_collision_01">
-        <pose>0.012963 -0.0305 0.002845 3.128092 0.0 0.0</pose>
-        <geometry>
-          <box>
-            <size>0.008112 0.00025 0.0025</size>
-          </box>
-        </geometry>
-      </collision>
-      <collision name="contact_collision_01_holder">
-        <pose>0.012963 -0.030 0.008 3.128092 0.0 0.0</pose>
-        <geometry>
-          <box>
-            <size>0.008112 0.00025 0.002</size>
-          </box>
-        </geometry>
-      </collision>
     </link>
     <plugin
       filename="static://gz::sim::systems::TouchPlugin"
@@ -696,22 +716,6 @@
 
     <link name="sfp_port_1_link">
       <pose relative_to="nic_card_link">-0.01025 -0.031572 0.00501 4.69895 0 0</pose>
-      <collision name="contact_collision_02">
-        <pose>-0.010237 -0.0305 0.002845 3.128092 0.0 0.0</pose>
-        <geometry>
-          <box>
-            <size>0.008112 0.00025 0.0025</size>
-          </box>
-        </geometry>
-      </collision>
-      <collision name="contact_collision_02_holder">
-        <pose>-0.010237 -0.030 0.008 3.128092 0.0 0.0</pose>
-        <geometry>
-          <box>
-            <size>0.008112 0.00025 0.002</size>
-          </box>
-        </geometry>
-      </collision>
     </link>
     <plugin
       filename="static://gz::sim::systems::TouchPlugin"

--- a/aic_assets/models/NIC Card Mount 0/model.sdf
+++ b/aic_assets/models/NIC Card Mount 0/model.sdf
@@ -651,6 +651,18 @@
             <size>0.008112 0.00025 0.0025</size>
           </box>
         </geometry>
+        <surface>
+          <friction>
+            <torsional>
+              <coefficient>0.1</coefficient>
+            </torsional>
+            <bullet>
+              <friction>0.1</friction>
+              <friction2>0.1</friction2>
+              <rolling_friction>0.1</rolling_friction>
+            </bullet>
+          </friction>
+        </surface>
       </collision>
 
       <collision name="contact_collision_02">
@@ -660,6 +672,18 @@
             <size>0.008112 0.00025 0.0025</size>
           </box>
         </geometry>
+        <surface>
+          <friction>
+            <torsional>
+              <coefficient>0.1</coefficient>
+            </torsional>
+            <bullet>
+              <friction>0.1</friction>
+              <friction2>0.1</friction2>
+              <rolling_friction>0.1</rolling_friction>
+            </bullet>
+          </friction>
+        </surface>
       </collision>
 
       <collision name="contact_collision_01_holder">
@@ -669,6 +693,18 @@
             <size>0.008112 0.00025 0.002</size>
           </box>
         </geometry>
+        <surface>
+          <friction>
+            <torsional>
+              <coefficient>0.1</coefficient>
+            </torsional>
+            <bullet>
+              <friction>0.1</friction>
+              <friction2>0.1</friction2>
+              <rolling_friction>0.1</rolling_friction>
+            </bullet>
+          </friction>
+        </surface>
       </collision>
 
       <collision name="contact_collision_02_holder">
@@ -678,6 +714,18 @@
             <size>0.008112 0.00025 0.002</size>
           </box>
         </geometry>
+        <surface>
+          <friction>
+            <torsional>
+              <coefficient>0.1</coefficient>
+            </torsional>
+            <bullet>
+              <friction>0.1</friction>
+              <friction2>0.1</friction2>
+              <rolling_friction>0.1</rolling_friction>
+            </bullet>
+          </friction>
+        </surface>
       </collision>
     </link>
 

--- a/aic_assets/models/NIC Card Mount 1/model.sdf
+++ b/aic_assets/models/NIC Card Mount 1/model.sdf
@@ -651,6 +651,18 @@
             <size>0.008112 0.00025 0.0025</size>
           </box>
         </geometry>
+        <surface>
+          <friction>
+            <torsional>
+              <coefficient>0.1</coefficient>
+            </torsional>
+            <bullet>
+              <friction>0.1</friction>
+              <friction2>0.1</friction2>
+              <rolling_friction>0.1</rolling_friction>
+            </bullet>
+          </friction>
+        </surface>
       </collision>
 
       <collision name="contact_collision_02">
@@ -660,6 +672,18 @@
             <size>0.008112 0.00025 0.0025</size>
           </box>
         </geometry>
+        <surface>
+          <friction>
+            <torsional>
+              <coefficient>0.1</coefficient>
+            </torsional>
+            <bullet>
+              <friction>0.1</friction>
+              <friction2>0.1</friction2>
+              <rolling_friction>0.1</rolling_friction>
+            </bullet>
+          </friction>
+        </surface>
       </collision>
 
       <collision name="contact_collision_01_holder">
@@ -669,6 +693,18 @@
             <size>0.008112 0.00025 0.002</size>
           </box>
         </geometry>
+        <surface>
+          <friction>
+            <torsional>
+              <coefficient>0.1</coefficient>
+            </torsional>
+            <bullet>
+              <friction>0.1</friction>
+              <friction2>0.1</friction2>
+              <rolling_friction>0.1</rolling_friction>
+            </bullet>
+          </friction>
+        </surface>
       </collision>
 
       <collision name="contact_collision_02_holder">
@@ -678,8 +714,21 @@
             <size>0.008112 0.00025 0.002</size>
           </box>
         </geometry>
+        <surface>
+          <friction>
+            <torsional>
+              <coefficient>0.1</coefficient>
+            </torsional>
+            <bullet>
+              <friction>0.1</friction>
+              <friction2>0.1</friction2>
+              <rolling_friction>0.1</rolling_friction>
+            </bullet>
+          </friction>
+        </surface>
       </collision>
     </link>
+
     <joint name="card_joint" type="fixed">
       <parent>nic_card_mount_link</parent>
       <child>nic_card_link</child>

--- a/aic_assets/models/NIC Card Mount 1/model.sdf
+++ b/aic_assets/models/NIC Card Mount 1/model.sdf
@@ -643,14 +643,7 @@
           </friction>
         </surface>
       </collision>
-    </link>
-    <joint name="card_joint" type="fixed">
-      <parent>nic_card_mount_link</parent>
-      <child>nic_card_link</child>
-    </joint>
 
-    <link name="sfp_port_0_link">
-      <pose relative_to="nic_card_link">0.01295 -0.031572 0.00501 4.69895 0 0</pose>
       <collision name="contact_collision_01">
         <pose>0.012963 -0.0305 0.002845 3.128092 0.0 0.0</pose>
         <geometry>
@@ -659,6 +652,16 @@
           </box>
         </geometry>
       </collision>
+
+      <collision name="contact_collision_02">
+        <pose>-0.010237 -0.0305 0.002845 3.128092 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.008112 0.00025 0.0025</size>
+          </box>
+        </geometry>
+      </collision>
+
       <collision name="contact_collision_01_holder">
         <pose>0.012963 -0.030 0.008 3.128092 0.0 0.0</pose>
         <geometry>
@@ -667,6 +670,23 @@
           </box>
         </geometry>
       </collision>
+
+      <collision name="contact_collision_02_holder">
+        <pose>-0.010237 -0.030 0.008 3.128092 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.008112 0.00025 0.002</size>
+          </box>
+        </geometry>
+      </collision>
+    </link>
+    <joint name="card_joint" type="fixed">
+      <parent>nic_card_mount_link</parent>
+      <child>nic_card_link</child>
+    </joint>
+
+    <link name="sfp_port_0_link">
+      <pose relative_to="nic_card_link">0.01295 -0.031572 0.00501 4.69895 0 0</pose>
     </link>
     <plugin
       filename="static://gz::sim::systems::TouchPlugin"
@@ -695,22 +715,6 @@
 
     <link name="sfp_port_1_link">
       <pose relative_to="nic_card_link">-0.01025 -0.031572 0.00501 4.69895 0 0</pose>
-      <collision name="contact_collision_02">
-        <pose>-0.010237 -0.0305 0.002845 3.128092 0.0 0.0</pose>
-        <geometry>
-          <box>
-            <size>0.008112 0.00025 0.0025</size>
-          </box>
-        </geometry>
-      </collision>
-      <collision name="contact_collision_02_holder">
-        <pose>-0.010237 -0.030 0.008 3.128092 0.0 0.0</pose>
-        <geometry>
-          <box>
-            <size>0.008112 0.00025 0.002</size>
-          </box>
-        </geometry>
-      </collision>
     </link>
     <plugin
       filename="static://gz::sim::systems::TouchPlugin"

--- a/aic_assets/models/NIC Card Mount 2/model.sdf
+++ b/aic_assets/models/NIC Card Mount 2/model.sdf
@@ -643,6 +643,42 @@
           </friction>
         </surface>
       </collision>
+
+      <collision name="contact_collision_01">
+        <pose>0.012963 -0.0305 0.002845 3.128092 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.008112 0.00025 0.0025</size>
+          </box>
+        </geometry>
+      </collision>
+
+      <collision name="contact_collision_02">
+        <pose>-0.010237 -0.0305 0.002845 3.128092 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.008112 0.00025 0.0025</size>
+          </box>
+        </geometry>
+      </collision>
+
+      <collision name="contact_collision_01_holder">
+        <pose>0.012963 -0.030 0.008 3.128092 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.008112 0.00025 0.002</size>
+          </box>
+        </geometry>
+      </collision>
+
+      <collision name="contact_collision_02_holder">
+        <pose>-0.010237 -0.030 0.008 3.128092 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.008112 0.00025 0.002</size>
+          </box>
+        </geometry>
+      </collision>
     </link>
 
     <joint name="card_joint" type="fixed">
@@ -652,22 +688,6 @@
 
     <link name="sfp_port_0_link">
       <pose relative_to="nic_card_link">0.01295 -0.031572 0.00501 4.69895 0 0</pose>
-      <collision name="contact_collision_01">
-        <pose>0.012963 -0.0305 0.002845 3.128092 0.0 0.0</pose>
-        <geometry>
-          <box>
-            <size>0.008112 0.00025 0.0025</size>
-          </box>
-        </geometry>
-      </collision>
-      <collision name="contact_collision_01_holder">
-        <pose>0.012963 -0.030 0.008 3.128092 0.0 0.0</pose>
-        <geometry>
-          <box>
-            <size>0.008112 0.00025 0.002</size>
-          </box>
-        </geometry>
-      </collision>
     </link>
     <plugin
       filename="static://gz::sim::systems::TouchPlugin"
@@ -696,22 +716,6 @@
 
     <link name="sfp_port_1_link">
       <pose relative_to="nic_card_link">-0.01025 -0.031572 0.00501 4.69895 0 0</pose>
-      <collision name="contact_collision_02">
-        <pose>-0.010237 -0.0305 0.002845 3.128092 0.0 0.0</pose>
-        <geometry>
-          <box>
-            <size>0.008112 0.00025 0.0025</size>
-          </box>
-        </geometry>
-      </collision>
-      <collision name="contact_collision_02_holder">
-        <pose>-0.010237 -0.030 0.008 3.128092 0.0 0.0</pose>
-        <geometry>
-          <box>
-            <size>0.008112 0.00025 0.002</size>
-          </box>
-        </geometry>
-      </collision>
     </link>
     <plugin
       filename="static://gz::sim::systems::TouchPlugin"

--- a/aic_assets/models/NIC Card Mount 2/model.sdf
+++ b/aic_assets/models/NIC Card Mount 2/model.sdf
@@ -651,6 +651,18 @@
             <size>0.008112 0.00025 0.0025</size>
           </box>
         </geometry>
+        <surface>
+          <friction>
+            <torsional>
+              <coefficient>0.1</coefficient>
+            </torsional>
+            <bullet>
+              <friction>0.1</friction>
+              <friction2>0.1</friction2>
+              <rolling_friction>0.1</rolling_friction>
+            </bullet>
+          </friction>
+        </surface>
       </collision>
 
       <collision name="contact_collision_02">
@@ -660,6 +672,18 @@
             <size>0.008112 0.00025 0.0025</size>
           </box>
         </geometry>
+        <surface>
+          <friction>
+            <torsional>
+              <coefficient>0.1</coefficient>
+            </torsional>
+            <bullet>
+              <friction>0.1</friction>
+              <friction2>0.1</friction2>
+              <rolling_friction>0.1</rolling_friction>
+            </bullet>
+          </friction>
+        </surface>
       </collision>
 
       <collision name="contact_collision_01_holder">
@@ -669,6 +693,18 @@
             <size>0.008112 0.00025 0.002</size>
           </box>
         </geometry>
+        <surface>
+          <friction>
+            <torsional>
+              <coefficient>0.1</coefficient>
+            </torsional>
+            <bullet>
+              <friction>0.1</friction>
+              <friction2>0.1</friction2>
+              <rolling_friction>0.1</rolling_friction>
+            </bullet>
+          </friction>
+        </surface>
       </collision>
 
       <collision name="contact_collision_02_holder">
@@ -678,6 +714,18 @@
             <size>0.008112 0.00025 0.002</size>
           </box>
         </geometry>
+        <surface>
+          <friction>
+            <torsional>
+              <coefficient>0.1</coefficient>
+            </torsional>
+            <bullet>
+              <friction>0.1</friction>
+              <friction2>0.1</friction2>
+              <rolling_friction>0.1</rolling_friction>
+            </bullet>
+          </friction>
+        </surface>
       </collision>
     </link>
 

--- a/aic_assets/models/NIC Card Mount 3/model.sdf
+++ b/aic_assets/models/NIC Card Mount 3/model.sdf
@@ -643,6 +643,42 @@
           </friction>
         </surface>
       </collision>
+
+      <collision name="contact_collision_01">
+        <pose>0.012963 -0.0305 0.002845 3.128092 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.008112 0.00025 0.0025</size>
+          </box>
+        </geometry>
+      </collision>
+
+      <collision name="contact_collision_02">
+        <pose>-0.010237 -0.0305 0.002845 3.128092 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.008112 0.00025 0.0025</size>
+          </box>
+        </geometry>
+      </collision>
+
+      <collision name="contact_collision_01_holder">
+        <pose>0.012963 -0.030 0.008 3.128092 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.008112 0.00025 0.002</size>
+          </box>
+        </geometry>
+      </collision>
+
+      <collision name="contact_collision_02_holder">
+        <pose>-0.010237 -0.030 0.008 3.128092 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.008112 0.00025 0.002</size>
+          </box>
+        </geometry>
+      </collision>
     </link>
 
     <joint name="card_joint" type="fixed">
@@ -652,22 +688,6 @@
 
     <link name="sfp_port_0_link">
       <pose relative_to="nic_card_link">0.01295 -0.031572 0.00501 4.69895 0 0</pose>
-      <collision name="contact_collision_01">
-        <pose>0.012963 -0.0305 0.002845 3.128092 0.0 0.0</pose>
-        <geometry>
-          <box>
-            <size>0.008112 0.00025 0.0025</size>
-          </box>
-        </geometry>
-      </collision>
-      <collision name="contact_collision_01_holder">
-        <pose>0.012963 -0.030 0.008 3.128092 0.0 0.0</pose>
-        <geometry>
-          <box>
-            <size>0.008112 0.00025 0.002</size>
-          </box>
-        </geometry>
-      </collision>
     </link>
     <plugin
       filename="static://gz::sim::systems::TouchPlugin"
@@ -696,22 +716,6 @@
 
     <link name="sfp_port_1_link">
       <pose relative_to="nic_card_link">-0.01025 -0.031572 0.00501 4.69895 0 0</pose>
-      <collision name="contact_collision_02">
-        <pose>-0.010237 -0.0305 0.002845 3.128092 0.0 0.0</pose>
-        <geometry>
-          <box>
-            <size>0.008112 0.00025 0.0025</size>
-          </box>
-        </geometry>
-      </collision>
-      <collision name="contact_collision_02_holder">
-        <pose>-0.010237 -0.030 0.008 3.128092 0.0 0.0</pose>
-        <geometry>
-          <box>
-            <size>0.008112 0.00025 0.002</size>
-          </box>
-        </geometry>
-      </collision>
     </link>
     <plugin
       filename="static://gz::sim::systems::TouchPlugin"

--- a/aic_assets/models/NIC Card Mount 3/model.sdf
+++ b/aic_assets/models/NIC Card Mount 3/model.sdf
@@ -651,6 +651,18 @@
             <size>0.008112 0.00025 0.0025</size>
           </box>
         </geometry>
+        <surface>
+          <friction>
+            <torsional>
+              <coefficient>0.1</coefficient>
+            </torsional>
+            <bullet>
+              <friction>0.1</friction>
+              <friction2>0.1</friction2>
+              <rolling_friction>0.1</rolling_friction>
+            </bullet>
+          </friction>
+        </surface>
       </collision>
 
       <collision name="contact_collision_02">
@@ -660,6 +672,18 @@
             <size>0.008112 0.00025 0.0025</size>
           </box>
         </geometry>
+        <surface>
+          <friction>
+            <torsional>
+              <coefficient>0.1</coefficient>
+            </torsional>
+            <bullet>
+              <friction>0.1</friction>
+              <friction2>0.1</friction2>
+              <rolling_friction>0.1</rolling_friction>
+            </bullet>
+          </friction>
+        </surface>
       </collision>
 
       <collision name="contact_collision_01_holder">
@@ -669,6 +693,18 @@
             <size>0.008112 0.00025 0.002</size>
           </box>
         </geometry>
+        <surface>
+          <friction>
+            <torsional>
+              <coefficient>0.1</coefficient>
+            </torsional>
+            <bullet>
+              <friction>0.1</friction>
+              <friction2>0.1</friction2>
+              <rolling_friction>0.1</rolling_friction>
+            </bullet>
+          </friction>
+        </surface>
       </collision>
 
       <collision name="contact_collision_02_holder">
@@ -678,6 +714,18 @@
             <size>0.008112 0.00025 0.002</size>
           </box>
         </geometry>
+        <surface>
+          <friction>
+            <torsional>
+              <coefficient>0.1</coefficient>
+            </torsional>
+            <bullet>
+              <friction>0.1</friction>
+              <friction2>0.1</friction2>
+              <rolling_friction>0.1</rolling_friction>
+            </bullet>
+          </friction>
+        </surface>
       </collision>
     </link>
 

--- a/aic_assets/models/NIC Card Mount 4/model.sdf
+++ b/aic_assets/models/NIC Card Mount 4/model.sdf
@@ -651,6 +651,18 @@
             <size>0.008112 0.00025 0.0025</size>
           </box>
         </geometry>
+        <surface>
+          <friction>
+            <torsional>
+              <coefficient>0.1</coefficient>
+            </torsional>
+            <bullet>
+              <friction>0.1</friction>
+              <friction2>0.1</friction2>
+              <rolling_friction>0.1</rolling_friction>
+            </bullet>
+          </friction>
+        </surface>
       </collision>
 
       <collision name="contact_collision_02">
@@ -660,6 +672,18 @@
             <size>0.008112 0.00025 0.0025</size>
           </box>
         </geometry>
+        <surface>
+          <friction>
+            <torsional>
+              <coefficient>0.1</coefficient>
+            </torsional>
+            <bullet>
+              <friction>0.1</friction>
+              <friction2>0.1</friction2>
+              <rolling_friction>0.1</rolling_friction>
+            </bullet>
+          </friction>
+        </surface>
       </collision>
 
       <collision name="contact_collision_01_holder">
@@ -669,6 +693,18 @@
             <size>0.008112 0.00025 0.002</size>
           </box>
         </geometry>
+        <surface>
+          <friction>
+            <torsional>
+              <coefficient>0.1</coefficient>
+            </torsional>
+            <bullet>
+              <friction>0.1</friction>
+              <friction2>0.1</friction2>
+              <rolling_friction>0.1</rolling_friction>
+            </bullet>
+          </friction>
+        </surface>
       </collision>
 
 
@@ -679,6 +715,18 @@
             <size>0.008112 0.00025 0.002</size>
           </box>
         </geometry>
+        <surface>
+          <friction>
+            <torsional>
+              <coefficient>0.1</coefficient>
+            </torsional>
+            <bullet>
+              <friction>0.1</friction>
+              <friction2>0.1</friction2>
+              <rolling_friction>0.1</rolling_friction>
+            </bullet>
+          </friction>
+        </surface>
       </collision>
     </link>
 

--- a/aic_assets/models/NIC Card Mount 4/model.sdf
+++ b/aic_assets/models/NIC Card Mount 4/model.sdf
@@ -643,6 +643,43 @@
           </friction>
         </surface>
       </collision>
+
+      <collision name="contact_collision_01">
+        <pose>0.012963 -0.0305 0.002845 3.128092 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.008112 0.00025 0.0025</size>
+          </box>
+        </geometry>
+      </collision>
+
+      <collision name="contact_collision_02">
+        <pose>-0.010237 -0.0305 0.002845 3.128092 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.008112 0.00025 0.0025</size>
+          </box>
+        </geometry>
+      </collision>
+
+      <collision name="contact_collision_01_holder">
+        <pose>0.012963 -0.030 0.008 3.128092 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.008112 0.00025 0.002</size>
+          </box>
+        </geometry>
+      </collision>
+
+
+      <collision name="contact_collision_02_holder">
+        <pose>-0.010237 -0.030 0.008 3.128092 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.008112 0.00025 0.002</size>
+          </box>
+        </geometry>
+      </collision>
     </link>
 
     <joint name="card_joint" type="fixed">
@@ -652,22 +689,6 @@
 
     <link name="sfp_port_0_link">
       <pose relative_to="nic_card_link">0.01295 -0.031572 0.00501 4.69895 0 0</pose>
-      <collision name="contact_collision_01">
-        <pose>0.012963 -0.0305 0.002845 3.128092 0.0 0.0</pose>
-        <geometry>
-          <box>
-            <size>0.008112 0.00025 0.0025</size>
-          </box>
-        </geometry>
-      </collision>
-      <collision name="contact_collision_01_holder">
-        <pose>0.012963 -0.030 0.008 3.128092 0.0 0.0</pose>
-        <geometry>
-          <box>
-            <size>0.008112 0.00025 0.002</size>
-          </box>
-        </geometry>
-      </collision>
     </link>
     <plugin
       filename="static://gz::sim::systems::TouchPlugin"
@@ -696,22 +717,6 @@
 
     <link name="sfp_port_1_link">
       <pose relative_to="nic_card_link">-0.01025 -0.031572 0.00501 4.69895 0 0</pose>
-      <collision name="contact_collision_02">
-        <pose>-0.010237 -0.0305 0.002845 3.128092 0.0 0.0</pose>
-        <geometry>
-          <box>
-            <size>0.008112 0.00025 0.0025</size>
-          </box>
-        </geometry>
-      </collision>
-      <collision name="contact_collision_02_holder">
-        <pose>-0.010237 -0.030 0.008 3.128092 0.0 0.0</pose>
-        <geometry>
-          <box>
-            <size>0.008112 0.00025 0.002</size>
-          </box>
-        </geometry>
-      </collision>
     </link>
     <plugin
       filename="static://gz::sim::systems::TouchPlugin"


### PR DESCRIPTION
The contact collisions at the bottom of the sfp ports were incorrectly placed inside the links: `sfp_port_0_link` and `sfp_port_1_link`. I moved them back to the main link: `nic_card_link`.  I also added friction values to the collisions for the reason mentioned in https://github.com/intrinsic-dev/aic/pull/535#discussion_r3277584498

After these changes, the touch event is properly triggered after successful insertion.

The SC Port models should not have this issue

Before: Contact collisions at an offet from the NIC Card (visualized in red and green)
<img width="464" height="603" alt="Screenshot from 2026-06-10 10-40-36" src="https://github.com/user-attachments/assets/7f4749b0-c937-4981-872b-8a9599f8dac2" />

After: Moved back to the bottom of the port
<img width="522" height="186" alt="Screenshot from 2026-06-10 10-42-19" src="https://github.com/user-attachments/assets/49e573bf-1fcb-4681-a6fa-6a8171b81bc9" />
