### PR TITLE
Fix missing toml entry for aic_engine_interfaces

### DIFF
--- a/aic_interfaces/aic_engine_interfaces/pixi.toml
+++ b/aic_interfaces/aic_engine_interfaces/pixi.toml
@@ -1,0 +1,8 @@
+[package.build.backend]
+name = "pixi-build-ros"
+version = "==0.3.3.20260113.c8b6a54"
+channels = [
+  "https://prefix.dev/pixi-build-backends",
+  "robostack-kilted",
+  "conda-forge",
+]

--- a/pixi.lock
+++ b/pixi.lock
@@ -554,6 +554,8 @@ environments:
         build: hb0f4dca_0
       - conda: aic_interfaces/aic_control_interfaces
         build: hb0f4dca_0
+      - conda: aic_interfaces/aic_engine_interfaces
+        build: hb0f4dca_0
       - conda: aic_interfaces/aic_model_interfaces
         build: hb0f4dca_0
       - conda: aic_interfaces/aic_task_interfaces
@@ -1144,6 +1146,8 @@ environments:
         build: h60d57d3_0
       - conda: aic_interfaces/aic_control_interfaces
         build: h60d57d3_0
+      - conda: aic_interfaces/aic_engine_interfaces
+        build: h60d57d3_0
       - conda: aic_interfaces/aic_model_interfaces
         build: h60d57d3_0
       - conda: aic_interfaces/aic_task_interfaces
@@ -1640,6 +1644,8 @@ environments:
         build: hb0f4dca_0
       - conda: aic_interfaces/aic_control_interfaces
         build: hb0f4dca_0
+      - conda: aic_interfaces/aic_engine_interfaces
+        build: hb0f4dca_0
       - conda: aic_interfaces/aic_model_interfaces
         build: hb0f4dca_0
       - conda: aic_interfaces/aic_task_interfaces
@@ -2017,6 +2023,8 @@ environments:
         build: h60d57d3_0
       - conda: aic_interfaces/aic_control_interfaces
         build: h60d57d3_0
+      - conda: aic_interfaces/aic_engine_interfaces
+        build: h60d57d3_0
       - conda: aic_interfaces/aic_model_interfaces
         build: h60d57d3_0
       - conda: aic_interfaces/aic_task_interfaces
@@ -2378,6 +2386,8 @@ environments:
         build: hb0f4dca_0
       - conda: aic_interfaces/aic_control_interfaces
         build: hb0f4dca_0
+      - conda: aic_interfaces/aic_engine_interfaces
+        build: hb0f4dca_0
       - conda: aic_interfaces/aic_model_interfaces
         build: hb0f4dca_0
       - conda: aic_interfaces/aic_task_interfaces
@@ -2717,6 +2727,8 @@ environments:
       - conda: aic_example_policies
         build: h60d57d3_0
       - conda: aic_interfaces/aic_control_interfaces
+        build: h60d57d3_0
+      - conda: aic_interfaces/aic_engine_interfaces
         build: h60d57d3_0
       - conda: aic_interfaces/aic_model_interfaces
         build: h60d57d3_0
@@ -10516,7 +10528,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
   license_family: Apache
-  purls: []
+  purls:
+  - pkg:pypi/opencv-python?source=compressed-mapping
   size: 1155387
   timestamp: 1780563571068
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/py-opencv-4.13.0-qt6_py312h82c0dd1_610.conda
@@ -11364,7 +11377,7 @@ packages:
   - ros2-distro-mutex >=0.15.0,<0.16.0a0
   - libcxx >=22
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_interfaces/aic_control_interfaces
   name: ros-kilted-aic-control-interfaces
@@ -11385,7 +11398,43 @@ packages:
   - libgcc >=15
   - libstdcxx >=15
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
+  license: LicenseRef-Apache-2.0
+- conda: aic_interfaces/aic_engine_interfaces
+  name: ros-kilted-aic-engine-interfaces
+  version: 0.1.1
+  build: h60d57d3_0
+  subdir: osx-arm64
+  variants:
+    target_platform: osx-arm64
+  depends:
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex
+  - ros2-distro-mutex >=0.15.0,<0.16.0a0
+  - libcxx >=22
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.25,<3
+  license: LicenseRef-Apache-2.0
+- conda: aic_interfaces/aic_engine_interfaces
+  name: ros-kilted-aic-engine-interfaces
+  version: 0.1.1
+  build: hb0f4dca_0
+  subdir: linux-64
+  variants:
+    target_platform: linux-64
+  depends:
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex
+  - ros2-distro-mutex >=0.15.0,<0.16.0a0
+  - libgcc >=15
+  - libgcc >=15
+  - libstdcxx >=15
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_example_policies
   name: ros-kilted-aic-example-policies
@@ -11410,7 +11459,7 @@ packages:
   - ros2-distro-mutex >=0.15.0,<0.16.0a0
   - libcxx >=22
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_example_policies
   name: ros-kilted-aic-example-policies
@@ -11437,7 +11486,7 @@ packages:
   - libgcc >=15
   - libstdcxx >=15
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_model
   name: ros-kilted-aic-model
@@ -11461,7 +11510,7 @@ packages:
   - ros2-distro-mutex >=0.15.0,<0.16.0a0
   - libcxx >=22
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_model
   name: ros-kilted-aic-model
