### PR TITLE
Fix missing docker builder failure

### DIFF
--- a/aic_interfaces/aic_engine_interfaces/pixi.toml
+++ b/aic_interfaces/aic_engine_interfaces/pixi.toml
@@ -1,0 +1,8 @@
+[package.build.backend]
+name = "pixi-build-ros"
+version = "==0.3.3.20260113.c8b6a54"
+channels = [
+  "https://prefix.dev/pixi-build-backends",
+  "robostack-kilted",
+  "conda-forge",
+]

--- a/flowstate/scripts/build_container.sh
+++ b/flowstate/scripts/build_container.sh
@@ -142,6 +142,9 @@ elif [[ -n "$SKILL_NAME" && -n "$SKILL_PACKAGE" ]]; then
     docker load -i "$IMAGES_DIR/${SKILL_NAME}/${SKILL_NAME}.tar"
 
     echo "INFO: Extracting descriptor set from container..."
+    # Remove any leftover temp_container from a previously aborted run so
+    # this `docker create` doesn't hit a name conflict.
+    docker rm -f temp_container >/dev/null 2>&1 || true
     docker create --name temp_container "$SKILL_PACKAGE:$SKILL_NAME"
     docker cp "temp_container:/opt/ros/overlay/install/share/${SKILL_PACKAGE}/${SKILL_NAME}_protos.desc" \
      "$IMAGES_DIR/${SKILL_NAME}/${SKILL_NAME}_protos.desc"

--- a/flowstate/scripts/build_container.sh
+++ b/flowstate/scripts/build_container.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Fail fast and surface the real error instead of cascading.
+set -eo pipefail
+
 IMAGES_DIR=./images
 BUILDER_NAME=container-builder
 ROS_DISTRO=kilted
