### PR TITLE
Support multiple SC ports per rail on the taskboard for phase 1 

### DIFF
--- a/aic_bringup/launch/spawn_task_board.launch.py
+++ b/aic_bringup/launch/spawn_task_board.launch.py
@@ -87,6 +87,24 @@ def launch_setup(context, *args, **kwargs):
     sc_port_1_pitch = LaunchConfiguration("sc_port_1_pitch")
     sc_port_1_yaw = LaunchConfiguration("sc_port_1_yaw")
 
+    sc_port_2_present = LaunchConfiguration("sc_port_2_present")
+    sc_port_2_translation = LaunchConfiguration("sc_port_2_translation")
+    sc_port_2_roll = LaunchConfiguration("sc_port_2_roll")
+    sc_port_2_pitch = LaunchConfiguration("sc_port_2_pitch")
+    sc_port_2_yaw = LaunchConfiguration("sc_port_2_yaw")
+
+    sc_port_3_present = LaunchConfiguration("sc_port_3_present")
+    sc_port_3_translation = LaunchConfiguration("sc_port_3_translation")
+    sc_port_3_roll = LaunchConfiguration("sc_port_3_roll")
+    sc_port_3_pitch = LaunchConfiguration("sc_port_3_pitch")
+    sc_port_3_yaw = LaunchConfiguration("sc_port_3_yaw")
+
+    sc_port_4_present = LaunchConfiguration("sc_port_4_present")
+    sc_port_4_translation = LaunchConfiguration("sc_port_4_translation")
+    sc_port_4_roll = LaunchConfiguration("sc_port_4_roll")
+    sc_port_4_pitch = LaunchConfiguration("sc_port_4_pitch")
+    sc_port_4_yaw = LaunchConfiguration("sc_port_4_yaw")
+
     # NIC Card Mount parameters
     nic_card_mount_0_present = LaunchConfiguration("nic_card_mount_0_present")
     nic_card_mount_0_translation = LaunchConfiguration("nic_card_mount_0_translation")
@@ -262,6 +280,51 @@ def launch_setup(context, *args, **kwargs):
             " ",
             "sc_port_1_yaw:=",
             sc_port_1_yaw,
+            " ",
+            "sc_port_2_present:=",
+            sc_port_2_present,
+            " ",
+            "sc_port_2_translation:=",
+            sc_port_2_translation,
+            " ",
+            "sc_port_2_roll:=",
+            sc_port_2_roll,
+            " ",
+            "sc_port_2_pitch:=",
+            sc_port_2_pitch,
+            " ",
+            "sc_port_2_yaw:=",
+            sc_port_2_yaw,
+            " ",
+            "sc_port_3_present:=",
+            sc_port_3_present,
+            " ",
+            "sc_port_3_translation:=",
+            sc_port_3_translation,
+            " ",
+            "sc_port_3_roll:=",
+            sc_port_3_roll,
+            " ",
+            "sc_port_3_pitch:=",
+            sc_port_3_pitch,
+            " ",
+            "sc_port_3_yaw:=",
+            sc_port_3_yaw,
+            " ",
+            "sc_port_4_present:=",
+            sc_port_4_present,
+            " ",
+            "sc_port_4_translation:=",
+            sc_port_4_translation,
+            " ",
+            "sc_port_4_roll:=",
+            sc_port_4_roll,
+            " ",
+            "sc_port_4_pitch:=",
+            sc_port_4_pitch,
+            " ",
+            "sc_port_4_yaw:=",
+            sc_port_4_yaw,
             " ",
             "nic_card_mount_0_present:=",
             nic_card_mount_0_present,
@@ -718,6 +781,117 @@ def generate_launch_description():
             "sc_port_1_yaw",
             default_value="0.0",
             description="SC Port 1 yaw orientation (radians)",
