### PR TITLE
Luca/phase 2 engine

### DIFF
--- a/aic_engine/CMakeLists.txt
+++ b/aic_engine/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(intrinsic_sdk_cmake REQUIRED)
 
 find_package(aic_scoring REQUIRED)
 find_package(aic_control_interfaces REQUIRED)
@@ -24,9 +25,20 @@ find_package(std_srvs REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
+intrinsic_sdk_generate_service_manifest(
+  SERVICE_NAME ${PROJECT_NAME}
+  MANIFEST ${PROJECT_NAME}.manifest.textproto
+  PARAMETER_DESCRIPTOR ${PROJECT_NAME}.proto
+  DEFAULT_CONFIGURATION ${PROJECT_NAME}_default_config.pbtxt
+  PROTOS_TARGET ${PROJECT_NAME}_protos
+)
+
 add_executable(aic_engine
   src/aic_engine.cpp
-	src/main.cpp
+  src/main.cpp
+)
+target_include_directories(aic_engine PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
 )
 target_link_libraries(aic_engine
   aic_scoring::aic_scoring
@@ -37,11 +49,19 @@ target_link_libraries(aic_engine
   ${aic_engine_interfaces_TARGETS}
   ${lifecycle_msgs_TARGETS}
   ${std_srvs_TARGETS}
+  ${PROJECT_NAME}_protos
+  intrinsic_sdk_cmake::intrinsic_sdk_cmake
 )
 
 install(
   TARGETS aic_engine
   DESTINATION lib/${PROJECT_NAME}
+)
+
+# Install proto descriptor file
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_protos.desc
+  DESTINATION share/${PROJECT_NAME}
 )
 
 # Install directories.

--- a/aic_engine/aic_engine.manifest.textproto
+++ b/aic_engine/aic_engine.manifest.textproto
@@ -21,8 +21,10 @@ service_def {
     image {
       archive_filename: "aic_engine.tar"
     }
-  } 
+  }
 }
 assets {
+  default_configuration_filename: "default_config.binarypb",
+  parameter_descriptor_filename: "parameter-descriptor-set.proto.bin",
   image_filenames: ["aic_engine.tar"]
 }

--- a/aic_engine/aic_engine.proto
+++ b/aic_engine/aic_engine.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package intrinsic;
+
+message AicEngineConfig {
+  bool use_sim_time = 1;
+}

--- a/aic_engine/aic_engine_default_config.pbtxt
+++ b/aic_engine/aic_engine_default_config.pbtxt
@@ -1,0 +1,6 @@
+# proto-file: aic_engine.proto
+# proto-message: AicEngineConfig
+# Corresponds to the message definition in aic_engine.proto
+[type.googleapis.com/intrinsic.AicEngineConfig] {
+  use_sim_time: true
+}

--- a/aic_engine/package.xml
+++ b/aic_engine/package.xml
@@ -12,6 +12,7 @@
   <depend>aic_scoring</depend>
   <depend>aic_control_interfaces</depend>
   <depend>aic_engine_interfaces</depend>
+  <depend>intrinsic_sdk_cmake</depend>
   <depend>lifecycle_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>