@@ -64,6 +67,11 @@ while [[ $# -gt 0 ]]; do
 done
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Ensure the buildx builder exists.
+# This is a no-op if the builder already exists.
+docker buildx inspect "$BUILDER_NAME" >/dev/null 2>&1 \
+  || docker buildx create --name "$BUILDER_NAME" --driver docker-container
 
 if [[ -n "$SERVICE_NAME" && -n "$SERVICE_PACKAGE" ]]; then
   mkdir -p $IMAGES_DIR/$SERVICE_NAME

--- a/pixi.lock
+++ b/pixi.lock
@@ -554,6 +554,8 @@ environments:
         build: hb0f4dca_0
       - conda: aic_interfaces/aic_control_interfaces
         build: hb0f4dca_0
+      - conda: aic_interfaces/aic_engine_interfaces
+        build: hb0f4dca_0
       - conda: aic_interfaces/aic_model_interfaces
         build: hb0f4dca_0
       - conda: aic_interfaces/aic_task_interfaces
@@ -1144,6 +1146,8 @@ environments:
         build: h60d57d3_0
       - conda: aic_interfaces/aic_control_interfaces
         build: h60d57d3_0
+      - conda: aic_interfaces/aic_engine_interfaces
+        build: h60d57d3_0
       - conda: aic_interfaces/aic_model_interfaces
         build: h60d57d3_0
       - conda: aic_interfaces/aic_task_interfaces
@@ -1640,6 +1644,8 @@ environments:
         build: hb0f4dca_0
       - conda: aic_interfaces/aic_control_interfaces
         build: hb0f4dca_0
+      - conda: aic_interfaces/aic_engine_interfaces
+        build: hb0f4dca_0
       - conda: aic_interfaces/aic_model_interfaces
         build: hb0f4dca_0
       - conda: aic_interfaces/aic_task_interfaces
@@ -2017,6 +2023,8 @@ environments:
         build: h60d57d3_0
       - conda: aic_interfaces/aic_control_interfaces
         build: h60d57d3_0
+      - conda: aic_interfaces/aic_engine_interfaces
+        build: h60d57d3_0
       - conda: aic_interfaces/aic_model_interfaces
         build: h60d57d3_0
       - conda: aic_interfaces/aic_task_interfaces
@@ -2378,6 +2386,8 @@ environments:
         build: hb0f4dca_0
       - conda: aic_interfaces/aic_control_interfaces
         build: hb0f4dca_0
+      - conda: aic_interfaces/aic_engine_interfaces
+        build: hb0f4dca_0
       - conda: aic_interfaces/aic_model_interfaces
         build: hb0f4dca_0
       - conda: aic_interfaces/aic_task_interfaces
@@ -2717,6 +2727,8 @@ environments:
       - conda: aic_example_policies
         build: h60d57d3_0
       - conda: aic_interfaces/aic_control_interfaces
+        build: h60d57d3_0
+      - conda: aic_interfaces/aic_engine_interfaces
         build: h60d57d3_0
       - conda: aic_interfaces/aic_model_interfaces
         build: h60d57d3_0
@@ -10516,7 +10528,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
   license_family: Apache
-  purls: []
+  purls:
+  - pkg:pypi/opencv-python?source=compressed-mapping
   size: 1155387
   timestamp: 1780563571068
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/py-opencv-4.13.0-qt6_py312h82c0dd1_610.conda
@@ -11364,7 +11377,7 @@ packages:
   - ros2-distro-mutex >=0.15.0,<0.16.0a0
   - libcxx >=22
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_interfaces/aic_control_interfaces
   name: ros-kilted-aic-control-interfaces
@@ -11385,7 +11398,43 @@ packages:
   - libgcc >=15
   - libstdcxx >=15
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
+  license: LicenseRef-Apache-2.0
+- conda: aic_interfaces/aic_engine_interfaces
+  name: ros-kilted-aic-engine-interfaces
+  version: 0.1.1
+  build: h60d57d3_0
+  subdir: osx-arm64
+  variants:
+    target_platform: osx-arm64
+  depends:
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex
+  - ros2-distro-mutex >=0.15.0,<0.16.0a0
+  - libcxx >=22
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.25,<3
+  license: LicenseRef-Apache-2.0
+- conda: aic_interfaces/aic_engine_interfaces
+  name: ros-kilted-aic-engine-interfaces
+  version: 0.1.1
+  build: hb0f4dca_0
+  subdir: linux-64
+  variants:
+    target_platform: linux-64
+  depends:
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex
+  - ros2-distro-mutex >=0.15.0,<0.16.0a0
+  - libgcc >=15
+  - libgcc >=15
+  - libstdcxx >=15
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_example_policies
   name: ros-kilted-aic-example-policies
@@ -11410,7 +11459,7 @@ packages:
   - ros2-distro-mutex >=0.15.0,<0.16.0a0
   - libcxx >=22
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_example_policies
   name: ros-kilted-aic-example-policies
@@ -11437,7 +11486,7 @@ packages:
   - libgcc >=15
   - libstdcxx >=15
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_model
   name: ros-kilted-aic-model
@@ -11461,7 +11510,7 @@ packages:
   - ros2-distro-mutex >=0.15.0,<0.16.0a0
   - libcxx >=22
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_model
   name: ros-kilted-aic-model
@@ -11487,7 +11536,7 @@ packages:
   - libgcc >=15
   - libstdcxx >=15
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_interfaces/aic_model_interfaces
   name: ros-kilted-aic-model-interfaces
@@ -11508,7 +11557,7 @@ packages:
   - ros2-distro-mutex >=0.15.0,<0.16.0a0
   - libcxx >=22
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_interfaces/aic_model_interfaces
   name: ros-kilted-aic-model-interfaces
@@ -11531,7 +11580,7 @@ packages:
   - libgcc >=15
   - libstdcxx >=15
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_interfaces/aic_task_interfaces
   name: ros-kilted-aic-task-interfaces
@@ -11546,7 +11595,7 @@ packages:
   - ros2-distro-mutex >=0.15.0,<0.16.0a0
   - libcxx >=22
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_interfaces/aic_task_interfaces
   name: ros-kilted-aic-task-interfaces
@@ -11563,7 +11612,7 @@ packages:
   - libgcc >=15
   - libstdcxx >=15
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_utils/aic_teleoperation
   name: ros-kilted-aic-teleoperation
@@ -11580,7 +11629,7 @@ packages:
   - ros2-distro-mutex >=0.15.0,<0.16.0a0
   - libcxx >=22
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_utils/aic_teleoperation
   name: ros-kilted-aic-teleoperation
@@ -11599,7 +11648,7 @@ packages:
   - libgcc >=15
   - libstdcxx >=15
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-ament-cmake-2.7.5-np2py312h2ed9cc7_19.conda
   sha256: b70debda536f646978317d943fa8fd8654202faeb68a8f9ea00848e5baf05821
@@ -14196,7 +14245,7 @@ packages:
   - ros2-distro-mutex >=0.15.0,<0.16.0a0
   - libcxx >=22
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: aic_utils/lerobot_robot_aic
   name: ros-kilted-lerobot-robot-aic
@@ -14218,7 +14267,7 @@ packages:
   - libgcc >=15
   - libstdcxx >=15
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - numpy >=1.25,<3
   license: LicenseRef-Apache-2.0
 - conda: https://conda.anaconda.org/robostack-kilted/linux-64/ros-kilted-libstatistics-collector-2.0.1-np2py312h2ed9cc7_19.conda
   sha256: 562f3687acfc6b6cc9689cbb60dc3d68509176905295e6c3a4cab11a9b8a6b04

--- a/pixi.toml
+++ b/pixi.toml
@@ -22,6 +22,7 @@ ros-kilted-aic-example-policies = { path = "aic_example_policies" }
 ros-kilted-aic-model = { path = "aic_model" }
 ros-kilted-aic-model-interfaces = { path = "aic_interfaces/aic_model_interfaces" }
 ros-kilted-aic-task-interfaces = { path = "aic_interfaces/aic_task_interfaces" }
+ros-kilted-aic-engine-interfaces = { path = "aic_interfaces/aic_engine_interfaces" }
 ros-kilted-aic-teleoperation = { path = "aic_utils/aic_teleoperation" }
 ros-kilted-control-msgs = "*"
 ros-kilted-geometry-msgs = "*"


### PR DESCRIPTION
> [!IMPORTANT]
> this goes on top of #587 so will include those changes. Therefore, it's still in draft.

Add the `docker buildx create` step to `build_container.sh` so that skill building on a fresh system (where that wasn't run) doesn't fail.

To reproduce, on a fresh system setup (from the `phase_1` branch), try to build a skill, e.g.:

```bash
pixi run --manifest-path src/aic/pixi.toml bash src/aic/flowstate/scripts/build_aic_flowstate_skills.sh --skill_name tare_force_torque_sensor_skill
```

Then observe: 

`build_aic_flowstate_skills.sh` fails with `ERROR: no builder "container-builder" found`, followed by a misleading cascade of errors (open ./images/…/<skill>.tar: no such file, pull access denied for aic_flowstate_skills, and more).

Reason: `build_container.sh` runs `docker buildx build --builder=container-builder` but neither it nor the docs create that builder (side note: `intrinsic_sdk_build/build.py` does create it).

After running `docker buildx create --name container-builder --driver docker-container`, it works.

This PR adds this step to the `build_container.sh` so it doesn't have to be run manually. With this branch `pixi run --manifest-path src/aic/pixi.toml bash src/aic/flowstate/scripts/build_aic_flowstate_skills.sh --skill_name tare_force_torque_sensor_skill` passes on a fresh setup. Also prevents the "misleading cascade of errors" by setting `set -eo pipefail`.