### PR TITLE
build: enforce deterministic pixi builds with --frozen

### DIFF
--- a/flowstate/README.md
+++ b/flowstate/README.md
@@ -35,6 +35,11 @@ vcs import . < aic/flowstate/flowstate.repos
 
 You can build and bundle both the services and skills automatically inside the Pixi environment. Run these commands from the **workspace root** (e.g. `~/ws_aic_phase1`):
 
+> [!IMPORTANT]
+> **Dependency Management Note**
+> The build commands below use the `--frozen` flag to ensure strict reproducibility. If you add or modify dependencies in `pixi.toml`, you **must** run `pixi update` first to regenerate the lockfile, otherwise your changes will be silently ignored during the build.
+
+
 ```bash
 # 1. Use the help to get the list of all available skills
 pixi run --frozen --manifest-path src/aic/pixi.toml bash src/aic/flowstate/scripts/build_aic_flowstate_skills.sh --help

--- a/flowstate/README.md
+++ b/flowstate/README.md
@@ -37,16 +37,16 @@ You can build and bundle both the services and skills automatically inside the P
 
 ```bash
 # 1. Use the help to get the list of all available skills
-pixi run --manifest-path src/aic/pixi.toml bash src/aic/flowstate/scripts/build_aic_flowstate_skills.sh --help
+pixi run --frozen --manifest-path src/aic/pixi.toml bash src/aic/flowstate/scripts/build_aic_flowstate_skills.sh --help
 
 # 2. Build and bundle skills in aic_flowstate_skills (builds all by default, or specify a single skill via --skill_name)
-pixi run --manifest-path src/aic/pixi.toml bash src/aic/flowstate/scripts/build_aic_flowstate_skills.sh [--skill_name <insert_cable_skill|tare_force_torque_sensor_skill|switch_to_aic_controller_skill>]
+pixi run --frozen --manifest-path src/aic/pixi.toml bash src/aic/flowstate/scripts/build_aic_flowstate_skills.sh [--skill_name <insert_cable_skill|tare_force_torque_sensor_skill|switch_to_aic_controller_skill>]
 
 # 3. Build and bundle the flowstate ROS bridge service
-pixi run --manifest-path src/aic/pixi.toml bash src/aic/flowstate/scripts/build_flowstate_ros_bridge.sh
+pixi run --frozen --manifest-path src/aic/pixi.toml bash src/aic/flowstate/scripts/build_flowstate_ros_bridge.sh
 
 # 4. Build and bundle the AIC adapter service