--- a/aic_engine/src/aic_engine.cpp
+++ b/aic_engine/src/aic_engine.cpp
@@ -460,8 +460,11 @@ bool Engine::check_endpoints() {
 bool Engine::ready_scoring(const uint64_t time_limit) {
   RCLCPP_INFO(node_->get_logger(), "Checking scoring system readiness...");
 
+  const bool use_sim_time = node_->get_parameter_or("use_sim_time", true);
+
   // Add a few seconds for safety since this is a limit for recorded data
-  if (!scoring_tier2_->StartRecording(std::chrono::seconds(time_limit + 10))) {
+  if (!scoring_tier2_->StartRecording(std::chrono::seconds(time_limit + 10),
+                                      use_sim_time)) {
     RCLCPP_ERROR(node_->get_logger(), "Failed to start recording");
     return false;
   }

--- a/aic_engine/src/main.cpp
+++ b/aic_engine/src/main.cpp
@@ -16,15 +16,50 @@
  */
 
 #include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <vector>
 
 #include "aic_engine.hpp"
+#include "aic_engine.pb.h"
+#include "intrinsic/resources/proto/runtime_context.pb.h"
 #include "rclcpp/executor.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+//==============================================================================
+intrinsic_proto::config::RuntimeContext GetRuntimeContext() {
+  intrinsic_proto::config::RuntimeContext runtime_context;
+  std::ifstream runtime_context_file;
+  runtime_context_file.open("/etc/intrinsic/runtime_config.pb",
+                            std::ios::binary);
+  if (!runtime_context.ParseFromIstream(&runtime_context_file)) {
+    // Return default context for running locally
+    std::cerr << "Warning: using default RuntimeContext\n";
+  }
+  return runtime_context;
+}
 
 //==============================================================================
 int main(int argc, char** argv) {
+  auto runtime_context = GetRuntimeContext();
+  intrinsic::AicEngineConfig config;
+  bool use_sim_time = true;
+  if (runtime_context.config().UnpackTo(&config)) {
+    use_sim_time = config.use_sim_time();
+  } else {
+    std::cerr << "Warning: Error unpacking AicEngineConfig from service "
+                 "config file... Passing default ros args to node\n";
+  }
+
   rclcpp::init(argc, argv);
 
-  auto engine = std::make_shared<aic::Engine>();
+  rclcpp::NodeOptions options;
+  std::vector<rclcpp::Parameter> params;
+  params.emplace_back("use_sim_time", use_sim_time);
+  options.parameter_overrides(params);
+
+  auto engine = std::make_shared<aic::Engine>(options);
   engine->spin();
 
   rclcpp::shutdown();

--- a/aic_scoring/include/aic_scoring/ScoringTier2.hh
+++ b/aic_scoring/include/aic_scoring/ScoringTier2.hh
@@ -210,16 +210,12 @@ namespace aic_scoring
     private: void ControllerStateCallback(const ControllerStateMsg& _msg);
 
     /// \brief Calculates score related with the gripper trajectory jerk.
-    /// \param[in] _success Whether the task succeeded.
     /// \return Scoring for the trajectory jerk score.
-    private: Tier2Score::CategoryScore GetTrajectoryJerkScore(
-        const bool _success) const;
+    private: Tier2Score::CategoryScore GetTrajectoryJerkScore() const;
 
     /// \brief Calculates score for trajectory efficiency (path length).
-    /// \param[in] _success Whether the task succeeded.
     /// \return Scoring for the trajectory efficiency category.
-    private: Tier2Score::CategoryScore GetTrajectoryEfficiencyScore(
-        const bool _success) const;
+    private: Tier2Score::CategoryScore GetTrajectoryEfficiencyScore() const;
 
     /// \brief Gets the transform for the specified entity at the requested time.
     /// \param[in] _t the time point to get the transform.
@@ -258,19 +254,16 @@ namespace aic_scoring
     private: Tier3Score ComputeTier3Score(std::size_t index) const;
 
     /// \brief Compute and combine tier 3 scores.
-    /// \return The tier3 score for the whole cable and a boolean that is true
-    /// if both tasks were close to succeeding, false otherwise.
-    private: std::pair<bool, Tier3Score> CombineTier3Score() const;
+    /// \return The tier3 score for the whole cable.
+    private: Tier3Score CombineTier3Score() const;
 
     /// \brief Calculates the penalty (if any) for contacts with off limit entities.
     /// \return Scoring for the off limit contacts category
     private: Tier2Score::CategoryScore GetContactsScore() const;
 
     /// \brief Calculates the score for task duration.
-    /// \param[in] _success Whether the task succeeded.
     /// \return Scoring for the task duration category.
-    private: Tier2Score::CategoryScore GetTaskDurationScore(
-        const bool _success) const;
+    private: Tier2Score::CategoryScore GetTaskDurationScore() const;
 
     /// \brief Wait for the cable and gripper TFs to be received.
     /// \return True if the transform were received, false if timeout occurred.

--- a/aic_scoring/include/aic_scoring/ScoringTier2.hh
+++ b/aic_scoring/include/aic_scoring/ScoringTier2.hh
@@ -150,7 +150,9 @@ namespace aic_scoring
     /// \brief Start recording all scoring topics.
     /// \return True if the scoring system is ready.
     /// \param[in] _max_task_time The maximum time to record for, used for tf buffer size.
-    public: bool StartRecording(const std::chrono::seconds &_max_task_time);
+    /// \param[in] _use_sim_time Whether to wait for simulation TFs.
+    public: bool StartRecording(const std::chrono::seconds &_max_task_time,
+                                const bool _use_sim_time = true);
 
     /// \brief Stop recording all scoring topics.
     /// \return True if the bag was closed correctly.

--- a/aic_scoring/src/ScoringTier2.cc
+++ b/aic_scoring/src/ScoringTier2.cc
@@ -526,7 +526,7 @@ Tier2Score::CategoryScore ScoringTier2::GetTrajectoryEfficiencyScore() const {
     if (this->task_start_time.has_value()) {
       const auto initDist = this->GetStartPlugPortDistance(index);
       if (initDist.has_value()) {
-        minPathLength += initDist.value();
+        minPathLength += 2.0 * initDist.value();
       } else {
         RCLCPP_WARN(this->node->get_logger(),
                     "Failed to get initial plug port distance");
@@ -547,7 +547,7 @@ Tier2Score::CategoryScore ScoringTier2::GetTrajectoryEfficiencyScore() const {
   // Score range and path length bounds (meters).
   const double kMaxEfficiencyScore = 6.0;             // Shortest path
   const double kMinEfficiencyScore = 0.0;             // Longest path
-  const double kMaxPathLength = 2.0 + minPathLength;  // Path for min score
+  const double kMaxPathLength = minPathLength * 10.0;  // Path for min score
 
   std::stringstream ss;
   ss << std::fixed << std::setprecision(2);
@@ -812,7 +812,8 @@ Tier2Score::CategoryScore ScoringTier2::GetInsertionForceScore() const {
   const double kDurationThreshold = 1.0;
   const double kPenalty = -12.0;
 
-  double max_force = 0.0;
+  std::size_t samples = 0;
+  double average_force = 0.0;
   double time_above_threshold = 0.0;
   // Start from 1 for easier dt calculation
   for (std::size_t i = 1; i < this->wrenches.size(); ++i) {
@@ -821,8 +822,18 @@ Tier2Score::CategoryScore ScoringTier2::GetInsertionForceScore() const {
     if (force_mag > kForceThreshold) {
       time_above_threshold +=
           this->wrenches[i].first - this->wrenches[i - 1].first;
+      average_force += force_mag;
+      ++samples;
+    } else {
+      // The penalty was applied and we are below threshold, break and report
+      if (time_above_threshold > kDurationThreshold) {
+        break;
+      }
+      // The penalty was not applied, and we are below threshold, reset count
+      time_above_threshold = 0.0;
+      average_force = 0.0;
+      samples = 0;
     }
-    if (force_mag > max_force) max_force = force_mag;
   }
 
   std::string msg;
@@ -830,13 +841,15 @@ Tier2Score::CategoryScore ScoringTier2::GetInsertionForceScore() const {
     return CategoryScore(0, "No excessive force detected");
   }
 
+  average_force /= samples;
+
   double score = 0.0;
   std::stringstream sstream;
   sstream.setf(std::ios::fixed);
   sstream.precision(2);
   sstream << "Insertion force above " << kForceThreshold
           << " N, detected for a time of " << time_above_threshold
-          << " seconds. Max detected force: " << max_force << "N.";
+          << " seconds. Average detected force: " << average_force << "N.";
 
   if (time_above_threshold > kDurationThreshold) {
     score = kPenalty;

--- a/aic_scoring/src/ScoringTier2.cc
+++ b/aic_scoring/src/ScoringTier2.cc
@@ -40,7 +40,8 @@ ScoringTier2::ScoringTier2(rclcpp::Node *_node,
     : node(_node), gripperFrame(_gripperFrame), connection(_connections) {}
 
 //////////////////////////////////////////////////
-bool ScoringTier2::StartRecording(const std::chrono::seconds &_max_task_time) {
+bool ScoringTier2::StartRecording(const std::chrono::seconds &_max_task_time,
+                                  const bool _use_sim_time) {
   this->tf2_buffer = std::make_unique<tf2::BufferCore>(_max_task_time);
 
   {
@@ -118,7 +119,10 @@ bool ScoringTier2::StartRecording(const std::chrono::seconds &_max_task_time) {
             }
           });
 
-  return this->WaitForTfs();
+  if (_use_sim_time) {
+    return this->WaitForTfs();
+  }
+  return true;
 }
 
 //////////////////////////////////////////////////

--- a/aic_scoring/src/ScoringTier2.cc
+++ b/aic_scoring/src/ScoringTier2.cc
@@ -192,13 +192,13 @@ std::pair<Tier2Score, Tier3Score> ScoringTier2::ComputeScore() {
   tier2_score.add_category_score("insertion force",
                                  this->GetInsertionForceScore());
   tier2_score.add_category_score("contacts", this->GetContactsScore());
-  const auto [success, tier3_score] = this->CombineTier3Score();
+  const auto tier3_score = this->CombineTier3Score();
   tier2_score.add_category_score("duration",
-                                 this->GetTaskDurationScore(success));
+                                 this->GetTaskDurationScore());
   tier2_score.add_category_score("trajectory smoothness",
-                                 this->GetTrajectoryJerkScore(success));
+                                 this->GetTrajectoryJerkScore());
   tier2_score.add_category_score("trajectory efficiency",
-                                 this->GetTrajectoryEfficiencyScore(success));
+                                 this->GetTrajectoryEfficiencyScore());
 
   return {tier2_score, tier3_score};
 }
@@ -403,8 +403,7 @@ static double CalculateInverseProportionalScore(const double max_score,
 }
 
 //////////////////////////////////////////////////
-Tier2Score::CategoryScore ScoringTier2::GetTrajectoryJerkScore(
-    const bool _success) const {
+Tier2Score::CategoryScore ScoringTier2::GetTrajectoryJerkScore() const {
   using CategoryScore = Tier2Score::CategoryScore;
 
   const double kMaxJerkScore = 6.0;
@@ -418,13 +417,6 @@ Tier2Score::CategoryScore ScoringTier2::GetTrajectoryJerkScore(
 
   if (!this->task_end_time.has_value()) {
     return CategoryScore(0, "Task not completed.");
-  }
-
-  if (!_success) {
-    return CategoryScore(
-        0,
-        "Plugs are not within max bounding radius from target ports, "
-        "not assigning jerk bonus");
   }
 
   if (this->endEffectorVelocities.size() < kWindowSize) {
@@ -515,19 +507,11 @@ Tier2Score::CategoryScore ScoringTier2::GetTrajectoryJerkScore(
 }
 
 //////////////////////////////////////////////////
-Tier2Score::CategoryScore ScoringTier2::GetTrajectoryEfficiencyScore(
-    const bool _success) const {
+Tier2Score::CategoryScore ScoringTier2::GetTrajectoryEfficiencyScore() const {
   using CategoryScore = Tier2Score::CategoryScore;
 
   if (!this->task_end_time.has_value()) {
     return CategoryScore(0, "Task not completed.");
-  }
-
-  if (!_success) {
-    return CategoryScore(
-        0,
-        "Plugs are not within max bounding radius from target ports, "
-        "not assigning efficiency bonus");
   }
 
   const std::size_t numConnections = this->connection.value().data.size();
@@ -796,16 +780,14 @@ Tier3Score ScoringTier2::ComputeTier3Score(std::size_t index) const {
   return this->GetDistanceScore(index);
 }
 
-std::pair<bool, Tier3Score> ScoringTier2::CombineTier3Score() const {
+Tier3Score ScoringTier2::CombineTier3Score() const {
   const auto score_0 = this->ComputeTier3Score(0);
   const auto score_1 = this->ComputeTier3Score(1);
-  const bool successful =
-      score_0.total_score() > 0 && score_1.total_score() > 0;
   const auto combinedScore =
       (score_0.total_score() + score_1.total_score()) / 2.0;
   const std::string msg = "[Task 0] : '" + score_0.message + "'. [Task 1]: '" +
                           score_1.message + "'.";
-  return {successful, Tier3Score(combinedScore, msg)};
+  return Tier3Score(combinedScore, msg);
 }
 
 //////////////////////////////////////////////////
@@ -888,8 +870,7 @@ Tier2Score::CategoryScore ScoringTier2::GetContactsScore() const {
 }
 
 //////////////////////////////////////////////////
-Tier2Score::CategoryScore ScoringTier2::GetTaskDurationScore(
-    const bool _success) const {
+Tier2Score::CategoryScore ScoringTier2::GetTaskDurationScore() const {
   using CategoryScore = Tier2Score::CategoryScore;
 
   const rclcpp::Duration kMaxTaskTime = rclcpp::Duration::from_seconds(300.0);
@@ -903,13 +884,6 @@ Tier2Score::CategoryScore ScoringTier2::GetTaskDurationScore(
 
   if (!this->task_start_time.has_value()) {
     return CategoryScore(0, "Time computation failed, task start time not set");
-  }
-
-  if (!_success) {
-    return CategoryScore(
-        0,
-        "Plugs are not within max bounding radius from target ports, "
-        "not assigning time bonus");
   }
 
   const rclcpp::Duration task_duration =

--- a/aic_scoring/src/ScoringTier2.cc
+++ b/aic_scoring/src/ScoringTier2.cc
@@ -516,6 +516,7 @@ Tier2Score::CategoryScore ScoringTier2::GetTrajectoryEfficiencyScore() const {
 
   const std::size_t numConnections = this->connection.value().data.size();
   double minPathLength = 0.0;
+  bool groundTruthFound = false;
   // Minimum distance is the sum of all the initialization distances.
   // It should be impossible to reach full score but this is a reasonable
   // minimum distance estimate.
@@ -527,9 +528,11 @@ Tier2Score::CategoryScore ScoringTier2::GetTrajectoryEfficiencyScore() const {
       const auto initDist = this->GetStartPlugPortDistance(index);
       if (initDist.has_value()) {
         minPathLength += 2.0 * initDist.value();
+        groundTruthFound = true;
       } else {
         RCLCPP_WARN(this->node->get_logger(),
-                    "Failed to get initial plug port distance");
+                    "Failed to get initial plug port distance, defaulting to 0.5m.");
+        minPathLength += 0.5;
       }
     }
   }
@@ -551,8 +554,15 @@ Tier2Score::CategoryScore ScoringTier2::GetTrajectoryEfficiencyScore() const {
 
   std::stringstream ss;
   ss << std::fixed << std::setprecision(2);
-  ss << "Total end-effector path length: " << totalPathLength << " m"
-     << ", initial plug-port distance: " << minPathLength << " m";
+
+  if (groundTruthFound) {
+    ss << "Total end-effector path length: " << totalPathLength << " m"
+       << ", initial plug-port distance: " << minPathLength << " m";
+  } else {
+    ss << "Total end-effector path length: " << totalPathLength << " m"
+       << ", no ground truth available, min distance for scoring: "
+       << minPathLength << " m";
+  }
 
   const double score = CalculateInverseProportionalScore(
       kMaxEfficiencyScore, kMinEfficiencyScore, kMaxPathLength, minPathLength,

--- a/flowstate/scripts/build_aic_engine.sh
+++ b/flowstate/scripts/build_aic_engine.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 IMAGES_DIR=./images
 BUILDER_NAME=container-builder
@@ -42,29 +43,26 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Compute absolute path to top-level aic directory (two levels up from flowstate/scripts)
 AIC_TOP_DIR=$(cd "$SCRIPT_DIR/../.." && pwd)
-
-# 1. Build the Flowstate service image on top of my-solution:v1
-# This step adds the necessary configurations to the base image,
-# allowing the service to communicate with Flowstate Zenoh router.
 SERVICE_DIR="$AIC_TOP_DIR/flowstate/services/aic_engine"
 DOCKERFILE_SERVICE="$SERVICE_DIR/Dockerfile.service"
 
-docker buildx build -t flowstate:aic_engine \
-  --no-cache \
-  --load \
-  --file "$DOCKERFILE_SERVICE" \
-  "$AIC_TOP_DIR/.."
-
-# 2. Export the service image to a .tar bundle
-# This saves the docker image as a tar archive to the file system, which
-# can be subsequently bundled by the inbuild tool.
-echo "INFO: Exporting image to tar file..."
+# 1. Build and export the service image to a compressed .tar bundle
+# This builds the image and exports it directly to a tar archive with ZSTD compression,
+# which is much smaller and can be subsequently bundled by the inbuild tool.
+echo "INFO: Building and exporting image to compressed tar file..."
 if [ -d "$IMAGES_DIR/aic_engine" ]; then
   echo "INFO: Deleting existing $IMAGES_DIR/aic_engine directory..."
   rm -rf "$IMAGES_DIR/aic_engine"
 fi
 mkdir -p "$IMAGES_DIR/aic_engine"
-docker save -o "$IMAGES_DIR/aic_engine/aic_engine.tar" flowstate:aic_engine
+
+docker buildx build -t flowstate:aic_engine \
+  --no-cache \
+  --builder="$BUILDER_NAME" \
+  --output="type=docker,dest=$IMAGES_DIR/aic_engine/aic_engine.tar,compression=zstd,push=false,name=flowstate:aic_engine" \
+  --file "$DOCKERFILE_SERVICE" \
+  "$AIC_TOP_DIR/.."
+
 chmod 644 "$IMAGES_DIR/aic_engine/aic_engine.tar"
 
 # 3. Bundle the service using inbuild

--- a/flowstate/scripts/build_aic_engine.sh
+++ b/flowstate/scripts/build_aic_engine.sh
@@ -86,9 +86,19 @@ if [ -f ./inbuild ] && [ ! -x ./inbuild ]; then
   chmod +x ./inbuild
 fi
 
+echo "INFO: Loading newly built service image into local daemon..."
+docker load -i "$IMAGES_DIR/aic_engine/aic_engine.tar"
+
+echo "INFO: Extracting descriptor set from container..."
+docker create --name temp_container_service flowstate:aic_engine
+docker cp "temp_container_service:/ws_aic/install/share/aic_engine/aic_engine_protos.desc" \
+  "$IMAGES_DIR/aic_engine/aic_engine_protos.desc"
+docker rm -f temp_container_service
 
 echo "INFO: Bundling service using inbuild..."
 ./inbuild service bundle \
-  --manifest "$SERVICE_DIR/aic_engine.manifest.textproto" \
+  --file_descriptor_set "$IMAGES_DIR/aic_engine/aic_engine_protos.desc" \
+  --manifest "$AIC_TOP_DIR/aic_engine/aic_engine.manifest.textproto" \
   --oci_image "$IMAGES_DIR/aic_engine/aic_engine.tar" \
-  --output "$IMAGES_DIR/aic_engine/aic_engine.bundle.tar"
+  --output "$IMAGES_DIR/aic_engine/aic_engine.bundle.tar" \
+  --default_config "$AIC_TOP_DIR/aic_engine/aic_engine_default_config.pbtxt"

--- a/flowstate/services/aic_engine/Dockerfile.service
+++ b/flowstate/services/aic_engine/Dockerfile.service
@@ -37,7 +37,7 @@ ZENOH_CONFIG_OVERRIDE='connect/endpoints=["tcp/'"$AIC_ROUTER_ADDR"'"]'
 ZENOH_CONFIG_OVERRIDE+=';transport/shared_memory/enabled=false'
 export ZENOH_CONFIG_OVERRIDE
 
-exec ros2 run aic_engine aic_engine --ros-args -p use_sim_time:=true
+exec ros2 run aic_engine aic_engine
 EOF
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
* Add a `use_sim_time` parameter, set to `true` for simulation tests, `false` for real world tests.
* Always score tier 2 points regardless of whether tier 3 was successful or not. This is necessary because in real world there are no tier 3 scores (no ground truth is available).
* Make distance metric work even when no ground truth is available (previously it would have always scored 0).
* Tune messages a bit so instead of "error" scoring shows "no ground truth available" for phase 2 real world logs.