### PR TITLE
Add ROS 2 Jazzy compatibiilty

### DIFF
--- a/aic_bringup/scripts/home_robot.py
+++ b/aic_bringup/scripts/home_robot.py
@@ -139,18 +139,22 @@ class HomeTrajectoryNode(Node):
 
 
 def main(args=None):
+    node = None
     try:
-        with rclpy.init(args=args):
-            node = HomeTrajectoryNode()
-            node.send_trajectory()
-            if node.use_aic_control:
-                # Keep alive for a short duration to ensure message delivery.
-                rclpy.spin_once(node, timeout_sec=2.0)
-                rclpy.shutdown()
-            else:
-                rclpy.spin(node)
+        rclpy.init(args=args)
+        node = HomeTrajectoryNode()
+        node.send_trajectory()
+        if node.use_aic_control:
+            # Keep alive for a short duration to ensure message delivery.
+            rclpy.spin_once(node, timeout_sec=2.0)
+        else:
+            rclpy.spin(node)
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
+    finally:
+        if node is not None:
+            node.destroy_node()
+        rclpy.shutdown()
 
 
 if __name__ == "__main__":

--- a/aic_bringup/scripts/test_impedance.py
+++ b/aic_bringup/scripts/test_impedance.py
@@ -174,9 +174,10 @@ class TestImpedanceNode(Node):
 
 
 def main(args=None):
+    node = None
     try:
-        with rclpy.init(args=args):
-            node = TestImpedanceNode()
+        rclpy.init(args=args)
+        node = TestImpedanceNode()
 
             # Send service request to switch to Cartesian target mode
             node.send_change_target_mode_req(TargetMode.MODE_CARTESIAN)
@@ -232,9 +233,10 @@ def main(args=None):
 
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
-
-    node.destroy_node()
-    rclpy.shutdown()
+    finally:
+        if node is not None:
+            node.destroy_node()
+        rclpy.shutdown()
 
 
 if __name__ == "__main__":

--- a/aic_controller/include/aic_controller/actions/gravity_compensation_action.hpp
+++ b/aic_controller/include/aic_controller/actions/gravity_compensation_action.hpp
@@ -33,7 +33,7 @@
 #include "rclcpp/version.h"
 #if RCLCPP_VERSION_GTE(29, 0, 0)
 #include "urdf/model.hpp"
-#elif
+#else
 #include "urdf/model.h"
 #endif
 

--- a/aic_controller/include/aic_controller/aic_controller.hpp
+++ b/aic_controller/include/aic_controller/aic_controller.hpp
@@ -45,7 +45,7 @@
 #include "rclcpp/version.h"
 #if RCLCPP_VERSION_GTE(29, 0, 0)
 #include "urdf/model.hpp"
-#elif
+#else
 #include "urdf/model.h"
 #endif
 

--- a/aic_model/aic_model/aic_model.py
+++ b/aic_model/aic_model/aic_model.py
@@ -321,14 +321,19 @@ class AicModel(LifecycleNode):
 
 
 def main(args=None):
+    aic_model_node = None
     try:
-        with rclpy.init(args=args):
-            aic_model_node = AicModel()
-            executor = MultiThreadedExecutor()
-            executor.add_node(aic_model_node)
-            executor.spin()
+        rclpy.init(args=args)
+        aic_model_node = AicModel()
+        executor = MultiThreadedExecutor()
+        executor.add_node(aic_model_node)
+        executor.spin()
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
+    finally:
+        if aic_model_node is not None:
+            aic_model_node.destroy_node()
+        rclpy.shutdown()
 
 
 if __name__ == "__main__":

--- a/aic_model/test/cancel_task.py
+++ b/aic_model/test/cancel_task.py
@@ -37,9 +37,15 @@ class CancelAllTasksNode(Node):
 
 
 def main(args=None):
-    with rclpy.init(args=args):
+    node = None
+    try:
+        rclpy.init(args=args)
         node = CancelAllTasksNode()
         node.call_cancel_task()
+    finally:
+        if node is not None:
+            node.destroy_node()
+        rclpy.shutdown()
 
 
 if __name__ == "__main__":