+        )
+    )
+
+    # SC Port 2 arguments
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "sc_port_2_present",
+            default_value="false",
+            description="Whether SC Port 2 is present",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "sc_port_2_translation",
+            default_value="0.0",
+            description="SC Port 2 translation along rail (meters)",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "sc_port_2_roll",
+            default_value="0.0",
+            description="SC Port 2 roll orientation (radians)",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "sc_port_2_pitch",
+            default_value="0.0",
+            description="SC Port 2 pitch orientation (radians)",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "sc_port_2_yaw",
+            default_value="0.0",
+            description="SC Port 2 yaw orientation (radians)",
+        )
+    )
+
+    # SC Port 3 arguments
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "sc_port_3_present",
+            default_value="false",
+            description="Whether SC Port 3 is present",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "sc_port_3_translation",
+            default_value="0.0",
+            description="SC Port 3 translation along rail (meters)",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "sc_port_3_roll",
+            default_value="0.0",
+            description="SC Port 3 roll orientation (radians)",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "sc_port_3_pitch",
+            default_value="0.0",
+            description="SC Port 3 pitch orientation (radians)",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "sc_port_3_yaw",
+            default_value="0.0",
+            description="SC Port 3 yaw orientation (radians)",
+        )
+    )
+
+    # SC Port 4 arguments
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "sc_port_4_present",
+            default_value="false",
+            description="Whether SC Port 4 is present",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "sc_port_4_translation",
+            default_value="0.0",
+            description="SC Port 4 translation along rail (meters)",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "sc_port_4_roll",
+            default_value="0.0",
+            description="SC Port 4 roll orientation (radians)",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "sc_port_4_pitch",
+            default_value="0.0",
+            description="SC Port 4 pitch orientation (radians)",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "sc_port_4_yaw",
+            default_value="0.0",
+            description="SC Port 4 yaw orientation (radians)",
         )
     )
 

--- a/aic_description/urdf/task_board.urdf.xacro
+++ b/aic_description/urdf/task_board.urdf.xacro
@@ -72,6 +72,27 @@
   <xacro:arg name="sc_port_1_pitch" default="0.0"/>
   <xacro:arg name="sc_port_1_yaw" default="0.0"/>
 
+  <!-- SC Port 2 (SC_RAIL_0) -->
+  <xacro:arg name="sc_port_2_present" default="false"/>
+  <xacro:arg name="sc_port_2_translation" default="0.0"/>
+  <xacro:arg name="sc_port_2_roll" default="0.0"/>
+  <xacro:arg name="sc_port_2_pitch" default="0.0"/>
+  <xacro:arg name="sc_port_2_yaw" default="0.0"/>
+
+  <!-- SC Port 3 (SC_RAIL_1) -->
+  <xacro:arg name="sc_port_3_present" default="false"/>
+  <xacro:arg name="sc_port_3_translation" default="0.0"/>
+  <xacro:arg name="sc_port_3_roll" default="0.0"/>
+  <xacro:arg name="sc_port_3_pitch" default="0.0"/>
+  <xacro:arg name="sc_port_3_yaw" default="0.0"/>
+
+  <!-- SC Port 4 (SC_RAIL_1) -->
+  <xacro:arg name="sc_port_4_present" default="false"/>
+  <xacro:arg name="sc_port_4_translation" default="0.0"/>
+  <xacro:arg name="sc_port_4_roll" default="0.0"/>
+  <xacro:arg name="sc_port_4_pitch" default="0.0"/>
+  <xacro:arg name="sc_port_4_yaw" default="0.0"/>
+
   <!-- NIC Card Mount 0 -->
   <xacro:arg name="nic_card_mount_0_present" default="false"/>
   <xacro:arg name="nic_card_mount_0_translation" default="0.0"/>
@@ -176,7 +197,7 @@
     </joint>
   </xacro:if>
 
-  <!-- SC Port 0 -->
+  <!-- SC Port 0 (SC_RAIL_0, Y=0.0295) -->
   <xacro:if value="$(arg sc_port_0_present)">
     <xacro:sc_port prefix="sc_port_0" pose="${-0.075 + $(arg sc_port_0_translation)} 0.0295 0.0165 ${1.57 + $(arg sc_port_0_roll)} $(arg sc_port_0_pitch) ${1.57 + $(arg sc_port_0_yaw)}"/>
     <gazebo>