@@ -11487,7 +11536,7 @@ packages:
   - libgcc >=15
   - libstdcxx >=15
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_interfaces/aic_model_interfaces
   name: ros-kilted-aic-model-interfaces
@@ -11508,7 +11557,7 @@ packages:
   - ros2-distro-mutex >=0.15.0,<0.16.0a0
   - libcxx >=22
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_interfaces/aic_model_interfaces
   name: ros-kilted-aic-model-interfaces
@@ -11531,7 +11580,7 @@ packages:
   - libgcc >=15
   - libstdcxx >=15
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_interfaces/aic_task_interfaces
   name: ros-kilted-aic-task-interfaces
@@ -11546,7 +11595,7 @@ packages:
   - ros2-distro-mutex >=0.15.0,<0.16.0a0
   - libcxx >=22
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_interfaces/aic_task_interfaces
   name: ros-kilted-aic-task-interfaces
@@ -11563,7 +11612,7 @@ packages:
   - libgcc >=15
   - libstdcxx >=15
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_utils/aic_teleoperation
   name: ros-kilted-aic-teleoperation
@@ -11580,7 +11629,7 @@ packages:
   - ros2-distro-mutex >=0.15.0,<0.16.0a0
   - libcxx >=22
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_utils/aic_teleoperation
   name: ros-kilted-aic-teleoperation
@@ -11599,7 +11648,7 @@ packages:
   - libgcc >=15
   - libstdcxx >=15
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-2.7.5-np2py312h2ed9cc7_19.conda
   sha256: b70debda536f646978317d943fa8fd8654202faeb68a8f9ea00848e5baf05821
@@ -14196,7 +14245,7 @@ packages:
   - ros2-distro-mutex >=0.15.0,<0.16.0a0
   - libcxx >=22
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_utils/lerobot_robot_aic
   name: ros-kilted-lerobot-robot-aic
@@ -14218,7 +14267,7 @@ packages:
   - libgcc >=15
   - libstdcxx >=15
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-libstatistics-collector-2.0.1-np2py312h2ed9cc7_19.conda
   sha256: 562f3687acfc6b6cc9689cbb60dc3d68509176905295e6c3a4cab11a9b8a6b04

--- a/pixi.toml
+++ b/pixi.toml
@@ -22,6 +22,7 @@ ros-kilted-aic-example-policies = { path = "aic_example_policies" }
 ros-kilted-aic-model = { path = "aic_model" }
 ros-kilted-aic-model-interfaces = { path = "aic_interfaces/aic_model_interfaces" }
 ros-kilted-aic-task-interfaces = { path = "aic_interfaces/aic_task_interfaces" }
+ros-kilted-aic-engine-interfaces = { path = "aic_interfaces/aic_engine_interfaces" }
 ros-kilted-aic-teleoperation = { path = "aic_utils/aic_teleoperation" }
 ros-kilted-control-msgs = "*"
 ros-kilted-geometry-msgs = "*"


### PR DESCRIPTION
Fix missing entry in toml file for `aic_engine_interfaces` leading to this error with `pixi run colcon-build`:

```
Starting >>> aic_flowstate_skills
▪ solving              [────────────────────]  0/19                                  
⠦ preparing packages   [────────────────────]  0/258 ros-kilted-rosidl-default-generators @ 0B/s                                                                          --- stderr: aic_flowstate_skills
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.


CMake Error at CMakeLists.txt:13 (find_package):
  By not providing "Findaic_engine_interfaces.cmake" in CMAKE_MODULE_PATH
  this project has asked CMake to find a package configuration file provided
  by "aic_engine_interfaces", but CMake did not find one.

  Could not find a package configuration file provided by
  "aic_engine_interfaces" with any of the following names:

    aic_engine_interfacesConfig.cmake
    aic_engine_interfaces-config.cmake

  Add the installation prefix of "aic_engine_interfaces" to CMAKE_PREFIX_PATH
  or set "aic_engine_interfaces_DIR" to a directory containing one of the
  above files.  If "aic_engine_interfaces" provides a separate development
  package or SDK, be sure it has been installed.


▪ solving              [────────────────────]  0/19                                  
⠈ preparing packages   [────────────────────]  0/258 ros-kilted-rosidl-default-genera▪ solving              [────────────────────]  0/19                                  
⠁ preparing packages   [────────────────────]  0/258 ros-kilted-rosidl-default-genera▪ solving              [────────────────────]  0/19                                  
⠒ preparing packages   [────────────────────]  0/258 ros-kilted-rosidl-default-generators @ 0B/s                                                                          Aborted  <<< flowstate_ros_gz_bridge [2.21s]
Aborted  <<< flowstate_ros_bridge [2.28s]

Summary: 22 packages finished [11min 31s]
  1 package failed: aic_flowstate_skills
  4 packages aborted: flowstate_ros_bridge flowstate_ros_gz_bridge generic_action_skill intrinsic_sdk_ros
  12 packages had stderr output: aic_flowstate_skills flowstate_interfaces flowstate_ros_bridge flowstate_ros_gz_bridge generic_action_skill intrinsic_sdk_cmake intrinsic_sdk_ros opencensus_cpp_vendor ortools_vendor pybind11_abseil_vendor ros_gz_bridge_ve▪ solving              [────────────────────]  0/19    
```