### PR TITLE
subscribe to f/t sensor topic and add the tare offset to the controll…

### DIFF
--- a/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.cpp
+++ b/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.cpp
@@ -58,6 +58,7 @@ constexpr const char* kFlowstateZenohRouterParamName =
     "flowstate_zenoh_router_address";
 constexpr const char* kRestartConnectionRetriesParamName =
     "restart_connection_retries";
+constexpr const char* kForceTorqueTopicParamName = "force_torque_topic";
 
 ///=============================================================================
 void RobotControlBridge::declare_ros_parameters(
@@ -108,6 +109,9 @@ bool RobotControlBridge::initialize(
   data_->restart_connection_retries_ =
       param_interface->get_parameter(kRestartConnectionRetriesParamName)
           .get_value<int>();
+  std::string force_torque_topic =
+      param_interface->get_parameter(kForceTorqueTopicParamName)
+          .get_value<std::string>();
   std::filesystem::path task_settings_file =
       param_interface->get_parameter(kAgentBridgeTaskSettingsFileParamName)
           .get_value<std::string>();
@@ -245,6 +249,16 @@ bool RobotControlBridge::initialize(
   rclcpp::QoS reliable_qos = rclcpp::QoS(rclcpp::KeepLast(10)).reliable();
 
   // ROS Subscriptions to MotionUpdate and JointMotionUpdate commands
+  if (!force_torque_topic.empty()) {
+    data_->ft_sensor_sub_ =
+        rclcpp::create_subscription<geometry_msgs::msg::WrenchStamped>(
+            topics_interface, force_torque_topic, reliable_qos,
+            [this](const geometry_msgs::msg::WrenchStamped::SharedPtr msg) {
+              std::lock_guard<std::mutex> lock(data_->controller_state_mutex_);
+              data_->sensed_wrench_at_tip_ = *msg;
+            });
+  }
+
   data_->motion_update_sub_ =
       rclcpp::create_subscription<aic_control_interfaces::msg::MotionUpdate>(
           topics_interface, "aic_controller/pose_commands", reliable_qos,
@@ -610,6 +624,12 @@ void RobotControlBridge::TareForceTorqueSensorCallback(
     response->message =
         "No active controller session or tare action not initialized";
     return;
+  }
+
+  // Read force torque sensor value and store the offset
+  {
+    std::lock_guard<std::mutex> lock(data_->controller_state_mutex_);
+    data_->controller_state_.fts_tare_offset = data_->sensed_wrench_at_tip_;
   }
 
   auto status =

--- a/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.hpp
+++ b/flowstate/aic_flowstate_ros_bridge/src/robot_control_bridge.hpp
@@ -40,6 +40,7 @@
 #include "aic_control_interfaces/msg/target_mode.hpp"
 #include "aic_control_interfaces/msg/trajectory_generation_mode.hpp"
 #include "aic_control_interfaces/srv/change_target_mode.hpp"
+#include "geometry_msgs/msg/wrench_stamped.hpp"
 #include "std_srvs/srv/trigger.hpp"
 
 namespace flowstate_ros_bridge {
@@ -201,6 +202,9 @@ class RobotControlBridge : public BridgeInterface {
     rclcpp::Publisher<aic_control_interfaces::msg::ControllerState>::SharedPtr
         controller_state_pub_;
 
+    rclcpp::Subscription<geometry_msgs::msg::WrenchStamped>::SharedPtr
+        ft_sensor_sub_;
+
     rclcpp::Service<aic_control_interfaces::srv::ChangeTargetMode>::SharedPtr
         change_target_mode_srv_;
     rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr restart_bridge_srv_;
@@ -220,6 +224,7 @@ class RobotControlBridge : public BridgeInterface {
 
     aic_control_interfaces::msg::ControllerState controller_state_;
     std::mutex controller_state_mutex_;
+    geometry_msgs::msg::WrenchStamped sensed_wrench_at_tip_;
 
     Data();
     ~Data();


### PR DESCRIPTION
This PR addresses [issue 112 of aic-phase-1](https://github.com/intrinsic-dev/aic-phase-1/issues/112) by publishing the F/T sensor tare offset on the `aic_controller/controller_state` topic, this value keeps track of the last tared measurements from the F/T sensor.

It makes the following changes to the `robot_control_bridge` plugin for the **Flowstate-ROS Bridge**:
1. Subscribes to the `/fts_broadcaster/wrench` topic (published by the `world_bridge` plugin of **Flowstate-ROS Bridge** and stores this value. 
2. The stored F/T sensor value is then used to populate the `fts_tare_offset` field within the published `ControllerState` message on the `aic_controller/controller_state` topic.   