@@ -187,13 +208,46 @@
     </gazebo>
   </xacro:if>
 
-  <!-- SC Port 1 -->
+  <!-- SC Port 1 (SC_RAIL_0, Y=0.0295) -->
   <xacro:if value="$(arg sc_port_1_present)">
-    <xacro:sc_port prefix="sc_port_1" pose="${-0.075 + $(arg sc_port_1_translation)} 0.0705 0.0165 ${1.57 + $(arg sc_port_1_roll)} $(arg sc_port_1_pitch) ${1.57 + $(arg sc_port_1_yaw)}"/>
+    <xacro:sc_port prefix="sc_port_1" pose="${-0.075 + $(arg sc_port_1_translation)} 0.0295 0.0165 ${1.57 + $(arg sc_port_1_roll)} $(arg sc_port_1_pitch) ${1.57 + $(arg sc_port_1_yaw)}"/>
     <gazebo>
       <joint name="sc_port_1_joint" type="fixed">
         <parent>task_board_base_link</parent>
         <child>sc_port_1::sc_port_link</child>
+      </joint>
+    </gazebo>
+  </xacro:if>
+
+  <!-- SC Port 2 (SC_RAIL_0, Y=0.0295) -->
+  <xacro:if value="$(arg sc_port_2_present)">
+    <xacro:sc_port prefix="sc_port_2" pose="${-0.075 + $(arg sc_port_2_translation)} 0.0295 0.0165 ${1.57 + $(arg sc_port_2_roll)} $(arg sc_port_2_pitch) ${1.57 + $(arg sc_port_2_yaw)}"/>
+    <gazebo>
+      <joint name="sc_port_2_joint" type="fixed">
+        <parent>task_board_base_link</parent>
+        <child>sc_port_2::sc_port_link</child>
+      </joint>
+    </gazebo>
+  </xacro:if>
+
+  <!-- SC Port 3 (SC_RAIL_1, Y=0.0705) -->
+  <xacro:if value="$(arg sc_port_3_present)">
+    <xacro:sc_port prefix="sc_port_3" pose="${-0.075 + $(arg sc_port_3_translation)} 0.0705 0.0165 ${1.57 + $(arg sc_port_3_roll)} $(arg sc_port_3_pitch) ${1.57 + $(arg sc_port_3_yaw)}"/>
+    <gazebo>
+      <joint name="sc_port_3_joint" type="fixed">
+        <parent>task_board_base_link</parent>
+        <child>sc_port_3::sc_port_link</child>
+      </joint>
+    </gazebo>
+  </xacro:if>
+
+  <!-- SC Port 4 (SC_RAIL_1, Y=0.0705) -->
+  <xacro:if value="$(arg sc_port_4_present)">
+    <xacro:sc_port prefix="sc_port_4" pose="${-0.075 + $(arg sc_port_4_translation)} 0.0705 0.0165 ${1.57 + $(arg sc_port_4_roll)} $(arg sc_port_4_pitch) ${1.57 + $(arg sc_port_4_yaw)}"/>
+    <gazebo>
+      <joint name="sc_port_4_joint" type="fixed">
+        <parent>task_board_base_link</parent>
+        <child>sc_port_4::sc_port_link</child>
       </joint>
     </gazebo>
   </xacro:if>


### PR DESCRIPTION
# Add taskboard multi-SC-port spawn support (0-4) for Phase 1

## Summary

This PR supports spawning of multiple SC ports.

1. Taskboard SC-port spawning support is extended from 2 ports to 5 ports (`sc_port_0` .. `sc_port_4`) in the taskboard Xacro and launch flow.


## Why

- We need to enable 5 SC port spawning and interfaces to enable training with this configuration for phase 1 of the AI for Industry Challenge

## Changes Included

### 1. Taskboard SC port expansion (phase_1-compatible)

- Updated taskboard model to support 5 SC ports total:
  - Rail 0: `sc_port_0`, `sc_port_1`, `sc_port_2`
  - Rail 1: `sc_port_3`, `sc_port_4`