-pixi run --manifest-path src/aic/pixi.toml bash src/aic/flowstate/scripts/build_aic_adapter.sh
+pixi run --frozen --manifest-path src/aic/pixi.toml bash src/aic/flowstate/scripts/build_aic_adapter.sh
 ```
 
 ---

--- a/flowstate/resources/Dockerfile.service
+++ b/flowstate/resources/Dockerfile.service
@@ -75,6 +75,7 @@ WORKDIR /workspace
 
 # Copy Pixi environment and built artifacts
 COPY --from=build /workspace/.pixi/envs/skill-runtime /workspace/.pixi/envs/skill-runtime
+# Symlink skill-build to skill-runtime to fix hardcoded paths generated in the colcon install space
 RUN ln -s /workspace/.pixi/envs/skill-runtime /workspace/.pixi/envs/skill-build
 COPY --from=build /workspace/install ./install
 COPY --from=build /pixi_hook.sh /pixi_hook.sh

--- a/flowstate/resources/Dockerfile.service
+++ b/flowstate/resources/Dockerfile.service
@@ -24,13 +24,13 @@ COPY src/aic/aic_interfaces/ ./aic_interfaces/
 COPY src/aic/aic_example_policies/ ./aic_example_policies/
 COPY src/aic/aic_model/ ./aic_model/
 COPY src/aic/aic_utils/ ./aic_utils/
-RUN pixi install --environment skill-build && pixi install --environment skill-runtime
+RUN pixi install --frozen --environment skill-build && pixi install --frozen --environment skill-runtime
 
 
 # Pre-build SDK to optimize caching of heavy dependencies
 FROM pixi-builder AS sdk-builder
 COPY src/sdk-ros/ ./sdk-ros/
-RUN pixi run --environment skill-build colcon build \
+RUN pixi run --frozen --environment skill-build colcon build \
     --merge-install \
     --cmake-args -DCMAKE_BUILD_TYPE=Release \
     --event-handlers=console_direct+ \
@@ -48,7 +48,7 @@ COPY src/aic/flowstate/ ./flowstate/
 COPY src/aic/aic_adapter/ ./aic_adapter/
 
 # Build target service package using existing install space
-RUN pixi run --environment skill-build colcon build \
+RUN pixi run --frozen --environment skill-build colcon build \
     --merge-install \
     --cmake-args -DCMAKE_BUILD_TYPE=Release \
     --event-handlers=console_direct+ \
@@ -56,7 +56,7 @@ RUN pixi run --environment skill-build colcon build \
     --base-paths flowstate aic_adapter sdk-ros
 
 # Capture pixi environment activation for runtime
-RUN pixi shell-hook --environment skill-runtime > /pixi_hook.sh \
+RUN pixi shell-hook --frozen --environment skill-runtime > /pixi_hook.sh \
     && rm -rf /root/.pixi/cache /root/.cache/pixi /workspace/.pixi/cache
 
 # Runtime stage
@@ -75,6 +75,7 @@ WORKDIR /workspace
 
 # Copy Pixi environment and built artifacts
 COPY --from=build /workspace/.pixi/envs/skill-runtime /workspace/.pixi/envs/skill-runtime
+RUN ln -s /workspace/.pixi/envs/skill-runtime /workspace/.pixi/envs/skill-build
 COPY --from=build /workspace/install ./install
 COPY --from=build /pixi_hook.sh /pixi_hook.sh
 

--- a/flowstate/resources/Dockerfile.skill
+++ b/flowstate/resources/Dockerfile.skill
@@ -79,6 +79,7 @@ WORKDIR /workspace
 
 # Copy Pixi environment and built artifacts
 COPY --from=build /workspace/.pixi/envs/skill-runtime /workspace/.pixi/envs/skill-runtime
+# Symlink skill-build to skill-runtime to fix hardcoded paths generated in the colcon install space
 RUN ln -s /workspace/.pixi/envs/skill-runtime /workspace/.pixi/envs/skill-build
 COPY --from=build /workspace/install ./install
 COPY --from=build /pixi_hook.sh /pixi_hook.sh

--- a/flowstate/resources/Dockerfile.skill
+++ b/flowstate/resources/Dockerfile.skill
@@ -24,13 +24,13 @@ COPY src/aic/aic_interfaces/ ./aic_interfaces/
 COPY src/aic/aic_example_policies/ ./aic_example_policies/
 COPY src/aic/aic_model/ ./aic_model/
 COPY src/aic/aic_utils/ ./aic_utils/
-RUN pixi install --environment skill-build && pixi install --environment skill-runtime
+RUN pixi install --frozen --environment skill-build && pixi install --frozen --environment skill-runtime
 
 
 # Pre-build SDK to optimize caching of heavy dependencies
 FROM pixi-builder AS sdk-builder
 COPY src/sdk-ros/ ./sdk-ros/
-RUN pixi run --environment skill-build colcon build \
+RUN pixi run --frozen --environment skill-build colcon build \
     --merge-install \
     --cmake-args -DCMAKE_BUILD_TYPE=Release \
     --event-handlers=console_direct+ \
@@ -48,7 +48,7 @@ COPY src/aic/flowstate/ ./flowstate/
 COPY src/aic/aic_adapter/ ./aic_adapter/
 
 # Build target skill package using existing install space
-RUN pixi run --environment skill-build colcon build \
+RUN pixi run --frozen --environment skill-build colcon build \
     --merge-install \
     --cmake-args -DCMAKE_BUILD_TYPE=Release \
     --event-handlers=console_direct+ \
@@ -56,7 +56,7 @@ RUN pixi run --environment skill-build colcon build \
     --base-paths flowstate aic_adapter sdk-ros aic_interfaces
 
 # Capture pixi environment activation for runtime
-RUN pixi shell-hook --environment skill-runtime > /pixi_hook.sh \
+RUN pixi shell-hook --frozen --environment skill-runtime > /pixi_hook.sh \
     && rm -rf /root/.pixi/cache /root/.cache/pixi /workspace/.pixi/cache \
     && if [ -d /workspace/build/pybind11_abseil_vendor/pybind11_abseil_vendor-prefix/src/pybind11_abseil_vendor-build ]; then \
         mkdir -p /workspace/install/opt/bindings && \
@@ -79,6 +79,7 @@ WORKDIR /workspace
 
 # Copy Pixi environment and built artifacts
 COPY --from=build /workspace/.pixi/envs/skill-runtime /workspace/.pixi/envs/skill-runtime
+RUN ln -s /workspace/.pixi/envs/skill-runtime /workspace/.pixi/envs/skill-build
 COPY --from=build /workspace/install ./install
 COPY --from=build /pixi_hook.sh /pixi_hook.sh
 


### PR DESCRIPTION
## Summary 

This PR updates our Dockerfiles and local build scripts to use the --frozen flag for pixi commands. This ensures that all builds rely strictly on the pixi.lock file as the absolute source of truth for dependencies, guaranteeing deterministic, reproducible builds and preventing unexpected breaks caused by transitive dependency updates.

Note: The core implementation of the` --frozen` flags and symlink logic was cherry-picked from original commits by @trushant05. I have added some minor supplemental documentation and code comments.

## Key Changes:

Strict Dependency Resolution: Added --frozen to pixi install, pixi run, and pixi shell-hook in both Dockerfile.skill and Dockerfile.service (Author: Trushant).
Local Scripts: Added --frozen to the README.md build commands to ensure local developers build with the exact same dependency tree as CI (Author: Trushant).
Documentation: Added an important callout to the README.md warning developers that they must explicitly run pixi update if they modify pixi.toml so the lockfile is regenerated.
Runtime Path Resolution: Added a symlink (ln -s) from skill-runtime to skill-build in the final Dockerfile stages (Author: Trushant), along with explanatory comments. 