--- a/aic_model/test/create_and_cancel_task.py
+++ b/aic_model/test/create_and_cancel_task.py
@@ -133,14 +133,19 @@ class CreateAndCancelTaskNode(Node):
 
 
 def main(args=None):
+    node = None
     try:
-        with rclpy.init(args=args):
-            node = CreateAndCancelTaskNode()
-            node.activate_model_node()
-            node.send_goal()
-            rclpy.spin(node)
+        rclpy.init(args=args)
+        node = CreateAndCancelTaskNode()
+        node.activate_model_node()
+        node.send_goal()
+        rclpy.spin(node)
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
+    finally:
+        if node is not None:
+            node.destroy_node()
+        rclpy.shutdown()
 
 
 if __name__ == "__main__":

--- a/aic_model/test/cycle_through_lifecycle.py
+++ b/aic_model/test/cycle_through_lifecycle.py
@@ -54,7 +54,9 @@ class CycleLifecycleNode(Node):
 
 
 def main(args=None):
-    with rclpy.init(args=args):
+    node = None
+    try:
+        rclpy.init(args=args)
         node = CycleLifecycleNode()
         state = node.get_model_state()
         print(f"current state: {state}")
@@ -73,6 +75,10 @@ def main(args=None):
 
         print(f"shutting down...")
         node.change_model_state(Transition.TRANSITION_INACTIVE_SHUTDOWN)
+    finally:
+        if node is not None:
+            node.destroy_node()
+        rclpy.shutdown()
 
 
 if __name__ == "__main__":

--- a/aic_scoring/package.xml
+++ b/aic_scoring/package.xml
@@ -33,6 +33,7 @@
   <exec_depend>tf2_msgs</exec_depend>
 
   <depend>eigen</depend>
+  <depend>gz_math_vendor</depend>
 
   <test_depend>ament_lint_auto</test_depend>
 

--- a/aic_utils/aic_teleoperation/aic_teleoperation/cartesian_keyboard_teleop.py
+++ b/aic_utils/aic_teleoperation/aic_teleoperation/cartesian_keyboard_teleop.py
@@ -261,16 +261,18 @@ def main(args=None):
         """
     )
 
+    node = None
     try:
-        with rclpy.init(args=args):
-            node = AICCartesianTeleoperatorNode()
-            node.send_change_control_mode_req(TargetMode.MODE_CARTESIAN)
-            rclpy.spin(node)
+        rclpy.init(args=args)
+        node = AICCartesianTeleoperatorNode()
+        node.send_change_control_mode_req(TargetMode.MODE_CARTESIAN)
+        rclpy.spin(node)
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
     finally:
-        node.stop_keyboard_listener()
-        node.destroy_node()
+        if node is not None:
+            node.stop_keyboard_listener()
+            node.destroy_node()
         rclpy.shutdown()
 
 

--- a/aic_utils/aic_teleoperation/aic_teleoperation/joint_keyboard_teleop.py
+++ b/aic_utils/aic_teleoperation/aic_teleoperation/joint_keyboard_teleop.py
@@ -218,15 +218,17 @@ def main(args=None):
         """
     )
 
+    node = None
     try:
-        with rclpy.init(args=args):
-            node = AICTeleoperatorNode()
-            node.send_change_control_mode_req(TargetMode.MODE_JOINT)
-            rclpy.spin(node)
+        rclpy.init(args=args)
+        node = AICTeleoperatorNode()
+        node.send_change_control_mode_req(TargetMode.MODE_JOINT)
+        rclpy.spin(node)
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
     finally:
-        node.destroy_node()
+        if node is not None:
+            node.destroy_node()
         rclpy.shutdown()
 
 


### PR DESCRIPTION
The patch fixes three Jazzy-specific incompatibilities:
- `rclpy.init()` no longer supports the context manager protocol — replaced with explicit `try/finally` in all scripts
- `#elif` with no expression in C++ urdf include guards — changed to `#else`
- Missing `gz_math_vendor` dependency in `aic_scoring/package.xml` for correct colcon build order

The code was tested with ROS 2 Jazzy and ROS 2 Kilted.