- Added corresponding launch argument pass-through in taskboard spawner launch.

Files:

- `aic_description/urdf/task_board.urdf.xacro`
- `aic_bringup/launch/spawn_task_board.launch.py`


## Impact

- Taskboard can spawn 5 SC ports (`sc_port_0`..`sc_port_4`) when enabled via launch/xacro arguments.
-  Assuming 3 ports on rail 0 and 2 on rail 1

## Validation
- Launch and Xacro files were checked for diagnostics (no editor-reported errors).

## Testing Instructions

Local build validation flow:

1. Spawn a new Gazebo sim with the robot and no task board.

```bash
cd /home/kaushik/intrinsic_ws
source install/setup.bash
ros2 launch aic_training_utils aic_training_gz_bringup.launch.py \
  spawn_task_board:=false \
  spawn_cable:=false \
  start_aic_engine:=false
```

1. In a second terminal (same sourced workspace), programmatically generate a task board with 5 SC ports and spawn it.

```bash
cd /home/kaushik/intrinsic_ws
source install/setup.bash

python3 - <<'PY'
import rclpy

from aic_training_interfaces.srv import ExpandXacro
from simulation_interfaces.srv import SpawnEntity


def wait_for(client, service_name):
    if not client.wait_for_service(timeout_sec=15.0):
        raise RuntimeError(f"Service not available: {service_name}")


def main():
    rclpy.init()
    node = rclpy.create_node('spawn_taskboard_5_sc_ports')

    expand_cli = node.create_client(ExpandXacro, '/expand_xacro')
    wait_for(expand_cli, '/expand_xacro')

    expand_req = ExpandXacro.Request()
    expand_req.package_name = 'aic_description'
    expand_req.relative_path = 'urdf/task_board.urdf.xacro'
    expand_req.xacro_arguments = [
        'ground_truth:=true',
        'sc_port_0_present:=true',
      'sc_port_0_translation:=-0.04',
        'sc_port_1_present:=true',
      'sc_port_1_translation:=0.00',
        'sc_port_2_present:=true',
      'sc_port_2_translation:=0.04',
        'sc_port_3_present:=true',
      'sc_port_3_translation:=-0.02',
        'sc_port_4_present:=true',
      'sc_port_4_translation:=0.02',
    ]

    expand_future = expand_cli.call_async(expand_req)
    rclpy.spin_until_future_complete(node, expand_future, timeout_sec=30.0)
    if not expand_future.result() or not expand_future.result().success:
        msg = expand_future.result().message if expand_future.result() else 'no response'
        raise RuntimeError(f"ExpandXacro failed: {msg}")

    spawn_cli = node.create_client(SpawnEntity, '/gz_server/spawn_entity')
    wait_for(spawn_cli, '/gz_server/spawn_entity')

    spawn_req = SpawnEntity.Request()
    spawn_req.name = 'task_board_5_sc_ports'
    spawn_req.allow_renaming = True
    spawn_req.resource_string = expand_future.result().xml
    spawn_req.initial_pose.header.frame_id = 'world'
    spawn_req.initial_pose.pose.position.x = 0.15
    spawn_req.initial_pose.pose.position.y = -0.2
    spawn_req.initial_pose.pose.position.z = 1.14
    spawn_req.initial_pose.pose.orientation.z = 1.0
    spawn_req.initial_pose.pose.orientation.w = 0.0

    spawn_future = spawn_cli.call_async(spawn_req)
    rclpy.spin_until_future_complete(node, spawn_future, timeout_sec=30.0)
    if not spawn_future.result() or spawn_future.result().result.result != 1:
        msg = spawn_future.result().result.error_message if spawn_future.result() else 'no response'
        raise RuntimeError(f"SpawnEntity failed: {msg}")

    print(f"Spawned entity: {spawn_future.result().entity_name}")
    node.destroy_node()
    rclpy.shutdown()


if __name__ == '__main__':
    main()
PY
```

1. Verify in Gazebo that `task_board_5_sc_ports` appears with SC ports `sc_port_0` .. `sc_port_4`.
