### PR TITLE
Update collisions on SC end

### DIFF
--- a/aic_assets/models/cable_base_c_rotated_phase_1/model.sdf
+++ b/aic_assets/models/cable_base_c_rotated_phase_1/model.sdf
@@ -1136,10 +1136,10 @@
         </inertia>
       </inertial>
       <collision name='link_20_collision'>
-        <pose>0 0 0 0 0 0</pose>
+        <pose>0 0 -0.006 0 0 0</pose>
         <geometry>
           <capsule>
-            <length>0.048000000000000001</length>
+            <length>0.036</length>
             <radius>0.002</radius>
           </capsule>
         </geometry>

--- a/aic_assets/models/sfp_sc_cable_phase_1/model.sdf
+++ b/aic_assets/models/sfp_sc_cable_phase_1/model.sdf
@@ -7,29 +7,11 @@
          Workaround this by removing their collisions.
       -->
       <experimental:params>
-        <collision element_id="link_1::link_1_collision" action="modify">
-          <pose>0 0 0.006 0 0 0</pose>
-          <geometry>
-            <capsule>
-              <length>0.036</length>
-              <radius>0.002</radius>
-            </capsule>
-          </geometry>
-          <surface>
-            <friction>
-              <torsional>
-                <coefficient>0.05</coefficient>
-              </torsional>
-              <bullet>
-                <friction>0.05</friction>
-                <friction2>0.05</friction2>
-              </bullet>
-            </friction>
-          </surface>
-        </collision>
         <collision element_id="cable_end_0::base_collision" action="remove"/>
         <collision element_id="cable_connection_0::collision_0" action="remove"/>
         <collision element_id="cable_connection_0::collision_1" action="remove"/>
+        <collision element_id="cable_connection_1::collision_0" action="remove"/>
+        <collision element_id="cable_connection_1::collision_1" action="remove"/>
       </experimental:params>
       <uri>model://cable_base_c_rotated_phase_1</uri>
     </include>


### PR DESCRIPTION
Updated a few collisions near the SC end that can potentially collide with the base of the gripper
* Removed the `cable_connection_1` link collisions - this is the Y split link connecting the plug to the cable body
* Shorten capsule collision at `link_20` (this make it consistent with the length of `link_0` collision near the SFP module)

Before:
<img width="976" height="564" alt="Screenshot from 2026-06-29 16-47-26" src="https://github.com/user-attachments/assets/abccabe4-840a-4fd4-9153-c5f5d5252663" />

After:
<img width="976" height="564" alt="Screenshot from 2026-06-29 16-42-53" src="https://github.com/user-attachments/assets/b6ef8c70-13ba-4968-b1e0-674b9dd42a3e" />

