### PR TITLE
Use frozen flag with pixi

### DIFF
--- a/docker/aic_model/Dockerfile
+++ b/docker/aic_model/Dockerfile
@@ -16,7 +16,7 @@ COPY pixi_env_setup.sh /ws_aic/src/aic/
 
 SHELL ["/bin/bash", "-c"]
 RUN --mount=type=cache,target=/root/.cache/rattler/cache --mount=type=cache,target=/ws_aic/src/aic/.pixi/build \
-    cd /ws_aic/src/aic && pixi install --locked
+    cd /ws_aic/src/aic && pixi install --frozen
 
 WORKDIR /ws_aic/src/aic
 COPY --chmod=755 <<"EOF" /entrypoint.sh


### PR DESCRIPTION
Changes:
- locked flag updates the lock file which is not intended hence we will use frozen flag to reproduce exact environment