### PR TITLE
Expose tool transformation for FT sensor

### DIFF
--- a/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge.proto
+++ b/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge.proto
@@ -12,6 +12,15 @@ message RobotControlBridgeConfig {
   string joint_task_settings_file = 6;
 }
 
+message ToolTransformationConfig {
+  double x = 1;
+  double y = 2;
+  double z = 3;
+  double roll = 4;
+  double pitch = 5;
+  double yaw = 6;
+}
+
 // Configuration to control which sensors are enabled to publish ROS 2 messages.
 // Robot state (joints) and force/torque sensor data.
 message SensorPublisherConfig {
@@ -24,6 +33,7 @@ message SensorPublisherConfig {
   string robot_controller_instance = 7;
   bool throttle_robot_state_topic = 8;
   repeated string override_joint_names = 9;
+  ToolTransformationConfig force_torque_tool_transform = 10;
 }
 
 message FlowstateRosBridgeConfig {

--- a/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge_default_config.pbtxt
+++ b/flowstate/aic_flowstate_ros_bridge/aic_flowstate_ros_bridge_default_config.pbtxt
@@ -36,6 +36,14 @@
       "wrist_2_joint",
       "wrist_3_joint"
     ]
+    force_torque_tool_transform: {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      roll: 0.0
+      pitch: 0.0
+      yaw: 0.0
+    }
   },
   robot_control_bridge_config: {
     server_address: "istio-ingressgateway.app-ingress.svc.cluster.local:80"

--- a/flowstate/aic_flowstate_ros_bridge/src/aic_flowstate_ros_bridge_main.cpp
+++ b/flowstate/aic_flowstate_ros_bridge/src/aic_flowstate_ros_bridge_main.cpp
@@ -112,6 +112,19 @@ int main(int argc, char* argv[]) {
                       s.robot_controller_instance());
   params.emplace_back("throttle_robot_state_topic",
                       s.throttle_robot_state_topic());
+  if (s.has_force_torque_tool_transform()) {
+    std::vector<double> ft_transform = {
+        s.force_torque_tool_transform().x(),
+        s.force_torque_tool_transform().y(),
+        s.force_torque_tool_transform().z(),
+        s.force_torque_tool_transform().roll(),
+        s.force_torque_tool_transform().pitch(),
+        s.force_torque_tool_transform().yaw()
+    };
+    params.emplace_back("force_torque_tool_transform", ft_transform);
+  } else {
+    params.emplace_back("force_torque_tool_transform", std::vector<double>{0, 0, 0, 0, 0, 0});
+  }
 
   const auto& robot_control_bridge_config =
       ros_config.robot_control_bridge_config();

--- a/flowstate/aic_flowstate_ros_bridge/src/aic_flowstate_ros_bridge_main.cpp
+++ b/flowstate/aic_flowstate_ros_bridge/src/aic_flowstate_ros_bridge_main.cpp
@@ -113,17 +113,16 @@ int main(int argc, char* argv[]) {
   params.emplace_back("throttle_robot_state_topic",
                       s.throttle_robot_state_topic());
   if (s.has_force_torque_tool_transform()) {
-    std::vector<double> ft_transform = {
-        s.force_torque_tool_transform().x(),
-        s.force_torque_tool_transform().y(),
-        s.force_torque_tool_transform().z(),
-        s.force_torque_tool_transform().roll(),
-        s.force_torque_tool_transform().pitch(),
-        s.force_torque_tool_transform().yaw()
-    };
+    std::vector<double> ft_transform = {s.force_torque_tool_transform().x(),
+                                        s.force_torque_tool_transform().y(),
+                                        s.force_torque_tool_transform().z(),
+                                        s.force_torque_tool_transform().roll(),
+                                        s.force_torque_tool_transform().pitch(),
+                                        s.force_torque_tool_transform().yaw()};
     params.emplace_back("force_torque_tool_transform", ft_transform);
   } else {
-    params.emplace_back("force_torque_tool_transform", std::vector<double>{0, 0, 0, 0, 0, 0});
+    params.emplace_back("force_torque_tool_transform",
+                        std::vector<double>{0, 0, 0, 0, 0, 0});
   }
 
   const auto& robot_control_bridge_config =

--- a/flowstate/flowstate.repos
+++ b/flowstate/flowstate.repos
@@ -3,4 +3,4 @@ repositories:
     type: git
     url: https://github.com/intrinsic-ai/sdk-ros.git
     # From https://github.com/intrinsic-ai/sdk-ros/tree/aic
-    version: 17f1aab71bdf5ad237c86f7e4c83a30e3f21e245
+    version: cbc15287ae0867c7093a70b852cde8bc33a557eb


### PR DESCRIPTION

## Summary
This PR updates the `aic_flowstate_ros_bridge` configuration schema to support the newly added Force/Torque sensor tool transformation feature from upstream `sdk-ros`.  Related to : https://github.com/intrinsic-ai/sdk-ros/pull/138

By exposing these fields, we can mathematically shift and rotate the F/T sensor wrench into the tool's coordinate frame (e.g. `ati/tool_link`) directly from Flowstate, mimicking the hardware tool transformation capabilities found in physical EtherCAT setups.

## Changes
* **`aic_flowstate_ros_bridge.proto`**: Added the `ToolTransformationConfig` message (`x, y, z` in meters, `roll, pitch, yaw` in degrees) to match the upstream definition.
* **`aic_flowstate_ros_bridge_main.cpp`**: Added parameter unpacking logic to read `force_torque_tool_transform` from the `runtime_config.pb` and emplace it as a `std::vector<double>` parameter. This ensures the parameter is correctly passed to the dynamically loaded `FlowstateROSBridge` plugin.

## Dependencies
Requires the corresponding `sdk-ros` PR which implements the Eigen mathematical transformations inside `WorldBridge`.